### PR TITLE
[AKS] Add cdn source for `install-cli` command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -361,6 +361,7 @@ def k8s_install_cli(cmd, client_version='latest', install_location=None, base_sr
                           kubelogin_install_location, kubelogin_base_src_url)
 
 
+# pylint: disable=too-many-statements
 def k8s_install_kubectl(cmd, client_version='latest', install_location=None, source_url=None):
     """
     Install kubectl, a command-line interface for Kubernetes clusters.
@@ -386,7 +387,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
         client_version = version.decode('UTF-8').strip()
     else:
         client_version = "v%s" % client_version
-        if enable_cdn is None:
+        if enable_cdn is None and client_version != "1.18.7":
             enable_cdn = True
 
     file_url = ''
@@ -455,6 +456,10 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
             source_url = 'https://mirror.azure.cn/kubernetes/kubelogin'
 
     if client_version == 'latest':
+        logger.warning(
+            "To avoid throttling caused by querying the version number, "
+            "it is recommended to specify the version number explicitly"
+        )
         context = _ssl_context()
         latest_release_url = 'https://api.github.com/repos/Azure/kubelogin/releases/latest'
         if cloud_name.lower() == 'azurechinacloud':

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -380,7 +380,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
     if client_version == 'latest':
         logger.warning(
             "To avoid incompatibility, it is recommended to specify the same version number "
-            "as the server side through the '--client-version' option"
+            "as the server side through the '--client-version' option for kubectl."
         )
         context = _ssl_context()
         version = urlopen(source_url + '/stable.txt', context=context).read()
@@ -457,8 +457,8 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
 
     if client_version == 'latest':
         logger.warning(
-            "To avoid throttling caused by querying the version number, "
-            "it is recommended to specify the version number explicitly"
+            "To avoid throttling caused by querying the version number, it is recommended to specify "
+            "the version number through the '--kubelogin-version' option for kubelogin."
         )
         context = _ssl_context()
         latest_release_url = 'https://api.github.com/repos/Azure/kubelogin/releases/latest'


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Add cdn source (https://acs-mirror.azureedge.net/kubernetes/) for `install-cli` command. We also added a warning level log to remind the user that it is recommended to specify the version number for both `kubectl` and `kubelogin`.

When the user specifies the client version (via `--client-version`) and the system platform is linux or windows, download kubectl from the CDN source instead.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
