### PR TITLE
{login} double quoting on az login password

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -20,7 +20,7 @@ examples:
       text: az login
     - name: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
       text: az login -u johndoe@contoso.com -p VerySecret
-    - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
+    - name: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'. For some special characters, including double quotes in the password string is required; in PowerShell this would be -p ``"`"abc[?>def`""``.
       text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
     - name: Log in with a service principal using client certificate.
       text: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com


### PR DESCRIPTION
This workaround came from https://github.com/Azure/azure-cli/issues/8070

**Description**<!--Mandatory-->
With the special characters [?> (not sure which of those, but definitely one of them is the culprit, and probably many others) the only way to get az login for a SPN to succeed is with adding extra double quotes to this string. This wasn't documented so I thought I would propose it.

**Testing Guide**
$password = "<password>"
``az login --service-principal -u <client_id_here> -p "`"$password`"" --tenant <tenant_id_here>``

**History Notes**
[login] suggesting documenting double quotes on az login password to fix issue #8070

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ x ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
