### PR TITLE
{Profile} `az login`: Support `~` in certificate path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -263,8 +263,9 @@ class ServicePrincipalAuth:
         """
         entry = {}
         if secret_or_certificate:
-            if os.path.isfile(secret_or_certificate):
-                entry[_CERTIFICATE] = secret_or_certificate
+            user_expanded = os.path.expanduser(secret_or_certificate)
+            if os.path.isfile(user_expanded):
+                entry[_CERTIFICATE] = user_expanded
                 if use_cert_sn_issuer:
                     entry[_USE_CERT_SN_ISSUER] = use_cert_sn_issuer
             else:


### PR DESCRIPTION
**Description**<!--Mandatory-->
Refinement to #20632

Certificate path can now include `~` which expands to HOME folder:

```
az login --service-principal
         --username d0e3a385-0435-4e2d-bc8b-8298daa7e115
         --password '~\Desktop\3.pem'
         --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a
```