### PR TITLE
[Core] Enable token cache encryption on MacOS

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -861,7 +861,7 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
     from .auth.identity import Identity
 
     # Only enable encryption for Windows (for now).
-    fallback = sys.platform.startswith('win32')
+    fallback = sys.platform.startswith('win32') or sys.platform.startswith('darwin')
     # encrypt_token_cache affects both MSAL token cache and service principal entries.
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 


### PR DESCRIPTION
## Description

Utilize https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/103 to enable token cache encryption on MacOS.

We don't need to provide `account_name` by ourselves. Instead, `msal-extensions` automatically computes `account_name` from `signal_location`.

See code comment for more information.

⚠ **After this change, user will have to re-login so that credential is stored into Keychain.**

## References

Related email discussion: _Naming for service_name and account_name for MacOS token encryption_
