### PR TITLE
{testsdk} Add `ContentLengthProcessor` to fix `Content-Length` header

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
@@ -203,3 +203,25 @@ class RequestUrlNormalizer(RecordingProcessor):
         import re
         request.uri = re.sub('(?<!:)//', '/', request.uri)
         return request
+
+
+class ContentLengthProcessor(RecordingProcessor):
+    # After replacing body content with processors like GeneralNameReplacer and SingleValueReplacer,
+    # Content-Length header will not match the actual length of body.
+    # We should re-compute Content-Length header with the new body.
+
+    def process_request(self, request):
+        # azure-core currently doesn't check request's Content-Length, but we fix it anyway.
+        if is_text_payload(request) and request.body and 'Content-Length' in request.headers:
+            body = str(request.body, 'utf-8') if isinstance(request.body, bytes) else str(request.body)
+            request.headers['Content-Length'] = str(len(body))
+        return request
+
+    def process_response(self, response):
+        # If Content-Length doesn't match the body,
+        # azure.core.pipeline.transport._requests_basic.StreamDownloadGenerator
+        # fails with azure.core.exceptions.IncompleteReadError:
+        # https://github.com/Azure/azure-sdk-for-python/pull/20888
+        if is_text_payload(response) and response['body']['string'] and 'content-length' in response['headers']:
+            response['headers']['content-length'][0] = str(len(response['body']['string']))
+        return response


### PR DESCRIPTION
**Description**<!--Mandatory-->

When the test framework replaces a random name, its length is not preserved:

```diff
- appxxxxxxxxxxxx
+ app000003
```

This make `Content-Length` header in the response not match the actual body, causing failure due to the new `azure-core` check https://github.com/Azure/azure-sdk-for-python/pull/20888.

There are several processors that changes the `Content-Length` of the body:

1. All preparers that inherits from `AbstractPreparer` or `SingleValueReplacer`, like `ResourceGroupPreparer`
2. `AADGraphUserReplacer`
3. `GraphClientPasswordReplacer`
4. etc

This makes it difficult to enforce all processors to rectify the `Content-Length` header. The best place is to rectify `Content-Length` header when all processors are finished.

See

- https://github.com/Azure/azure-cli/pull/20541
- https://github.com/Azure/azure-cli/pull/20533
