### PR TITLE
{testsdk} Fix `GeneralNameReplacer`

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -14,6 +14,7 @@ import tempfile
 from .scenario_tests import (IntegrationTestBase, ReplayableTest, SubscriptionRecordingProcessor,
                              LargeRequestBodyProcessor,
                              LargeResponseBodyProcessor, LargeResponseBodyReplacer, RequestUrlNormalizer,
+                             GeneralNameReplacer,
                              live_only, DeploymentNameReplacer, patch_time_sleep_api, create_random_name)
 
 from .scenario_tests.const import MOCKED_SUBSCRIPTION_ID, ENV_SKIP_ASSERT
@@ -22,7 +23,7 @@ from .patches import (patch_load_cached_subscriptions, patch_main_exception_hand
                       patch_retrieve_token_for_user, patch_long_run_operation_delay,
                       patch_progress_controller, patch_get_current_system_username)
 from .exceptions import CliExecutionError
-from .utilities import (find_recording_dir, StorageAccountKeyReplacer, GraphClientPasswordReplacer, GeneralNameReplacer,
+from .utilities import (find_recording_dir, StorageAccountKeyReplacer, GraphClientPasswordReplacer,
                         AADAuthRequestFilter)
 from .reverse_dependency import get_dummy_cli
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py
@@ -11,7 +11,6 @@ import tempfile
 import shutil
 import logging
 import threading
-import six
 import vcr
 
 from .config import TestConfig
@@ -182,7 +181,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
             response['headers'] = headers
 
             body = response['body']['string']
-            if is_text_payload(response) and body and not isinstance(body, six.string_types):
+            if is_text_payload(response) and body and not isinstance(body, str):
                 response['body']['string'] = body.decode('utf-8')
 
             for processor in self.recording_processors:
@@ -200,7 +199,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
     @classmethod
     def _custom_request_query_matcher(cls, r1, r2):
         """ Ensure method, path, and query parameters match. """
-        from six.moves.urllib_parse import urlparse, parse_qs  # pylint: disable=import-error, relative-import
+        from urllib.parse import urlparse, parse_qs
 
         url1 = urlparse(r1.uri)
         url2 = urlparse(r2.uri)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py
@@ -97,7 +97,7 @@ class AbstractPreparer(object):
 class SingleValueReplacer(RecordingProcessor):
     # pylint: disable=no-member
     def process_request(self, request):
-        from urllib.parse import quote_plus  # pylint: disable=import-error, relative-import
+        from urllib.parse import quote_plus
         if self.random_name in request.uri:
             request.uri = request.uri.replace(self.random_name, self.moniker)
         elif quote_plus(self.random_name) in request.uri:

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/preparers.py
@@ -97,7 +97,7 @@ class AbstractPreparer(object):
 class SingleValueReplacer(RecordingProcessor):
     # pylint: disable=no-member
     def process_request(self, request):
-        from six.moves.urllib_parse import quote_plus  # pylint: disable=import-error, relative-import
+        from urllib.parse import quote_plus  # pylint: disable=import-error, relative-import
         if self.random_name in request.uri:
             request.uri = request.uri.replace(self.random_name, self.moniker)
         elif quote_plus(self.random_name) in request.uri:

--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/recording_processors.py
@@ -109,12 +109,11 @@ class LargeResponseBodyProcessor(RecordingProcessor):
 class LargeResponseBodyReplacer(RecordingProcessor):
     def process_response(self, response):
         if is_text_payload(response) and not is_json_payload(response):
-            import six
             body = response['body']['string']
 
             # backward compatibility. under 2.7 response body is unicode, under 3.5 response body is
             # bytes. when set the value back, the same type must be used.
-            body_is_string = isinstance(body, six.string_types)
+            body_is_string = isinstance(body, str)
 
             content_in_string = (response['body']['string'] or b'').decode('utf-8')
             index = content_in_string.find(LargeResponseBodyProcessor.control_flag)
@@ -179,7 +178,7 @@ class GeneralNameReplacer(RecordingProcessor):
             request.uri = request.uri.replace(old, new)
 
             if is_text_payload(request) and request.body:
-                body = str(request.body)
+                body = str(request.body, 'utf-8') if isinstance(request.body, bytes) else str(request.body)
                 if old in body:
                     request.body = body.replace(old, new)
 

--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -6,8 +6,7 @@
 import os
 from contextlib import contextmanager
 
-from .scenario_tests import (create_random_name as create_random_name_base, RecordingProcessor,
-                             GeneralNameReplacer as _BuggyGeneralNameReplacer)
+from .scenario_tests import (create_random_name as create_random_name_base, RecordingProcessor)
 from .scenario_tests.utilities import is_text_payload
 
 
@@ -180,24 +179,6 @@ class AADGraphUserReplacer:
             response['body']['string'] = response['body']['string'].replace(self.test_user,
                                                                             self.mock_user)
         return response
-
-
-# Override until this is fixed in azure_devtools
-class GeneralNameReplacer(_BuggyGeneralNameReplacer):
-
-    def process_request(self, request):
-        for old, new in self.names_name:
-            request.uri = request.uri.replace(old, new)
-
-            if is_text_payload(request) and request.body:
-                try:
-                    body = str(request.body, 'utf-8') if isinstance(request.body, bytes) else str(request.body)
-                except TypeError:  # python 2 doesn't allow decoding through str
-                    body = str(request.body)
-                if old in body:
-                    request.body = body.replace(old, new)
-
-        return request
 
 
 class AADAuthRequestFilter(RecordingProcessor):


### PR DESCRIPTION
**Description**<!--Mandatory-->

`GeneralNameReplacer` from `azure_devtools` is buggy, and is overridden to provide correct functionality. 

Now that we have incorporated `azure_devtools` (#20601), there is no need to override `GeneralNameReplacer`.
