### PR TITLE
{Storage} `az storage account update`: Fix AttributeError when updating user_identity

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -368,7 +368,7 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
 
     if identity_type and 'UserAssigned' in identity_type and user_identity_id:
         user_assigned_identities = {user_identity_id: {}}
-        if instance.identity.user_assigned_identities:
+        if instance.identity and instance.identity.user_assigned_identities:
             for item in instance.identity.user_assigned_identities:
                 if item != user_identity_id:
                     user_assigned_identities[item] = None


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
If the original storage account doesn't have user identity, update storage account with user_identity will fail like:
![image](https://user-images.githubusercontent.com/10227683/145523505-cd98bda4-aa9a-43f5-aaaf-10086445ebf6.png)


**Testing Guide**
<!--Example commands with explanations.-->
```
az storage account create -n testsa -g testrg
az storage account update -n testsa -g testrg --identity-type UserAssigned --user-identity-id testidentityid
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
