### PR TITLE
{testsdk} Add `ConfigArgParse` dependency

### DIFF
--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -24,6 +24,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
+    'ConfigArgParse>=0.12.0',
     'jmespath',
     'vcrpy>=1.10.3',
     'pytest'

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -97,7 +97,6 @@ certifi==2019.6.16
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-ConfigArgParse==0.14.0
 cryptography==3.3.2
 fabric==2.4.0
 humanfriendly==10.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -97,7 +97,6 @@ certifi==2019.6.16
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-ConfigArgParse==0.14.0
 cryptography==3.3.2
 distro==1.6.0
 fabric==2.4.0


### PR DESCRIPTION
**Description**<!--Mandatory-->

Extension CI fails:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1240705&view=logs&j=59e8686e-5e74-514d-6cad-f7d66c66b425&t=59602323-6717-504d-f2cc-5c81369f935f&l=736

```
ERROR: azext_aks_preview.tests.latest.test_aks_commands (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: azext_aks_preview.tests.latest.test_aks_commands
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/vsts/work/1/s/src/aks-preview/azext_aks_preview/tests/latest/test_aks_commands.py", line 10, in <module>
    from azure.cli.testsdk import (
  File "/home/vsts/work/1/s/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/__init__.py", line 6, in <module>
    from .scenario_tests import live_only, record_only, get_sha1_hash
  File "/home/vsts/work/1/s/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/__init__.py", line 13, in <module>
    from .base import IntegrationTestBase, ReplayableTest, LiveTest
  File "/home/vsts/work/1/s/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/base.py", line 17, in <module>
    from .config import TestConfig
  File "/home/vsts/work/1/s/azure-cli/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/config.py", line 6, in <module>
    import configargparse
ModuleNotFoundError: No module named 'configargparse'
```

This is because `azure_devtools` requires `ConfigArgParse`

https://github.com/Azure/azure-python-devtools/blob/aae33c216028960fbf54e70dcb1c579600034054/setup.py#L30

```py
DEPENDENCIES = [
    'ConfigArgParse>=0.12.0',
```

but it is not added in
 
- https://github.com/Azure/azure-cli/pull/20601

Main repo CI doesn't fail because `ConfigArgParse` is in

- `src/azure-cli/requirements.py3.Darwin.txt`
- `src/azure-cli/requirements.py3.Linux.txt`

added by #9785, but they are not in `src/azure-cli/requirements.py3.windows.txt` and it is not used by any code. I have no idea why they were introduced.