### PR TITLE
[App Service] Fix #19550: `az staticwebapp users update`: Allow updating static web app user roles again 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -7,7 +7,7 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.util import sdk_no_wait
 
 from azure.cli.core.commands import LongRunningOperation
-from azure.cli.core.azclierror import ValidationError
+from azure.cli.core.azclierror import ValidationError, RequiredArgumentMissingError
 from knack.util import CLIError
 from knack.log import get_logger
 from msrestazure.tools import parse_resource_id
@@ -314,6 +314,8 @@ def invite_staticsite_users(cmd, name, authentication_provider, user_details, do
 
 def update_staticsite_users(cmd, name, roles, authentication_provider=None, user_details=None, user_id=None,
                             resource_group_name=None):
+    from azure.mgmt.web.models import StaticSiteUserARMResource
+
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
@@ -327,9 +329,13 @@ def update_staticsite_users(cmd, name, roles, authentication_provider=None, user
             client, resource_group_name, name, user_id, authentication_provider, user_details)
 
     if not authentication_provider or not user_id:
-        raise CLIError("Either user id or user details is required.")
+        raise RequiredArgumentMissingError("Either user id or user details is required.")
 
-    return client.update_static_site_user(resource_group_name, name, authentication_provider, user_id, roles=roles)
+    user_envelope = StaticSiteUserARMResource(roles=roles)
+
+    return client.update_static_site_user(resource_group_name,
+                                          name, authentication_provider, user_id,
+                                          static_site_user_envelope=user_envelope)
 
 
 def create_staticsites(cmd, resource_group_name, name, location,

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -440,6 +440,8 @@ class TestStaticAppCommands(unittest.TestCase):
         self.assertEqual(invitation_expiration_in_hours, arg_list[2].num_hours_to_expiration)
 
     def test_update_staticsite_users_with_resourcegroup_with_all_args(self):
+        from azure.mgmt.web.models import StaticSiteUserARMResource
+
         roles = 'Contributor,Reviewer'
         authentication_provider = 'GitHub'
         user_details = 'JohnDoe'
@@ -448,10 +450,12 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite_users(self.mock_cmd, self.name1, roles, authentication_provider=authentication_provider,
                                 user_details=user_details, user_id=user_id, resource_group_name=self.rg1)
 
-        self.staticapp_client.update_static_site_user.assert_called_once_with(
-            self.rg1, self.name1, authentication_provider, user_id, roles=roles)
+        self.staticapp_client.update_static_site_user.assert_called_once_with(self.rg1, self.name1,
+            authentication_provider, user_id, static_site_user_envelope=StaticSiteUserARMResource(roles=roles))
 
     def test_update_staticsite_users_with_resourcegroup_without_auth_provider(self):
+        from azure.mgmt.web.models import StaticSiteUserARMResource
+
         roles = 'Contributor,Reviewer'
         user_details = 'JohnDoe'
         authentication_provider = 'GitHub'
@@ -461,8 +465,8 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite_users(self.mock_cmd, self.name1, roles,
                                 user_details=user_details, user_id=user_id, resource_group_name=self.rg1)
 
-        self.staticapp_client.update_static_site_user.assert_called_once_with(
-            self.rg1, self.name1, authentication_provider, user_id, roles=roles)
+        self.staticapp_client.update_static_site_user.assert_called_once_with(self.rg1, self.name1,
+            authentication_provider, user_id, static_site_user_envelope=StaticSiteUserARMResource(roles=roles))
 
     def test_update_staticsite_users_with_resourcegroup_without_auth_provider_user_not_found(self):
         roles = 'Contributor,Reviewer'
@@ -476,6 +480,8 @@ class TestStaticAppCommands(unittest.TestCase):
                                     user_details=user_details, user_id=user_id, resource_group_name=self.rg1)
 
     def test_update_staticsite_users_with_resourcegroup_without_user_id_without_auth_provider(self):
+        from azure.mgmt.web.models import StaticSiteUserARMResource
+
         roles = 'Contributor,Reviewer'
         user_details = 'JohnDoe'
         authentication_provider = 'GitHub'
@@ -485,8 +491,8 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite_users(self.mock_cmd, self.name1, roles,
                                 user_details=user_details, resource_group_name=self.rg1)
 
-        self.staticapp_client.update_static_site_user.assert_called_once_with(
-            self.rg1, self.name1, authentication_provider, user_id, roles=roles)
+        self.staticapp_client.update_static_site_user.assert_called_once_with(self.rg1, self.name1,
+            authentication_provider, user_id, static_site_user_envelope=StaticSiteUserARMResource(roles=roles))
 
     def test_update_staticsite_users_with_resourcegroup_without_user_id_without_auth_provider_user_not_found(self):
         roles = 'Contributor,Reviewer'
@@ -499,6 +505,8 @@ class TestStaticAppCommands(unittest.TestCase):
                                     user_details=user_details, resource_group_name=self.rg1)
 
     def test_update_staticsite_users_with_resourcegroup_without_user_id(self):
+        from azure.mgmt.web.models import StaticSiteUserARMResource
+
         roles = 'Contributor,Reviewer'
         user_details = 'JohnDoe'
         authentication_provider = 'GitHub'
@@ -508,8 +516,8 @@ class TestStaticAppCommands(unittest.TestCase):
         update_staticsite_users(self.mock_cmd, self.name1, roles, authentication_provider=authentication_provider,
                                 user_details=user_details, resource_group_name=self.rg1)
 
-        self.staticapp_client.update_static_site_user.assert_called_once_with(
-            self.rg1, self.name1, authentication_provider, user_id, roles=roles)
+        self.staticapp_client.update_static_site_user.assert_called_once_with(self.rg1, self.name1,
+            authentication_provider, user_id, static_site_user_envelope=StaticSiteUserARMResource(roles=roles))
 
     def test_update_staticsite_users_with_resourcegroup_without_user_id_user_not_found(self):
         roles = 'Contributor,Reviewer'


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fixes the `az staticwebapp users update` issue described by #19550. The command was broken by an update to the static web apps SDK -- the new method for updating user roles expected a slightly different set of arguments. 

**Testing Guide**
<!--Example commands with explanations.-->
`azdev test test_staticapp_commands_thru_mock`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
