### PR TITLE
{testsdk} Include `azure.cli.testsdk.scenario_tests` in wheel

### DIFF
--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -47,7 +47,8 @@ setup(
     zip_safe=False,
     classifiers=CLASSIFIERS,
     packages=[
-        'azure.cli.testsdk'
+        'azure.cli.testsdk',
+        'azure.cli.testsdk.scenario_tests',
     ],
     install_requires=DEPENDENCIES
 )


### PR DESCRIPTION
**Description**<!--Mandatory-->

After

- https://github.com/Azure/azure-cli/pull/20601

CI fails:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1244125&view=logs&jobId=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&j=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&t=9ebb608a-8a51-5834-bad0-46e2c03d2282

```
==================================== ERRORS ====================================
_________ ERROR collecting tests/latest/test_acr_agentpool_commands.py _________
ImportError while importing test module '/opt/az/lib/python3.6/site-packages/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/az/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/opt/az/lib/python3.6/site-packages/azure/cli/command_modules/acr/tests/latest/test_acr_agentpool_commands.py:6: in <module>
    from azure.cli.testsdk import ScenarioTest, StorageAccountPreparer, ResourceGroupPreparer, record_only
/opt/az/lib/python3.6/site-packages/azure/cli/testsdk/__init__.py:6: in <module>
    from .scenario_tests import live_only, record_only, get_sha1_hash
E   ModuleNotFoundError: No module named 'azure.cli.testsdk.scenario_tests'
```

This is because `azure.cli.testsdk.scenario_tests` is missing from the built wheel. 

Adding it to `setup.py`.
