### PR TITLE
{Auth} Bump `msal-extensions` to 0.3.1

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -51,7 +51,7 @@ DEPENDENCIES = [
     'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.9.0',
-    'msal-extensions>=0.3.0,<0.4',
+    'msal-extensions>=0.3.1,<0.4',
     'msal>=1.16.0,<2.0.0',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -42,7 +42,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=[
         'applicationinsights>=0.11.1,<0.12',
-        'portalocker~=1.6',
+        'portalocker>=1.6,<3',
     ],
     packages=[
         'azure.cli.telemetry',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.0
+msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -117,7 +117,7 @@ oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.7.1
+portalocker==2.3.2
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.55

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.0
+msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -118,7 +118,7 @@ oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.7.1
+portalocker==2.3.2
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.55

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.0
+msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
 msrestazure==0.6.3

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -117,7 +117,7 @@ oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
-portalocker==1.7.1
+portalocker==2.3.2
 psutil==5.8.0
 pycparser==2.19
 PyGithub==1.55


### PR DESCRIPTION
**Description**<!--Mandatory-->

Bump `msal-extensions` to 0.3.1 to incorporate changes from https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/105.

Specifically, this will fix 

- https://github.com/Azure/azure-cli/issues/20273
