### PR TITLE
[Storage] `az storage copy`: Add positional argument `extra_options` to pass through options to `azcopy`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1491,7 +1491,7 @@ examples:
   - name: Download a set of files from Azure File Share using wildcards, and you can also specify your storage account and share information as above.
     text: az storage copy -s https://[account].file.core.windows.net/[share]/ --include-pattern foo* -d /path/to/dir --recursive
   - name: Upload a single file to Azure Blob using url with azcopy options pass-through.
-    text: az storage copy -s /path/to/file.txt -d https://[account].blob.core.windows.net/[container]/[path/to/blob] --extra-options "--block-size-mb 0.25 --check-length"
+    text: az storage copy -s /path/to/file.txt -d https://[account].blob.core.windows.net/[container]/[path/to/blob] -- --block-size-mb=0.25 --check-length
 """
 
 helps['storage cors'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1490,6 +1490,8 @@ examples:
     text: az storage copy -s https://[account].file.core.windows.net/[share]/[path/to/directory] -d /path/to/dir --recursive
   - name: Download a set of files from Azure File Share using wildcards, and you can also specify your storage account and share information as above.
     text: az storage copy -s https://[account].file.core.windows.net/[share]/ --include-pattern foo* -d /path/to/dir --recursive
+  - name: Upload a single file to Azure Blob using url with azcopy options pass-through.
+    text: az storage copy -s /path/to/file.txt -d https://[account].blob.core.windows.net/[container]/[path/to/blob] --extra-options "--block-size-mb 0.25 --check-length"
 """
 
 helps['storage cors'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1076,7 +1076,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('cap_mbps', arg_group='Additional Flags', help="Caps the transfer rate, in megabits per second. "
                    "Moment-by-moment throughput might vary slightly from the cap. "
                    "If this option is set to zero, or it is omitted, the throughput isn't capped. ")
-        c.argument('extra_options', arg_group='Additional Flags',
+        c.argument('extra_options', arg_group='Additional Flags', is_experimental=True,
                    help="Other options which will be passed through to azcopy as it is")
 
     with self.argument_context('storage blob copy') as c:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1076,8 +1076,9 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('cap_mbps', arg_group='Additional Flags', help="Caps the transfer rate, in megabits per second. "
                    "Moment-by-moment throughput might vary slightly from the cap. "
                    "If this option is set to zero, or it is omitted, the throughput isn't capped. ")
-        c.argument('extra_options', arg_group='Additional Flags', is_experimental=True,
-                   help="Other options which will be passed through to azcopy as it is")
+        c.positional('extra_options', nargs='+', arg_group='Additional Flags', is_experimental=True,
+                     help="Other options which will be passed through to azcopy as it is. "
+                          "Please put all the extra options after a `--`")
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1076,6 +1076,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('cap_mbps', arg_group='Additional Flags', help="Caps the transfer rate, in megabits per second. "
                    "Moment-by-moment throughput might vary slightly from the cap. "
                    "If this option is set to zero, or it is omitted, the throughput isn't capped. ")
+        c.argument('extra_options', arg_group='Additional Flags',
+                   help="Other options which will be passed through to azcopy as it is")
 
     with self.argument_context('storage blob copy') as c:
         for item in ['destination', 'source']:

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1076,7 +1076,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('cap_mbps', arg_group='Additional Flags', help="Caps the transfer rate, in megabits per second. "
                    "Moment-by-moment throughput might vary slightly from the cap. "
                    "If this option is set to zero, or it is omitted, the throughput isn't capped. ")
-        c.positional('extra_options', nargs='+', arg_group='Additional Flags', is_experimental=True,
+        c.positional('extra_options', nargs='*', is_experimental=True, default=[],
                      help="Other options which will be passed through to azcopy as it is. "
                           "Please put all the extra options after a `--`")
 

--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 STORAGE_RESOURCE_ENDPOINT = "https://storage.azure.com"
 SERVICES = {'blob', 'file'}
-AZCOPY_VERSION = '10.8.0'
+AZCOPY_VERSION = '10.13.0'
 
 
 class AzCopy:
@@ -39,7 +39,7 @@ class AzCopy:
         install_dir = os.path.dirname(install_location)
         if not os.path.exists(install_dir):
             os.makedirs(install_dir)
-        base_url = 'https://azcopyvnext.azureedge.net/release20201211/azcopy_{}_{}_{}.{}'
+        base_url = 'https://azcopyvnext.azureedge.net/release20211027/azcopy_{}_{}_{}.{}'
 
         if self.system == 'Windows':
             if platform.machine().endswith('64'):

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -99,7 +99,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('storage', custom_command_type=get_custom_sdk('azcopy', None)) as g:
         from ._validators import validate_azcopy_credential
-        g.storage_custom_command('copy', 'storage_copy', is_preview=True, validator=validate_azcopy_credential)
+        g.storage_custom_command('copy', 'storage_copy', validator=validate_azcopy_credential)
 
     with self.command_group('storage account', storage_account_sdk, resource_type=ResourceType.MGMT_STORAGE,
                             custom_command_type=storage_account_custom_type) as g:

--- a/src/azure-cli/azure/cli/command_modules/storage/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/storage/linter_exclusions.yml
@@ -15,4 +15,9 @@ storage blob copy start:
         if_unmodified_since:
             rule_exclusions:
             - option_length_too_long
+storage copy:
+    parameters:
+        extra_options:
+            rule_exclusions:
+            - no_positional_parameters
 ...

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import shlex
 from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy, _generate_sas_token
 
 
@@ -10,7 +11,7 @@ from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy,
 def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=None,
                  preserve_s2s_access_tier=None, content_type=None, follow_symlinks=None,
                  exclude_pattern=None, include_pattern=None, exclude_path=None, include_path=None,
-                 cap_mbps=None, **kwargs):
+                 cap_mbps=None, extra_options=None, **kwargs):
 
     azcopy = AzCopy()
     flags = []
@@ -36,6 +37,8 @@ def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=No
         flags.append('--follow-symlinks=true')
     if cap_mbps is not None:
         flags.append('--cap-mbps=' + cap_mbps)
+    if extra_options is not None:
+        flags.extend(shlex.split(extra_options))
     azcopy.copy(source, destination, flags=flags)
 
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -11,7 +11,7 @@ from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy,
 def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=None,
                  preserve_s2s_access_tier=None, content_type=None, follow_symlinks=None,
                  exclude_pattern=None, include_pattern=None, exclude_path=None, include_path=None,
-                 cap_mbps=None, extra_options=None, **kwargs):
+                 cap_mbps=None, extra_options=[], **kwargs):
 
     azcopy = AzCopy()
     flags = []

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import shlex
 from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy, _generate_sas_token
 
 
@@ -11,7 +10,7 @@ from ..azcopy.util import AzCopy, client_auth_for_azcopy, login_auth_for_azcopy,
 def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=None,
                  preserve_s2s_access_tier=None, content_type=None, follow_symlinks=None,
                  exclude_pattern=None, include_pattern=None, exclude_path=None, include_path=None,
-                 cap_mbps=None, extra_options=[], **kwargs):
+                 cap_mbps=None, extra_options=None, **kwargs):
 
     azcopy = AzCopy()
     flags = []

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -38,7 +38,7 @@ def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=No
     if cap_mbps is not None:
         flags.append('--cap-mbps=' + cap_mbps)
     if extra_options is not None:
-        flags.extend(shlex.split(extra_options))
+        flags.extend(extra_options)
     azcopy.copy(source, destination, flags=flags)
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Feature asked by #20662 #20663 #20666 
This PR:
- Adds positional argument `extra_options` with `experimental` tag for flexibility
- Upgrades `azcopy` from `10.8.0` to `10.13.0`
- Removes `preview` tag for `az storage copy`

**Testing Guide**
<!--Example commands with explanations.-->
`az storage copy -s source_file -d destination_container_url -- --block-size-mb=0.25 --check-length`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
