### PR TITLE
{Packaging} Upgrade `virtualenv` to 16.7.11 to fix install on python 3.10

### DIFF
--- a/scripts/curl_install_pypi/install
+++ b/scripts/curl_install_pypi/install
@@ -9,7 +9,7 @@
 # Bash script to install the Azure CLI
 #
 INSTALL_SCRIPT_URL="https://azurecliprod.blob.core.windows.net/install.py"
-INSTALL_SCRIPT_SHA256=c5107b96cfe881c46c8d8d9f401fcf931aab2b769a20fda58626b6e6e907219b
+INSTALL_SCRIPT_SHA256=7869d3c46992852525b8f9e4c63e34edd2d29cafed9e16fd94d5356665eefdfd
 _TTY=/dev/tty
 
 install_script=$(mktemp -t azure_cli_install_tmp_XXXXXX) || exit

--- a/scripts/curl_install_pypi/install.py
+++ b/scripts/curl_install_pypi/install.py
@@ -41,10 +41,10 @@ AZ_DISPATCH_TEMPLATE = """#!/usr/bin/env bash
 {install_dir}/bin/python -m azure.cli "$@"
 """
 
-VIRTUALENV_VERSION = '16.7.7'
+VIRTUALENV_VERSION = '16.7.11'
 VIRTUALENV_ARCHIVE = 'virtualenv-'+VIRTUALENV_VERSION+'.tar.gz'
 VIRTUALENV_DOWNLOAD_URL = 'https://pypi.python.org/packages/source/v/virtualenv/'+VIRTUALENV_ARCHIVE
-VIRTUALENV_ARCHIVE_SHA256 = 'd257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136'
+VIRTUALENV_ARCHIVE_SHA256 = '0f73ef551d889bf4b3241f1819aaf5f5c7e27259c1537255b1f63207552919b1'
 
 DEFAULT_INSTALL_DIR = os.path.expanduser(os.path.join('~', 'lib', 'azure-cli'))
 DEFAULT_EXEC_DIR = os.path.expanduser(os.path.join('~', 'bin'))


### PR DESCRIPTION
https://github.com/pypa/virtualenv/pull/2109
https://virtualenv.pypa.io/en/legacy/changes.html#v16-7-11-2021-07-20

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Linux install script is not working with Python 3.10  (#20713) due to the fact the version of virutalenv is pinned to 16.7.7, which is not compatible with python 3.10. This PR upgrades virtualenv to 16.7.11.

**Testing Guide**
<!--Example commands with explanations.-->
```
docker run --rm -it python:3.10 bash

# errored out
curl -o install_old.py https://raw.githubusercontent.com/Azure/azure-cli/azure-cli-2.31.0/scripts/curl_install_pypi/install.py
python install_old.py

# works
curl -o install_new.py https://raw.githubusercontent.com/pallxk/azure-cli/fix-install-script-py-3.10/scripts/curl_install_pypi/install.py
python install_new.py
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Packaging] Fix install script on Python 3.10

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
