### PR TITLE
[Bot Service] `az bot create`: Add location as specified by user to bot creation for regionality/EUDB

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/botservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/custom.py
@@ -100,7 +100,7 @@ def __handle_failed_name_check(name_response, cmd, client, resource_group_name, 
 
 
 def create(cmd, client, resource_group_name, resource_name, kind, msa_app_id, password=None, language=None,  # pylint: disable=too-many-locals, too-many-statements, inconsistent-return-statements
-           description=None, display_name=None, endpoint=None, tags=None, location='Central US',
+           description=None, display_name=None, endpoint=None, tags=None, location='global',
            sku_name='F0', deploy_echo=None, cmek_key_vault_url=None):
     # Kind parameter validation
     kind = kind.lower()
@@ -152,7 +152,7 @@ def create(cmd, client, resource_group_name, resource_name, kind, msa_app_id, pa
             is_cmek_enabled = True
 
         parameters = Bot(
-            location='global',
+            location=location,
             sku=Sku(name=sku_name),
             kind=kind,
             tags=tags,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously the location parameter as specified by the user in the az bot create command was not actually used. This was okay previously because all bot resources are global. However due to EU data boundary work, we now support creation of Europe and United States regional bots and guarantee data residency for such bots. Because this is not a breaking change, and the lack of propagation of this property is technically a bug, we would prefer to take this change as a hotfix.

**Testing Guide**
<!--Example commands with explanations.-->
Test cases:
To validate existing functionality
- run az bot create without a location
- run az bot create with "global" as the specified location
- (can only be included when the ARM manifest is able to be updated in January for the service) run az bot create with "westeurope" or "westus2" as the location parameter

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
