### PR TITLE
{Core} Retry loading MSAL HTTP cache in case of failure

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -862,7 +862,12 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
 
     # Only enable encryption for Windows (for now).
     fallback = sys.platform.startswith('win32')
+
+    # EXPERIMENTAL: Use core.encrypt_token_cache=False to turn off token cache encryption.
     # encrypt_token_cache affects both MSAL token cache and service principal entries.
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 
-    return Identity(*args, encrypt=encrypt, **kwargs)
+    # EXPERIMENTAL: Use core.use_msal_http_cache=False to turn off MSAL HTTP cache.
+    use_msal_http_cache = cli_ctx.config.getboolean('core', 'use_msal_http_cache', fallback=True)
+
+    return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache, **kwargs)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -5,9 +5,12 @@
 
 import json
 import os
+import pickle
 import re
+import time
 
 from azure.cli.core._environment import get_config_dir
+from azure.cli.core.decorators import retry
 from msal import PublicClientApplication
 
 from knack.log import get_logger
@@ -45,7 +48,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     # It follows singleton pattern so that _secret_file is read only once.
     _service_principal_store_instance = None
 
-    def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False):
+    def __init__(self, authority, tenant_id=None, client_id=None, encrypt=False, use_msal_http_cache=True):
         """
         :param authority: Authentication authority endpoint. For example,
             - AAD: https://login.microsoftonline.com
@@ -58,7 +61,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         self.authority = authority
         self.tenant_id = tenant_id
         self.client_id = client_id or AZURE_CLI_CLIENT_ID
-        self.encrypt = encrypt
+        self._encrypt = encrypt
+        self._use_msal_http_cache = use_msal_http_cache
 
         # Build the authority in MSAL style
         self._msal_authority, self._is_adfs = _get_authority_url(authority, tenant_id)
@@ -80,7 +84,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         if not Identity._msal_token_cache:
             Identity._msal_token_cache = self._load_msal_token_cache()
 
-        if not Identity._msal_http_cache:
+        if self._use_msal_http_cache and not Identity._msal_http_cache:
             Identity._msal_http_cache = self._load_msal_http_cache()
 
         return {
@@ -100,25 +104,46 @@ class Identity:  # pylint: disable=too-many-instance-attributes
 
     def _load_msal_token_cache(self):
         # Store for user token persistence
-        cache = load_persisted_token_cache(self._token_cache_file, self.encrypt)
+        cache = load_persisted_token_cache(self._token_cache_file, self._encrypt)
         return cache
+
+    @retry()
+    def __load_msal_http_cache(self):
+        """Load MSAL HTTP cache with retry. If it still fails at last, raise the original exception as-is."""
+        logger.debug("__load_msal_http_cache: %s", self._http_cache_file)
+        try:
+            with open(self._http_cache_file, 'rb') as f:
+                return pickle.load(f)
+        except FileNotFoundError:
+            # The cache file has not been created. This is expected.
+            logger.debug("%s not found. Using a fresh one.", self._http_cache_file)
+            return {}
+
+    def _dump_msal_http_cache(self):
+        logger.debug("_dump_msal_http_cache: %s", self._http_cache_file)
+        with open(self._http_cache_file, 'wb') as f:
+            # At this point, an empty cache file will be created. Loading this cache file will
+            # trigger EOFError. This can be simulated by adding time.sleep(30) here.
+            # So, during loading, EOFError is ignored.
+            pickle.dump(self._msal_http_cache, f)
 
     def _load_msal_http_cache(self):
         import atexit
-        import pickle
 
         logger.debug("_load_msal_http_cache: %s", self._http_cache_file)
         try:
-            with open(self._http_cache_file, 'rb') as f:
-                persisted_http_cache = pickle.load(f)
-        except (pickle.UnpicklingError, FileNotFoundError) as ex:
-            logger.debug("Failed to load MSAL HTTP cache: %s", ex)
+            persisted_http_cache = self.__load_msal_http_cache()
+        except (pickle.UnpicklingError, EOFError) as ex:
+            # We still get exception after retry:
+            # - pickle.UnpicklingError is caused by corrupted cache file, perhaps due to concurrent writes.
+            # - EOFError is caused by empty cache file created by other az instance, but hasn't been filled yet.
+            logger.debug("Failed to load MSAL HTTP cache: %s. Using a fresh one.", ex)
             persisted_http_cache = {}  # Ignore a non-exist or corrupted http_cache
-        atexit.register(lambda: pickle.dump(
-            # When exit, flush it back to the file.
-            # If 2 processes write at the same time, the cache will be corrupted,
-            # but that is fine. Subsequent runs would reach eventual consistency.
-            persisted_http_cache, open(self._http_cache_file, 'wb')))
+
+        # When exiting, flush it back to the file.
+        # If 2 processes write at the same time, the cache will be corrupted,
+        # but that is fine. Subsequent runs would reach eventual consistency.
+        atexit.register(self._dump_msal_http_cache)
 
         return persisted_http_cache
 
@@ -128,7 +153,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         The instance is lazily created.
         """
         if not Identity._service_principal_store_instance:
-            store = load_secret_store(self._secret_file, self.encrypt)
+            store = load_secret_store(self._secret_file, self._encrypt)
             Identity._service_principal_store_instance = ServicePrincipalStore(store)
         return Identity._service_principal_store_instance
 

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -7,7 +7,6 @@ import json
 import os
 import pickle
 import re
-import time
 
 from azure.cli.core._environment import get_config_dir
 from azure.cli.core.decorators import retry

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -8,7 +8,6 @@
 
 import json
 import sys
-import time
 
 from msal_extensions import (FilePersistenceWithDataProtection, KeychainPersistence, LibsecretPersistence,
                              FilePersistence, PersistedTokenCache, CrossPlatLock)

--- a/src/azure-cli-core/azure/cli/core/auth/persistence.py
+++ b/src/azure-cli-core/azure/cli/core/auth/persistence.py
@@ -15,6 +15,8 @@ from msal_extensions import (FilePersistenceWithDataProtection, KeychainPersiste
 from msal_extensions.persistence import PersistenceNotFound
 
 from knack.log import get_logger
+from azure.cli.core.decorators import retry
+
 
 logger = get_logger(__name__)
 
@@ -60,27 +62,9 @@ class SecretStore:
         with CrossPlatLock(self._lock_file):
             self._persistence.save(json.dumps(content, indent=4))
 
-    def _load(self):
+    @retry()
+    def load(self):
         try:
             return json.loads(self._persistence.load())
         except PersistenceNotFound:
             return []
-
-    def load(self):
-        # Use optimistic locking rather than CrossPlatLock, so that multiple processes can
-        # read the same file at the same time.
-        retry = 3
-        for attempt in range(1, retry + 1):
-            try:
-                return self._load()
-            except Exception:  # pylint: disable=broad-except
-                # Presumably other processes are writing the file, causing dirty read
-                if attempt < retry:
-                    logger.debug("Unable to load secret store in No. %d attempt", attempt)
-                    import traceback
-                    logger.debug(traceback.format_exc())
-                    time.sleep(0.5)
-                else:
-                    raise  # End of retry. Re-raise the exception as-is.
-
-        return []  # Not really reachable here. Just to keep pylint happy.

--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -87,8 +87,13 @@ def suppress_all_exceptions(fallback_return=None, **kwargs):  # pylint: disable=
 
 
 def retry(retry_times=3, interval=0.5, exceptions=Exception):
-    # Use optimistic locking to call a function, so that multiple processes can
-    # access the same resource (such as a file) at the same time.
+    """Use optimistic locking to call a function, so that multiple processes can
+    access the same resource (such as a file) at the same time.
+
+    :param retry_times: Times to retry.
+    :param interval: Interval between retries.
+    :param exceptions: Exceptions that can be ignored. Use a tuple if multiple exceptions should be ignored.
+    """
     def _decorator(func):
         @wraps(func)
         def _wrapped_func(*args, **kwargs):

--- a/src/azure-cli-core/azure/cli/core/decorators.py
+++ b/src/azure-cli-core/azure/cli/core/decorators.py
@@ -16,6 +16,9 @@ from functools import wraps
 from knack.log import get_logger
 
 
+logger = get_logger(__name__)
+
+
 # pylint: disable=too-few-public-methods
 class Completer:
 
@@ -79,5 +82,27 @@ def suppress_all_exceptions(fallback_return=None, **kwargs):  # pylint: disable=
                 get_logger(__name__).info('Suppress exception:\n%s', traceback.format_exc())
                 if fallback_return is not None:
                     return fallback_return
+        return _wrapped_func
+    return _decorator
+
+
+def retry(retry_times=3, interval=0.5, exceptions=Exception):
+    # Use optimistic locking to call a function, so that multiple processes can
+    # access the same resource (such as a file) at the same time.
+    def _decorator(func):
+        @wraps(func)
+        def _wrapped_func(*args, **kwargs):
+            for attempt in range(1, retry_times + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions:  # pylint: disable=broad-except
+                    if attempt < retry_times:
+                        logger.debug("%s failed in No. %d attempt", func, attempt)
+                        import traceback
+                        import time
+                        logger.debug(traceback.format_exc())
+                        time.sleep(interval)
+                    else:
+                        raise  # End of retry. Re-raise the exception as-is.
         return _wrapped_func
     return _decorator


### PR DESCRIPTION
## Symptom

Fix #20707, #20676, #20720

When invoked by Terraform concurrently, one instance of `az` fails with:

```
│   File "/opt/az/lib/python3.6/site-packages/azure/cli/core/auth/identity.py", line 113, in _load_msal_http_cache
│     persisted_http_cache = pickle.load(f)
│ EOFError: Ran out of input
```

This is because a racing condition happens after the cache file `~/.azure/msal_http_cache.bin` is created but not filled yet:

https://github.com/Azure/azure-cli/blob/713b0edca860a8e4037bfc865d847b945fb12886/src/azure-cli-core/azure/cli/core/auth/identity.py#L117-L121

The second instance will see an empty cache file, resulting in `EOFError`.


## Change

This PR adds a retry logic to `_load_msal_http_cache` so that it retries several times in case of failure. If it still fails at last, ignore exceptions and use a fresh MSAL HTTP cache.

An experimental config option `core.use_msal_http_cache` is added to allow the user opt out of MSAL HTTP cache.


## Testing Guide

Sleep for a while here:

https://github.com/Azure/azure-cli/blob/6e431b0bc879eedab1f8542133515a6c11e4097a/src/azure-cli-core/azure/cli/core/auth/identity.py#L124-L128

This will reproduce `EOFError`. Launch another instance of `az` with `--debug` to see `EOFError` is ignored. In reality, the `retry` logic will allow the second `az` to load the cache file successfully.
