### PR TITLE
{Core} Migrate `CloudError` for resource Track 2 SDK

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -71,13 +71,13 @@ def generate_deployment_name(namespace):
 def get_default_location_from_resource_group(cmd, namespace):
     if not namespace.location:
         from azure.cli.core.commands.client_factory import get_mgmt_service_client
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import HttpResponseError
         from knack.util import CLIError
 
         resource_client = get_mgmt_service_client(cmd.cli_ctx, ResourceType.MGMT_RESOURCE_RESOURCES)
         try:
             rg = resource_client.resource_groups.get(namespace.resource_group_name)
-        except CloudError as ex:
+        except HttpResponseError as ex:
             raise CLIError('error retrieving default location: {}'.format(ex.message))
         namespace.location = rg.location  # pylint: disable=no-member
         logger.debug("using location '%s' from resource group '%s'", namespace.location, rg.name)


### PR DESCRIPTION
Fix: #20732

Since the resource module has migrated to Track 2 https://github.com/Azure/azure-cli/pull/17783, `CloudError` should be replaced by `HttpResponseError` in track 2, so submit this PR to modify it

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
