### PR TITLE
{Packaging} Add missing dependencies for `azure-cli-core`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -195,7 +195,7 @@ class Profile:
 
     def login_with_managed_identity(self, identity_id=None, allow_no_subscriptions=None):
         import jwt
-        from msrestazure.tools import is_valid_resource_id
+        from azure.mgmt.core.tools import is_valid_resource_id
         from azure.cli.core.auth.adal_authentication import MSIAuthenticationWrapper
         resource = self.cli_ctx.cloud.endpoints.active_directory_resource_id
 

--- a/src/azure-cli-core/azure/cli/core/commands/arm.py
+++ b/src/azure-cli-core/azure/cli/core/commands/arm.py
@@ -169,7 +169,7 @@ def deployment_validate_table_format(result):
 class ResourceId(str):
 
     def __new__(cls, val):
-        from msrestazure.tools import is_valid_resource_id
+        from azure.mgmt.core.tools import is_valid_resource_id
         if not is_valid_resource_id(val):
             raise ValueError()
         return str.__new__(cls, val)
@@ -782,7 +782,7 @@ def _gen_guid():
 
 
 def get_arm_resource_by_id(cli_ctx, arm_id, api_version=None):
-    from msrestazure.tools import parse_resource_id, is_valid_resource_id
+    from azure.mgmt.core.tools import parse_resource_id, is_valid_resource_id
 
     if not is_valid_resource_id(arm_id):
         raise CLIError("'{}' is not a valid ID.".format(arm_id))

--- a/src/azure-cli-core/azure/cli/core/commands/template_create.py
+++ b/src/azure-cli-core/azure/cli/core/commands/template_create.py
@@ -53,7 +53,7 @@ def get_folded_parameter_help_string(
 def _validate_name_or_id(
         cli_ctx, resource_group_name, property_value, property_type, parent_value, parent_type):
     from azure.cli.core.commands.client_factory import get_subscription_id
-    from msrestazure.tools import parse_resource_id, is_valid_resource_id
+    from azure.mgmt.core.tools import parse_resource_id, is_valid_resource_id
     has_parent = parent_type is not None
     if is_valid_resource_id(property_value):
         resource_id_parts = parse_resource_id(property_value)
@@ -95,7 +95,7 @@ def get_folded_parameter_validator(
 
     # construct the validator
     def validator(cmd, namespace):
-        from msrestazure.tools import resource_id
+        from azure.mgmt.core.tools import resource_id
         type_field_name = '{}_type'.format(property_name)
         property_val = getattr(namespace, property_name, None)
         parent_val = getattr(namespace, parent_name, None) if parent_name else None

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,6 +53,7 @@ DEPENDENCIES = [
     'knack~=0.9.0',
     'msal-extensions>=0.3.1,<0.4',
     'msal>=1.16.0,<2.0.0',
+    'msrestazure~=0.6.4',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
     'PyJWT>=2.1.0',

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -54,6 +54,7 @@ DEPENDENCIES = [
     'msal-extensions>=0.3.1,<0.4',
     'msal>=1.16.0,<2.0.0',
     'msrestazure~=0.6.4',
+    'packaging>=20.9,<22.0',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
     'PyJWT>=2.1.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -112,7 +112,7 @@ MarkupSafe==1.1.1
 msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
-msrestazure==0.6.3
+msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -113,7 +113,7 @@ MarkupSafe==1.1.1
 msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
-msrestazure==0.6.3
+msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -112,7 +112,7 @@ MarkupSafe==1.1.1
 msal-extensions==0.3.1
 msal==1.16.0
 msrest==0.6.21
-msrestazure==0.6.3
+msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
 paramiko==2.6.0


### PR DESCRIPTION
## Description

Fix #20732 

### `msrestazure`

`msrestazure` is indeed needed by `azure-cli-core` to authenticate with managed identity:

https://github.com/Azure/azure-cli/blob/d7e5ede07748b423d2b03fbb8bd25b8bb2c19023/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py#L8

It works now without declaring `msrestazure` dependency because `msrestazure` is installed by Track 1 SDKs.

### `packaging`
`packaging` is needed by extension operations:

https://github.com/Azure/azure-cli/blob/ed6e829554624894d5c94ad71bb85e788d726a43/src/azure-cli-core/azure/cli/core/extension/__init__.py#L283

It works now without declaring `packaging` dependency because `packaging` is installed by `azure-cli`:

https://github.com/Azure/azure-cli/blob/d5314bacaca2b0abc1c884d995f48a130a4261f9/src/azure-cli/setup.py#L144
