### PR TITLE
{ACR} Increase client connection timeout with storage when uploading local build context

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -57,10 +57,12 @@ def upload_source_code(cmd, client,
     BlockBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob#BlockBlobService')
     BlockBlobService(account_name=account_name,
                      sas_token=sas_token,
-                     endpoint_suffix=endpoint_suffix).create_blob_from_path(
+                     endpoint_suffix=endpoint_suffix,
+                     socket_timeout=300).create_blob_from_path(
                          container_name=container_name,
                          blob_name=blob_name,
-                         file_path=tar_file_path)
+                         file_path=tar_file_path,
+                         timeout=30)
     logger.warning("Sending context ({0:.3f} {1}) to registry: {2}...".format(
         size, unit, registry_name))
     return relative_path

--- a/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_archive_utils.py
@@ -58,11 +58,11 @@ def upload_source_code(cmd, client,
     BlockBlobService(account_name=account_name,
                      sas_token=sas_token,
                      endpoint_suffix=endpoint_suffix,
+                     # Increase socket timeout from default of 20s for clients with slow network connection.
                      socket_timeout=300).create_blob_from_path(
                          container_name=container_name,
                          blob_name=blob_name,
-                         file_path=tar_file_path,
-                         timeout=30)
+                         file_path=tar_file_path)
     logger.warning("Sending context ({0:.3f} {1}) to registry: {2}...".format(
         size, unit, registry_name))
     return relative_path


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fixes #20075

The `az acr build` command may upload local source code (the "context") to Azure prior to executing a build. In this case, the local build context is uploaded to Azure blob storage. In a slow network environment, customers may see the error `('Connection aborted.', timeout('The write operation timed out'))` during the upload stage of the command. This happens when the customer machine takes too long to connect to Azure storage server. Azure storage Python SDK uses a default client connection timeout of 20s. This change increases that timeout to 300s. 

**Testing Guide**

Queue a local context as a Linux build, tag it, and push it to the registry.
`az acr build -t sample/hello-world:{{.Run.ID}} -r MyRegistry .`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
