### PR TITLE
[App Service] Fix #20757: `az webapp up`:  Fix list index out of range when no `--plan` argument passed

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -379,11 +379,15 @@ def detect_os_form_src(src_dir, html=False):
 
 
 def get_plan_to_use(cmd, user, loc, sku, create_rg, resource_group_name, plan=None):
-    _default_asp = "{}_asp_{:04}".format(user, randint(0, 9999))
+    _default_asp = _get_default_plan_name(user)
     if plan is None:  # --plan not provided by user
         # get the plan name to use
         return _determine_if_default_plan_to_use(cmd, _default_asp, resource_group_name, loc, sku, create_rg)
     return plan
+
+
+def _get_default_plan_name(user):
+    return "{}_asp_{:04}".format(user, randint(0, 9999))
 
 
 # Portal uses the current_stack property in the app metadata to display the correct stack
@@ -400,8 +404,9 @@ def _determine_if_default_plan_to_use(cmd, plan_name, resource_group_name, loc, 
     client = web_client_factory(cmd.cli_ctx)
     if create_rg:  # if new RG needs to be created use the default name
         return plan_name
+
     # get all ASPs in the RG & filter to the ones that contain the plan_name
-    _asp_generic = plan_name[:-len(plan_name.split("_")[4])]
+    _asp_generic = plan_name[:plan_name.rindex("_")]
     _asp_list = (list(filter(lambda x: _asp_generic in x.name,
                              client.app_service_plans.list_by_resource_group(resource_group_name))))
     _num_asp = len(_asp_list)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #20757 

**Testing Guide**
<!--Example commands with explanations.-->
`azdev test --live test_webapp_up_no_plan_e2e `

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
