### PR TITLE
{ServiceConnector} Support RP auto registering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@
 /src/azure-cli/azure/cli/command_modules/role/ @jiasli @evelyn-ys @calvinhzy
 /src/azure-cli/azure/cli/command_modules/search/ @huangbolun @kairu-ms
 /src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @zhoxing-ms @jsntcy
-/src/azure-cli/azure/cli/command_modules/serviceconnector/ @yungezz @houk-ms
+/src/azure-cli/azure/cli/command_modules/serviceconnector/ @yungezz @houk-ms @xfz11
 /src/azure-cli/azure/cli/command_modules/servicefabric/ @QingChenmsft @zhoxing-ms @jsntcy
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/storage/ @jsntcy @zhoxing-ms @evelyn-ys @calvinhzy

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -123,7 +123,7 @@ def auto_register(func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except HttpResponseError as ex:
-        if ex.error.code == 'SubscriptionNotRegistered':
+        if ex.error and ex.error.code == 'SubscriptionNotRegistered':
             if register_provider():
                 return func(*args, **kwargs)
             raise CLIInternalError('Registeration failed, please manually run command '

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_utils.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import time
 from azure.cli.core.azclierror import (
     CLIInternalError
 )
@@ -87,3 +88,44 @@ def set_user_token_header(client, cli_ctx):
     client._config.logging_policy.headers_to_redact.append('x-ms-serviceconnector-user-token')
 
     return client
+
+
+def register_provider():
+    from knack.log import get_logger
+    logger = get_logger(__name__)
+
+    logger.warning('Provider Microsoft.ServiceLinker is not registered, '
+                   'trying to register. This usually takes 1-2 minutes.')
+    # register the provider
+    run_cli_cmd('az provider register -n Microsoft.ServiceLinker')
+
+    # verify the registration, 30 * 10s polling the result
+    MAX_RETRY_TIMES = 30
+    RETRY_INTERVAL = 10
+
+    count = 0
+    while count < MAX_RETRY_TIMES:
+        time.sleep(RETRY_INTERVAL)
+        output = run_cli_cmd('az provider show -n Microsoft.ServiceLinker')
+        current_state = output.get('registrationState')
+        if current_state == 'Registered':
+            return True
+        if current_state == 'Registering':
+            count += 1
+        else:
+            return False
+    return False
+
+
+def auto_register(func, *args, **kwargs):
+    from azure.core.exceptions import HttpResponseError
+
+    try:
+        return func(*args, **kwargs)
+    except HttpResponseError as ex:
+        if ex.error.code == 'SubscriptionNotRegistered':
+            if register_provider():
+                return func(*args, **kwargs)
+            raise CLIInternalError('Registeration failed, please manually run command '
+                                   '`az provider register -n Microsoft.ServiceLinker` to register the provider.')
+        raise ex

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -23,7 +23,10 @@ from ._validators import (
     get_target_resource_name
 )
 from ._addon_factory import AddonFactory
-from ._utils import set_user_token_header
+from ._utils import (
+    set_user_token_header,
+    auto_register
+)
 # pylint: disable=unused-argument
 
 
@@ -111,8 +114,9 @@ def connection_list_configuration(client,
                                   spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
-    return client.list_configurations(resource_uri=source_id,
-                                      linker_name=connection_name)
+    return auto_register(client.list_configurations,
+                         resource_uri=source_id,
+                         linker_name=connection_name)
 
 
 def connection_validate(cmd, client,
@@ -137,8 +141,7 @@ def connection_validate(cmd, client,
         if matched and resource_type in TARGET_RESOURCES_USERTOKEN:
             client = set_user_token_header(client, cmd.cli_ctx)
 
-    return client.begin_validate(resource_uri=source_id,
-                                 linker_name=connection_name)
+    return auto_register(client.begin_validate, resource_uri=source_id, linker_name=connection_name)
 
 
 def connection_create(cmd, client,  # pylint: disable=too-many-locals
@@ -208,11 +211,11 @@ def connection_create(cmd, client,  # pylint: disable=too-many-locals
             raise AzureResponseError('{}. Provision failed, please create the target resource '
                                      'manually and then create the connection.'.format(str(e)))
 
-    return sdk_no_wait(no_wait,
-                       client.begin_create_or_update,
-                       resource_uri=source_id,
-                       linker_name=connection_name,
-                       parameters=parameters)
+    return auto_register(sdk_no_wait, no_wait,
+                         client.begin_create_or_update,
+                         resource_uri=source_id,
+                         linker_name=connection_name,
+                         parameters=parameters)
 
 
 def connection_update(cmd, client,
@@ -268,11 +271,11 @@ def connection_update(cmd, client,
     if target_type in TARGET_RESOURCES_USERTOKEN:
         client = set_user_token_header(client, cmd.cli_ctx)
 
-    return sdk_no_wait(no_wait,
-                       client.begin_create_or_update,
-                       resource_uri=source_id,
-                       linker_name=connection_name,
-                       parameters=parameters)
+    return auto_register(sdk_no_wait, no_wait,
+                         client.begin_create_or_update,
+                         resource_uri=source_id,
+                         linker_name=connection_name,
+                         parameters=parameters)
 
 
 def connection_create_kafka(cmd, client,  # pylint: disable=too-many-locals

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -41,7 +41,7 @@ def connection_list(client,
                     spring=None, app=None, deployment=None):
     if not source_id:
         raise RequiredArgumentMissingError(err_msg.format('--source-id'))
-    return client.list(resource_uri=source_id)
+    return auto_register(client.list, resource_uri=source_id)
 
 
 def connection_list_support_types(cmd, client,
@@ -84,8 +84,7 @@ def connection_show(client,
                     spring=None, app=None, deployment=None):
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
-    return client.get(resource_uri=source_id,
-                      linker_name=connection_name)
+    return auto_register(client.get, resource_uri=source_id, linker_name=connection_name)
 
 
 def connection_delete(client,
@@ -99,10 +98,10 @@ def connection_delete(client,
     if not source_id or not connection_name:
         raise RequiredArgumentMissingError(err_msg.format('--source-id, --connection'))
 
-    return sdk_no_wait(no_wait,
-                       client.begin_delete,
-                       resource_uri=source_id,
-                       linker_name=connection_name)
+    return auto_register(sdk_no_wait, no_wait,
+                         client.begin_delete,
+                         resource_uri=source_id,
+                         linker_name=connection_name)
 
 
 def connection_list_configuration(client,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR brings some improvements for ServiceConnector. When users' subscription is not registered for `Microsoft.ServiceLinker`, we will register the subscription for users.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
