### PR TITLE
{AKS} Update validator for cluster auto-scaler profile

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -18,7 +18,7 @@ from knack.arguments import CLIArgumentType
 from ._completers import (
     get_vm_size_completion_list, get_k8s_versions_completion_list, get_k8s_upgrades_completion_list, get_ossku_completion_list)
 from ._validators import (
-    validate_cluster_autoscaler_profile, validate_create_parameters, validate_kubectl_version, validate_kubelogin_version, validate_k8s_version, validate_linux_host_name,
+    validate_create_parameters, validate_kubectl_version, validate_kubelogin_version, validate_k8s_version, validate_linux_host_name,
     validate_list_of_integers, validate_ssh_key, validate_nodes_count,
     validate_nodepool_name, validate_vm_set_type, validate_load_balancer_sku, validate_load_balancer_outbound_ips,
     validate_priority, validate_eviction_policy, validate_spot_max_price,
@@ -234,8 +234,7 @@ def load_arguments(self, _):
         c.argument('outbound_type', arg_type=get_enum_type(outbound_types))
         c.argument('auto_upgrade_channel', arg_type=get_enum_type(auto_upgrade_channels))
         c.argument('enable_cluster_autoscaler', action='store_true')
-        # TODO: replace "validate_cluster_autoscaler_profile" with "_extract_cluster_autoscaler_params"
-        c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"], validator=validate_cluster_autoscaler_profile,
+        c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"],
                    help="Space-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
         c.argument('min_count', type=int, validator=validate_nodes_count)
         c.argument('max_count', type=int, validator=validate_nodes_count)
@@ -316,8 +315,7 @@ def load_arguments(self, _):
                    "--disable-cluster-autoscaler", "-d"], action='store_true')
         c.argument('update_cluster_autoscaler', options_list=[
                    "--update-cluster-autoscaler", "-u"], action='store_true')
-        # TODO: replace "validate_cluster_autoscaler_profile" with "_extract_cluster_autoscaler_params
-        c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"], validator=validate_cluster_autoscaler_profile,
+        c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"],
                    help="Space-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")
         c.argument('min_count', type=int, validator=validate_nodes_count)
         c.argument('max_count', type=int, validator=validate_nodes_count)

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -108,39 +108,6 @@ def validate_k8s_version(namespace):
                            'such as "1.11.8" or "1.12.6"')
 
 
-def validate_cluster_autoscaler_profile(cmd, namespace):
-    """ Validates that cluster autoscaler profile is acceptable by:
-        1. Extracting the key[=value] format to map
-        2. Validating that the key isn't empty and that the key is valid
-        Empty strings pass validation
-    """
-    _extract_cluster_autoscaler_params(namespace)
-    if namespace.cluster_autoscaler_profile is not None:
-        for key in namespace.cluster_autoscaler_profile.keys():
-            _validate_cluster_autoscaler_key(cmd, key)
-
-
-def _validate_cluster_autoscaler_key(cmd, key):
-    if not key:
-        raise CLIError('Empty key specified for cluster-autoscaler-profile')
-    ManagedClusterPropertiesAutoScalerProfile = cmd.get_models('ManagedClusterPropertiesAutoScalerProfile',
-                                                               resource_type=ResourceType.MGMT_CONTAINERSERVICE,
-                                                               operation_group='managed_clusters')
-    valid_keys = list(k.replace("_", "-") for k, v in ManagedClusterPropertiesAutoScalerProfile._attribute_map.items())  # pylint: disable=protected-access
-    if key not in valid_keys:
-        raise CLIError("'{0}' is an invalid key for cluster-autoscaler-profile. "
-                       "Valid keys are {1}.".format(key, ', '.join(valid_keys)))
-
-
-def _extract_cluster_autoscaler_params(namespace):
-    """ Extracts multiple space-separated cluster autoscaler parameters in key[=value] format """
-    if isinstance(namespace.cluster_autoscaler_profile, list):
-        params_dict = {}
-        for item in namespace.cluster_autoscaler_profile:
-            params_dict.update(validate_tag(item))
-        namespace.cluster_autoscaler_profile = params_dict
-
-
 def validate_nodepool_name(namespace):
     """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
     if namespace.nodepool_name != "":

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -4,22 +4,19 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import unicode_literals
+
 import os
 import os.path
 import re
-from math import isnan, isclose
 from ipaddress import ip_network
+from math import isclose, isnan
 
-# pylint: disable=no-name-in-module,import-error
-from knack.log import get_logger
-
-from azure.cli.core.profiles import ResourceType
-
+from azure.cli.core import keys
+from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.core.commands.validators import validate_tag
 from azure.cli.core.util import CLIError
-from azure.cli.core.azclierror import InvalidArgumentValueError
-from azure.cli.core import keys
-
+# pylint: disable=no-name-in-module,import-error
+from knack.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -528,6 +528,56 @@ class AKSContext:
                     )
                 )
 
+    def __validate_cluster_autoscaler_profile(
+        self, cluster_autoscaler_profile: Union[List, Dict, None]
+    ) -> Union[Dict, None]:
+        """Helper function to parse and verify cluster_autoscaler_profile.
+
+        If the user input is a list, parse it with function "extract_comma_separated_string". If the type of user input
+        or parsed value is not a dictionary, raise an InvalidArgumentValueError. Otherwise, take the keys from the
+        attribute map of ManagedClusterPropertiesAutoScalerProfile to verify whether the keys in the key-value pairs
+        provided by the user are valid. If not, raise an InvalidArgumentValueError.
+
+        :return: dictionary or None
+        """
+        if cluster_autoscaler_profile is not None:
+            # convert list to dict
+            if isinstance(cluster_autoscaler_profile, list):
+                params_dict = {}
+                for item in cluster_autoscaler_profile:
+                    params_dict.update(
+                        extract_comma_separated_string(
+                            item,
+                            extract_kv=True,
+                            allow_empty_value=True,
+                            default_value={},
+                        )
+                    )
+                cluster_autoscaler_profile = params_dict
+            # check if the type is dict
+            if not isinstance(cluster_autoscaler_profile, dict):
+                raise InvalidArgumentValueError(
+                    "Unexpected input cluster-autoscaler-profile, value: '{}', type '{}'.".format(
+                        cluster_autoscaler_profile,
+                        type(cluster_autoscaler_profile),
+                    )
+                )
+            # verify keys
+            # pylint: disable=protected-access
+            valid_keys = list(
+                k.replace("_", "-") for k in self.models.ManagedClusterPropertiesAutoScalerProfile._attribute_map.keys()
+            )
+            for key in cluster_autoscaler_profile.keys():
+                if not key:
+                    raise InvalidArgumentValueError("Empty key specified for cluster-autoscaler-profile")
+                if key not in valid_keys:
+                    raise InvalidArgumentValueError(
+                        "'{}' is an invalid key for cluster-autoscaler-profile. Valid keys are {}.".format(
+                            key, ", ".join(valid_keys)
+                        )
+                    )
+        return cluster_autoscaler_profile
+
     def get_subscription_id(self):
         """Helper function to obtain the value of subscription_id.
 
@@ -4083,42 +4133,20 @@ class AKSContext:
     def _get_cluster_autoscaler_profile(self, read_only: bool = False) -> Union[Dict[str, str], None]:
         """Internal function to dynamically obtain the value of cluster_autoscaler_profile according to the context.
 
+        This function will call function "__validate_cluster_autoscaler_profile" to parse and verify the parameter
+        by default.
+
         In update mode, when cluster_autoscaler_profile is assigned and auto_scaler_profile in the `mc` object has also
         been set, dynamic completion will be triggerd. We will first make a copy of the original configuration
         (extract the dictionary from the ManagedClusterPropertiesAutoScalerProfile object), and then update the copied
         dictionary with the dictionary of new options.
 
-        This function will verify the parameter by default. If the user input is not empty, take the keys from the
-        attribute map of ManagedClusterPropertiesAutoScalerProfile to verify whether the keys in the key-value pairs
-        provided by the user are valid. If not, raise an InvalidArgumentValueError. The value of the raw parameter
-        should be a dictionary after being processed by the validator. If not, raise a CLIInternalError.
-
         :return: dictionary or None
         """
         # read the original value passed by the command
         cluster_autoscaler_profile = self.raw_param.get("cluster_autoscaler_profile")
-        # validate user input (replace function "_validate_cluster_autoscaler_key" in file "_validators.py")
-        if cluster_autoscaler_profile is not None:
-            if not isinstance(cluster_autoscaler_profile, dict):
-                raise CLIInternalError(
-                    "Unexpected input cluster-autoscaler-profile, value: '{}', type '{}'.".format(
-                        cluster_autoscaler_profile,
-                        type(cluster_autoscaler_profile),
-                    )
-                )
-            # pylint: disable=protected-access
-            valid_keys = list(
-                k.replace("_", "-") for k in self.models.ManagedClusterPropertiesAutoScalerProfile._attribute_map.keys()
-            )
-            for key in cluster_autoscaler_profile.keys():
-                if not key:
-                    raise InvalidArgumentValueError("Empty key specified for cluster-autoscaler-profile")
-                if key not in valid_keys:
-                    raise InvalidArgumentValueError(
-                        "'{}' is an invalid key for cluster-autoscaler-profile. Valid keys are {}.".format(
-                            key, ", ".join(valid_keys)
-                        )
-                    )
+        # parse and validate user input
+        cluster_autoscaler_profile = self.__validate_cluster_autoscaler_profile(cluster_autoscaler_profile)
 
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
         if self.decorator_mode == DecoratorMode.CREATE:
@@ -4147,15 +4175,13 @@ class AKSContext:
     def get_cluster_autoscaler_profile(self) -> Union[Dict[str, str], None]:
         """Dynamically obtain the value of cluster_autoscaler_profile according to the context.
 
+        This function will call function "__validate_cluster_autoscaler_profile" to parse and verify the parameter
+        by default.
+
         In update mode, when cluster_autoscaler_profile is assigned and auto_scaler_profile in the `mc` object has also
         been set, dynamic completion will be triggerd. We will first make a copy of the original configuration
         (extract the dictionary from the ManagedClusterPropertiesAutoScalerProfile object), and then update the copied
         dictionary with the dictionary of new options.
-
-        This function will verify the parameter by default. If the user input is not empty, take the keys from the
-        attribute map of ManagedClusterPropertiesAutoScalerProfile to verify whether the keys in the key-value pairs
-        provided by the user are valid. If not, raise an InvalidArgumentValueError. The value of the raw parameter
-        should be a dictionary after being processed by the validator. If not, raise a CLIInternalError.
 
         :return: dictionary or None
         """

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_validators.py
@@ -96,59 +96,6 @@ class TestValidateIPRanges(unittest.TestCase):
         self.assertEqual(str(cm.exception), err)
 
 
-class TestClusterAutoscalerParamsValidators(unittest.TestCase):
-    def setUp(self):
-        self.cli = MockCLI()
-
-    def test_empty_key_empty_value(self):
-        cluster_autoscaler_profile = ["="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_non_empty_key_empty_value(self):
-        cluster_autoscaler_profile = ["scan-interval="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-
-        validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-
-    def test_two_empty_keys_empty_value(self):
-        cluster_autoscaler_profile = ["=", "="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_one_empty_key_in_pair_one_non_empty(self):
-        cluster_autoscaler_profile = ["scan-interval=20s", "="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_invalid_key(self):
-        cluster_autoscaler_profile = ["bad-key=val"]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "'bad-key' is an invalid key for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertIn(err, str(cm.exception),)
-
-    def test_valid_parameters(self):
-        cluster_autoscaler_profile = ["scan-interval=20s", "scale-down-delay-after-add=15m"]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-
-        validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-
-
 class Namespace:
     def __init__(self, api_server_authorized_ip_ranges=None, cluster_autoscaler_profile=None):
         self.api_server_authorized_ip_ranges = api_server_authorized_ip_ranges

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -479,6 +479,18 @@ class AKSContextTestCase(unittest.TestCase):
         g8 = {"scan-interval": "20s", "scale-down-delay-after-add": "15m"}
         self.assertEqual(t8, g8)
 
+        # two pairs of empty key & empty value
+        s9 = ["=", "="]
+        # fail on empty key
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx._AKSContext__validate_cluster_autoscaler_profile(s9)
+
+        # additional empty key & empty value
+        s10 = ["scan-interval=20s", "="]
+        # fail on empty key
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx._AKSContext__validate_cluster_autoscaler_profile(s10)
+
     def test_get_subscription_id(self):
         ctx_1 = AKSContext(
             self.cmd, {}, self.models, decorator_mode=DecoratorMode.CREATE

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -97,59 +97,6 @@ class TestValidateIPRanges(unittest.TestCase):
         self.assertEqual(str(cm.exception), err)
 
 
-class TestClusterAutoscalerParamsValidators(unittest.TestCase):
-    def setUp(self):
-        self.cli = MockCLI()
-
-    def test_empty_key_empty_value(self):
-        cluster_autoscaler_profile = ["="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_non_empty_key_empty_value(self):
-        cluster_autoscaler_profile = ["scan-interval="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-
-        validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-
-    def test_two_empty_keys_empty_value(self):
-        cluster_autoscaler_profile = ["=", "="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_one_empty_key_in_pair_one_non_empty(self):
-        cluster_autoscaler_profile = ["scan-interval=20s", "="]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "Empty key specified for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertEqual(str(cm.exception), err)
-
-    def test_invalid_key(self):
-        cluster_autoscaler_profile = ["bad-key=val"]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-        err = "'bad-key' is an invalid key for cluster-autoscaler-profile"
-
-        with self.assertRaises(CLIError) as cm:
-            validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-        self.assertIn(err, str(cm.exception),)
-
-    def test_valid_parameters(self):
-        cluster_autoscaler_profile = ["scan-interval=20s", "scale-down-delay-after-add=15m"]
-        namespace = Namespace(cluster_autoscaler_profile=cluster_autoscaler_profile)
-
-        validators.validate_cluster_autoscaler_profile(MockCmd(self.cli), namespace)
-
-
 class Namespace:
     def __init__(self, api_server_authorized_ip_ranges=None, cluster_autoscaler_profile=None):
         self.api_server_authorized_ip_ranges = api_server_authorized_ip_ranges

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -346,29 +346,29 @@ class TestAssignIdentity(unittest.TestCase):
 
 class TestExtractCommaSeparatedString(unittest.TestCase):
     def test_extract_comma_separated_string(self):
-        s1 = "abc, xyz, 123"
-        t1 = validators.extract_comma_separated_string(s1)
-        g1 = ["abc", " xyz", " 123"]
+        s1 = None
+        t1 = validators.extract_comma_separated_string(s1, keep_none=True, default_value="")
+        g1 = None
         self.assertEqual(t1, g1)
 
-        s2 = "abc, xyz, 123"
-        t2 = validators.extract_comma_separated_string(s2, enable_strip=True)
-        g2 = ["abc", "xyz", "123"]
+        s2 = None
+        t2 = validators.extract_comma_separated_string(s2, keep_none=False, default_value="")
+        g2 = ""
         self.assertEqual(t2, g2)
 
-        s3 = None
-        t3 = validators.extract_comma_separated_string(s3, keep_none=True, default_value="")
-        g3 = None
+        s3 = ""
+        t3 = validators.extract_comma_separated_string(s3, keep_none=True, default_value={})
+        g3 = {}
         self.assertEqual(t3, g3)
 
-        s4 = None
-        t4 = validators.extract_comma_separated_string(s4, keep_none=False, default_value="")
-        g4 = ""
+        s4 = "abc, xyz, 123"
+        t4 = validators.extract_comma_separated_string(s4)
+        g4 = ["abc", " xyz", " 123"]
         self.assertEqual(t4, g4)
 
-        s5 = ""
-        t5 = validators.extract_comma_separated_string(s5, keep_none=True, default_value={})
-        g5 = {}
+        s5 = "abc, xyz, 123"
+        t5 = validators.extract_comma_separated_string(s5, enable_strip=True)
+        g5 = ["abc", "xyz", "123"]
         self.assertEqual(t5, g5)
 
         s6 = "abc = def, xyz = 123"
@@ -381,26 +381,34 @@ class TestExtractCommaSeparatedString(unittest.TestCase):
         g7 = {"abc": "def", "xyz": "123"}
         self.assertEqual(t7, g7)
 
-        s8 = "abc = def, xyz = 123"
-        t8 = validators.extract_comma_separated_string(s8, extract_kv=True, key_only=True)
-        g8 = {"abc ": "", " xyz ": ""}
+        s8 = "abc = def, xyz = "
+        t8 = validators.extract_comma_separated_string(s8, extract_kv=True, allow_empty_value=True)
+        g8 = {"abc ": " def", " xyz ": " "}
         self.assertEqual(t8, g8)
 
-        s9 = "abc = def, xyz = 123"
-        t9 = validators.extract_comma_separated_string(s9, enable_strip=True, extract_kv=True, key_only=True)
-        g9 = {"abc": "", "xyz": ""}
+        s9 = "abc = def, xyz = "
+        t9 = validators.extract_comma_separated_string(s9, enable_strip=True, extract_kv=True, allow_empty_value=True)
+        g9 = {"abc": "def", "xyz": ""}
         self.assertEqual(t9, g9)
 
-        s10 = "abc def, xyz 123"
-        t10 = validators.extract_comma_separated_string(s10, enable_strip=True, extract_kv=True, key_only=True)
-        g10 = {"abc def": "", "xyz 123": ""}
-        self.assertEqual(t10, g10)
+        s10 = "abc = def, xyz = "
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.extract_comma_separated_string(s10, extract_kv=True)
 
         s11 = "abc def, xyz 123"
         with self.assertRaises(InvalidArgumentValueError):
-            validators.extract_comma_separated_string(s11, enable_strip=True, extract_kv=True)
+            validators.extract_comma_separated_string(s11, extract_kv=True)
 
-        s12 = "WindowsContainerRuntime=containerd,AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview"
-        t12 = validators.extract_comma_separated_string(s12, enable_strip=True, extract_kv=True, default_value={},)
-        g12 = {"WindowsContainerRuntime": "containerd", "AKSHTTPCustomFeatures": "Microsoft.ContainerService/CustomNodeConfigPreview"}
-        self.assertEqual(t12, g12)
+        s12 = "abc=def=xyz,123=456"
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.extract_comma_separated_string(s12, extract_kv=True)
+
+        s13 = "WindowsContainerRuntime=containerd,AKSHTTPCustomFeatures=Microsoft.ContainerService/CustomNodeConfigPreview"
+        t13 = validators.extract_comma_separated_string(s13, enable_strip=True, extract_kv=True, default_value={},)
+        g13 = {"WindowsContainerRuntime": "containerd", "AKSHTTPCustomFeatures": "Microsoft.ContainerService/CustomNodeConfigPreview"}
+        self.assertEqual(t13, g13)
+
+        s14 = "="
+        t14 = validators.extract_comma_separated_string(s14, extract_kv=True, allow_empty_value=True)
+        g14 = {"": ""}
+        self.assertEqual(t14, g14)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Update validator for cluster auto-scaler profile.
- Move the validator for cluster auto-scaler profile from `_validator.py` to `decorator.py`.
- In the validation of the option `--cluster-autoscaler-profile`, the corresponding api model (`ManagedClusterPropertiesAutoScalerProfile`) needs to be loaded, and loading the model in file `_validator.py` requires hard-coding the api version or changing the function signature; if it is placed in file `decorator.py` for validation, no additional changes are required, and this would help us to reuse this part directly in azure-cli-extensions/aks-preview.
- The option `--cluster-autoscaler-profile` is only available in `aks create` and `aks update`, and now the implementation of these two commands are switched to decorator pattern.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
