### PR TITLE
{Core} Introduce `BinaryCache` for MSAL HTTP cache

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
+++ b/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
@@ -1,3 +1,8 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
 import collections.abc as collections
 import pickle
 

--- a/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
+++ b/src/azure-cli-core/azure/cli/core/auth/binary_cache.py
@@ -1,0 +1,79 @@
+import collections.abc as collections
+import pickle
+
+from azure.cli.core.decorators import retry
+from knack.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class BinaryCache(collections.MutableMapping):
+    """
+    Derived from azure.cli.core._session.Session.
+    A simple dict-like class that is backed by a binary file.
+
+    All direct modifications with `__setitem__` and `__delitem__` will save the file.
+    Indirect modifications should be followed by a call to `save`.
+    """
+
+    def __init__(self, file_name):
+        super().__init__()
+        self.filename = file_name
+        self.data = {}
+        self.load()
+
+    @retry()
+    def _load(self):
+        """Load cache with retry. If it still fails at last, raise the original exception as-is."""
+        try:
+            with open(self.filename, 'rb') as f:
+                return pickle.load(f)
+        except FileNotFoundError:
+            # The cache file has not been created. This is expected. No need to retry.
+            logger.debug("%s not found. Using a fresh one.", self.filename)
+            return {}
+
+    def load(self):
+        logger.debug("load: %s", self.filename)
+        try:
+            self.data = self._load()
+        except (pickle.UnpicklingError, EOFError) as ex:
+            # We still get exception after retry:
+            # - pickle.UnpicklingError is caused by corrupted cache file, perhaps due to concurrent writes.
+            # - EOFError is caused by empty cache file created by other az instance, but hasn't been filled yet.
+            logger.debug("Failed to load cache: %s. Using a fresh one.", ex)
+            self.data = {}  # Ignore a non-existing or corrupted http_cache
+
+    @retry()
+    def _save(self):
+        with open(self.filename, 'wb') as f:
+            # At this point, an empty cache file will be created. Loading this cache file will
+            # raise EOFError. This can be simulated by adding time.sleep(30) here.
+            # So during loading, EOFError is ignored.
+            pickle.dump(self.data, f)
+
+    def save(self):
+        logger.debug("save: %s", self.filename)
+        # If 2 processes write at the same time, the cache will be corrupted,
+        # but that is fine. Subsequent runs would reach eventual consistency.
+        self._save()
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+        self.save()
+
+    def __delitem__(self, key):
+        del self.data[key]
+        self.save()
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __len__(self):
+        return len(self.data)

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -5,7 +5,6 @@
 
 import json
 import os
-import pickle
 import re
 
 from azure.cli.core._environment import get_config_dir

--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -9,11 +9,10 @@ import pickle
 import re
 
 from azure.cli.core._environment import get_config_dir
-from azure.cli.core.decorators import retry
-from msal import PublicClientApplication
-
 from knack.log import get_logger
 from knack.util import CLIError
+from msal import PublicClientApplication
+
 # Service principal entry properties
 from .msal_authentication import _CLIENT_ID, _TENANT, _CLIENT_SECRET, _CERTIFICATE, _CLIENT_ASSERTION, \
     _USE_CERT_SN_ISSUER
@@ -69,7 +68,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         config_dir = get_config_dir()
         self._token_cache_file = os.path.join(config_dir, "msal_token_cache")
         self._secret_file = os.path.join(config_dir, "service_principal_entries")
-        self._http_cache_file = os.path.join(config_dir, "msal_http_cache.bin")
+        self._msal_http_cache_file = os.path.join(config_dir, "msal_http_cache.bin")
 
         # We make _msal_app_instance an instance attribute, instead of a class attribute,
         # because MSAL apps can have different tenant IDs.
@@ -106,45 +105,10 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         cache = load_persisted_token_cache(self._token_cache_file, self._encrypt)
         return cache
 
-    @retry()
-    def __load_msal_http_cache(self):
-        """Load MSAL HTTP cache with retry. If it still fails at last, raise the original exception as-is."""
-        logger.debug("__load_msal_http_cache: %s", self._http_cache_file)
-        try:
-            with open(self._http_cache_file, 'rb') as f:
-                return pickle.load(f)
-        except FileNotFoundError:
-            # The cache file has not been created. This is expected.
-            logger.debug("%s not found. Using a fresh one.", self._http_cache_file)
-            return {}
-
-    def _dump_msal_http_cache(self):
-        logger.debug("_dump_msal_http_cache: %s", self._http_cache_file)
-        with open(self._http_cache_file, 'wb') as f:
-            # At this point, an empty cache file will be created. Loading this cache file will
-            # trigger EOFError. This can be simulated by adding time.sleep(30) here.
-            # So, during loading, EOFError is ignored.
-            pickle.dump(self._msal_http_cache, f)
-
     def _load_msal_http_cache(self):
-        import atexit
-
-        logger.debug("_load_msal_http_cache: %s", self._http_cache_file)
-        try:
-            persisted_http_cache = self.__load_msal_http_cache()
-        except (pickle.UnpicklingError, EOFError) as ex:
-            # We still get exception after retry:
-            # - pickle.UnpicklingError is caused by corrupted cache file, perhaps due to concurrent writes.
-            # - EOFError is caused by empty cache file created by other az instance, but hasn't been filled yet.
-            logger.debug("Failed to load MSAL HTTP cache: %s. Using a fresh one.", ex)
-            persisted_http_cache = {}  # Ignore a non-exist or corrupted http_cache
-
-        # When exiting, flush it back to the file.
-        # If 2 processes write at the same time, the cache will be corrupted,
-        # but that is fine. Subsequent runs would reach eventual consistency.
-        atexit.register(self._dump_msal_http_cache)
-
-        return persisted_http_cache
+        from .binary_cache import BinaryCache
+        http_cache = BinaryCache(self._msal_http_cache_file)
+        return http_cache
 
     @property
     def _service_principal_store(self):


### PR DESCRIPTION
**Description**<!--Mandatory-->

A refinement to https://github.com/Azure/azure-cli/pull/20722.

Instead of dumping MSAL HTTP cache to a file **every time Azure CLI exits**, MSAL HTTP cache is dumped to a file **only when the cache content is changed**. 

This significantly **reduces the number of disk write operations**, thus reduces the possibility of encountering a corrupted HTTP cache file (`pickle.UnpicklingError`, `EOFError`).

But, the limitation is that this solution only works when MSAL updates the HTTP cache with `__setitem__`. If MSAL directly edits the content of cache items, the operation will slip under `BinaryCache`'s radar.
