### PR TITLE
[App Config] BREAKING CHANGE: Support app service slots

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1,4 +1,4 @@
-# --------------------------------------------------------------------------------------------
+
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
@@ -404,8 +404,9 @@ def __read_kv_from_app_service(cmd, appservice_account, prefix_to_add="", conten
     try:
         key_values = []
         from azure.cli.command_modules.appservice.custom import get_app_settings
+        slot = appservice_account.get('resource_name') if appservice_account.get('resource_type') == 'slots' else None
         settings = get_app_settings(
-            cmd, resource_group_name=appservice_account["resource_group"], name=appservice_account["name"], slot=None)
+            cmd, resource_group_name=appservice_account["resource_group"], name=appservice_account["name"], slot=slot)
         for item in settings:
             key = prefix_to_add + item['name']
             if validate_import_key(key):
@@ -485,9 +486,10 @@ def __write_kv_to_app_service(cmd, key_values, appservice_account):
             else:
                 non_slot_settings.append(name + '=' + value)
         # known issue 4/26: with in-place update, AppService could change slot-setting true/false incorrectly
+        slot = appservice_account.get('resource_name') if appservice_account.get('resource_type') == 'slots' else None
         from azure.cli.command_modules.appservice.custom import update_app_settings
         update_app_settings(cmd, resource_group_name=appservice_account["resource_group"],
-                            name=appservice_account["name"], settings=non_slot_settings, slot_settings=slot_settings)
+                            name=appservice_account["name"], settings=non_slot_settings, slot_settings=slot_settings, slot=slot)
     except Exception as exception:
         raise CLIError("Failed to write key-values to appservice: " + str(exception))
 

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1,4 +1,4 @@
-
+# --------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------

--- a/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/tests/latest/test_appconfig_commands.py
@@ -760,8 +760,13 @@ class AppConfigAppServiceImportExportLiveScenarioTest(LiveScenarioTest):
         # Create AppService plan and webapp
         webapp_name = self.create_random_name(prefix='WebApp', length=24)
         plan = self.create_random_name(prefix='Plan', length=24)
-        self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
+        # Require a standard sku to allow for deployment slots
+        self.cmd('appservice plan create -g {} -n {} --sku S1'.format(resource_group, plan))
         self.cmd('webapp create -g {} -n {} -p {}'.format(resource_group, webapp_name, plan))
+
+        # Create deployment slot
+        slot = self.create_random_name(prefix='Slot', length=24)
+        self.cmd('webapp deployment slot create -g {} -n {} -s {}'.format(resource_group, webapp_name, slot))
 
         # KeyVault reference tests
         keyvault_key = "HostSecrets"
@@ -795,6 +800,14 @@ class AppConfigAppServiceImportExportLiveScenarioTest(LiveScenarioTest):
         self.assertEqual(exported_keys['value'], appsvc_keyvault_value)
         self.assertEqual(exported_keys['slotSetting'], False)
 
+        self.kwargs.update({
+            'slot': slot
+        })
+
+        # Verify that the slot configuration was not updated
+        app_settings = self.cmd('webapp config appsettings list -g {rg} -n {appservice_account} -s {slot}').get_output_in_json()
+        assert not any(True for elem in app_settings if elem['name'] == keyvault_key)
+
         # Import KeyVault ref from AppService
         updated_label = 'ImportedFromAppService'
         self.kwargs.update({
@@ -806,6 +819,59 @@ class AppConfigAppServiceImportExportLiveScenarioTest(LiveScenarioTest):
                  checks=[self.check('[0].contentType', KeyVaultConstants.KEYVAULT_CONTENT_TYPE),
                          self.check('[0].key', keyvault_key),
                          self.check('[0].value', appconfig_keyvault_value),
+                         self.check('[0].label', updated_label)])
+
+        # Get the slot ID
+        slot_list = self.cmd('az webapp deployment slot list -g {rg} -n {appservice_account}').get_output_in_json()
+        assert slot_list and len(slot_list) == 1
+        slot_id = slot_list[0]['id']
+
+        # Update keyvault reference for slot export / import testing
+        slot_keyvault_id = "https://fake.vault.azure.net/secrets/slotsecret"
+        appconfigslot_keyvault_value = "{{\"uri\":\"https://fake.vault.azure.net/secrets/slotsecret\"}}"
+        appsvcslot_keyvault_value = "@Microsoft.KeyVault(SecretUri=https://fake.vault.azure.net/secrets/slotsecret)"
+        label = 'ForExportToAppServiceSlot'
+        self.kwargs.update({
+            'label': label,
+            'secret_identifier': slot_keyvault_id,
+            'slot_id': slot_id
+        })
+
+        # Add new KeyVault ref in AppConfig for the slot
+        self.cmd('appconfig kv set-keyvault --connection-string {connection_string} --key {key} --secret-identifier {secret_identifier} --label {label} -y',
+                 checks=[self.check('contentType', KeyVaultConstants.KEYVAULT_CONTENT_TYPE),
+                         self.check('key', keyvault_key),
+                         self.check('label', label),
+                         self.check('value', appconfigslot_keyvault_value)])
+
+        # Export KeyVault ref to AppService
+        self.cmd('appconfig kv export --connection-string {connection_string} -d {export_dest} --appservice-account {slot_id} --label {label} -y')
+
+        # Verify that the webapp configuration was not updated
+        app_settings = self.cmd('webapp config appsettings list -g {rg} -n {appservice_account}').get_output_in_json()
+        exported_keys = next(x for x in app_settings if x['name'] == keyvault_key)
+        self.assertEqual(exported_keys['name'], keyvault_key)
+        self.assertEqual(exported_keys['value'], appsvc_keyvault_value)
+        self.assertEqual(exported_keys['slotSetting'], False)
+
+        # Verify that the slot configuration was updated
+        app_settings = self.cmd('webapp config appsettings list -g {rg} -n {appservice_account} -s {slot}').get_output_in_json()
+        exported_keys = next(x for x in app_settings if x['name'] == keyvault_key)
+        self.assertEqual(exported_keys['name'], keyvault_key)
+        self.assertEqual(exported_keys['value'], appsvcslot_keyvault_value)
+        self.assertEqual(exported_keys['slotSetting'], False)
+
+        # Import KeyVault ref from AppService slot
+        updated_label = 'ImportedFromAppServiceSlot'
+        self.kwargs.update({
+            'label': updated_label
+        })
+        self.cmd('appconfig kv import --connection-string {connection_string} -s {export_dest} --appservice-account {slot_id} --label {label} -y')
+
+        self.cmd('appconfig kv list --connection-string {connection_string} --label {label}',
+                 checks=[self.check('[0].contentType', KeyVaultConstants.KEYVAULT_CONTENT_TYPE),
+                         self.check('[0].key', keyvault_key),
+                         self.check('[0].value', appconfigslot_keyvault_value),
                          self.check('[0].label', updated_label)])
 
         # Add keyvault ref to appservice in alt format and import to appconfig


### PR DESCRIPTION
**Description**
When importing or exporting an app configuration and the destination is an app service, the normal functionality is to use the production slot even when a non-production slot is provided as the app service ID. This change will use the provided slot to import / export instead of production. This has been marked as a breaking change since it will react differently than before if given the app service ID for a slot.

**Testing Guide**

**History Notes**


