### PR TITLE
[Packaging] Add SHA256 digest for RPM

### DIFF
--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -5,6 +5,10 @@
 # Turn off python byte compilation
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
+# Enforces SHA-256 in file digests
+%global _binary_filedigest_algorithm 8
+%global _source_filedigest_algorithm 8
+
 # .el7.centos -> .el7
 %if 0%{?rhel}
   %define dist .el%{?rhel}


### PR DESCRIPTION
**Description**
This pull request allows for RPM packages to be signed with SHA256 digests given that #11325 reverted CentOS8 changes that would've negated this request. This should address #20719 and unblock installation on Red Hat Enterprise Linux (RHEL) 8 systems. 

**Testing Guide**
On RHEL 8.4 systems, when the `azure-cli` is installed via Yum/RPM the current behavior without this change results in the following output: 
```
# rpm --checksig --verbose azure-cli-2.31.0-1.el7.x86_64.rpm
azure-cli-2.31.0-1.el7.x86_64.rpm:
    Header V4 RSA/SHA256 Signature, key ID be1229cf: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: NOTFOUND
    V4 RSA/SHA256 Signature, key ID be1229cf: OK
    MD5 digest: NOTFOUND
```

**External References**
* https://www.starlab.io/blog/adding-sha256-digests-to-rpms
* https://fedoraproject.org/wiki/Hash_algorithm_migration_status#rpm

**History Notes**
[Packaging] Add SHA256 digest for RPM: Ensure that all RPMs include SHA256 digest to enable installation on operating systems that do not accept SHA1 checksums