### PR TITLE
{Storage} Updated the usage of az storage container restore

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1424,14 +1424,10 @@ type: command
 short-summary: Restore soft-deleted container.
 long-summary:  Operation will only be successful if used within the specified number of days set in the delete retention policy.
 examples:
-  - name: Restore soft-deleted container.
-    text: az storage container restore -n deletedcontainer --deleted-version deletedversion
-    
-> [!NOTE]
-> Deleted containers have versions associated with them since you can delete and recreate the container with the same name, multiple times. 
-> The “deletedversion” in the above command, refers to the version of the container which is deleted, that you want to restore. 
-> You can fetch the version available through the az storage container list command when used with the --include-deleted parameter.
-
+  - name: List and restore soft-deleted container.
+    text: |
+          az storage container list --include-deleted
+          az storage container restore -n deletedcontainer --deleted-version deletedversion
 """
 
 helps['storage copy'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -1426,6 +1426,12 @@ long-summary:  Operation will only be successful if used within the specified nu
 examples:
   - name: Restore soft-deleted container.
     text: az storage container restore -n deletedcontainer --deleted-version deletedversion
+    
+> [!NOTE]
+> Deleted containers have versions associated with them since you can delete and recreate the container with the same name, multiple times. 
+> The “deletedversion” in the above command, refers to the version of the container which is deleted, that you want to restore. 
+> You can fetch the version available through the az storage container list command when used with the --include-deleted parameter.
+
 """
 
 helps['storage copy'] = """


### PR DESCRIPTION
--deleted-version parameter is mandatory to input in the az storage container restore command, Multiple users were unaware on how to fetch the --deleted-version parameter and there was a confusion if this parameter was related to Blob Versioning. The Deleted Version number is also not visible when you look up the soft deleted container --> properties in azure portal, nor is it present in the response body when initial Delete container API is called.

Suggested these changes to ease the usage of container restore command via Az cli for end users.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
