### PR TITLE
{Packaging} Bump `psutil` to 5.9.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -64,7 +64,7 @@ DEPENDENCIES = [
 
 # dependencies for specific OSes
 if not sys.platform.startswith('cygwin'):
-    DEPENDENCIES.append('psutil~=5.8')
+    DEPENDENCIES.append('psutil~=5.9')
 
 
 with open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -118,7 +118,7 @@ packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==2.3.2
-psutil==5.8.0
+psutil==5.9.0
 pycparser==2.19
 PyGithub==1.55
 PyJWT==2.1.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -119,7 +119,7 @@ packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==2.3.2
-psutil==5.8.0
+psutil==5.9.0
 pycparser==2.19
 PyGithub==1.55
 PyJWT==2.1.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -118,7 +118,7 @@ packaging==21.3
 paramiko==2.6.0
 pbr==5.3.1
 portalocker==2.3.2
-psutil==5.8.0
+psutil==5.9.0
 pycparser==2.19
 PyGithub==1.55
 PyJWT==2.1.0


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/pull/20195#issuecomment-979676353

When installing with `pip install azure-cli`, installing `psutil` 5.8.0 fails without Microsoft Visual C++:

```
  ERROR: Command errored out with exit status 1:
   command: 'D:\test-envs\test310\Scripts\python.exe' -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\username\\AppData\\Local\\Temp\\pip-install-ds9qtdad\\psutil_edc519ddccee4418ba33c3e0ff32ce49\\setup.py'"'"'; __file__='"'"'C:\\Users\\username\\AppData\\Local\\Temp\\pip-install-ds9qtdad\\psutil_edc519ddccee4418ba33c3e0ff32ce49\\setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d 'C:\Users\username\AppData\Local\Temp\pip-wheel-2caa_k7a'
       cwd: C:\Users\username\AppData\Local\Temp\pip-install-ds9qtdad\psutil_edc519ddccee4418ba33c3e0ff32ce49\
  Complete output (38 lines):
  ...
  copying psutil\tests\__main__.py -> build\lib.win-amd64-3.10\psutil\tests
  running build_ext
  building 'psutil._psutil_windows' extension
  error: Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft C++ Build Tools": https://visualstudio.microsoft.com/visual-cpp-build-tools/
  ----------------------------------------
  ERROR: Failed building wheel for psutil
  Running setup.py clean for psutil
```

This was fixed by

- https://github.com/giampaolo/psutil/pull/2015

and released in 5.9.0.