### PR TITLE
{CI} Drop Python 3.6 tests

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -20,8 +20,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -40,8 +38,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -60,8 +56,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -71,39 +65,6 @@ jobs:
       parameters:
         pythonVersion: '$(python.version)'
         profile: '2018-03-01-hybrid'
-        fullTest: true
-
-- job: AutomationFullTestPython36ProfileLatest
-  displayName: Automation Full Test Python36 Profile Latest
-  timeoutInMinutes: 9999
-  strategy:
-    maxParallel: 8
-    matrix:
-      instance1:
-        Instance_idx: 1
-      instance2:
-        Instance_idx: 2
-      instance3:
-        Instance_idx: 3
-      instance4:
-        Instance_idx: 4
-      instance5:
-        Instance_idx: 5
-      instance6:
-        Instance_idx: 6
-      instance7:
-        Instance_idx: 7
-      instance8:
-        Instance_idx: 8
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-    - template: .azure-pipelines/templates/automation_test.yml
-      parameters:
-        pythonVersion: '3.6'
-        profile: 'latest'
-        instance_cnt: '8'
-        instance_idx: '$(Instance_idx)'
         fullTest: true
 
 - job: AutomationFullTestPython39ProfileLatest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -375,12 +375,6 @@ jobs:
        CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
        PYPI_FILES=$(cd $BUILD_ARTIFACTSTAGINGDIRECTORY/pypi; pwd)
 
-
-       echo "== Testing pip install on Python 3.6 =="
-       docker run \
-         --rm -v $PYPI_FILES:/mnt/pypi python:3.6 \
-         /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
-
        echo "== Testing pip install on Python 3.7 =="
        docker run \
          --rm -v $PYPI_FILES:/mnt/pypi python:3.7 \
@@ -405,8 +399,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -424,8 +416,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -446,8 +436,6 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:
@@ -871,8 +859,6 @@ jobs:
   displayName: "PerformanceCheck"
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python39:
         python.version: '3.9'
       Python310:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Python 3.6 has been deprecated (https://github.com/Azure/azure-cli/issues/19858), so we should drop Python 3.6 tests.

However, this PR can't be merged immediately yet since CentOS 7 only has deprecated Python 3.6 available (https://github.com/Azure/azure-cli/issues/19858#issuecomment-1002842707). 

Update: CentOS 7 RPM will be dropped by https://github.com/Azure/azure-cli/pull/23047