### PR TITLE
{Core} Fix `_normalize_expires_on` on Python 3.6

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
@@ -96,7 +96,7 @@ def _normalize_expires_on(expires_on):
         # Python 3.6 doesn't recognize timezone as +00:00.
         # These lines can be dropped after Python 3.6 is dropped.
         # https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon
-        if ":" == expires_on[-3]:
+        if expires_on[-3] == ":":
             expires_on = expires_on[:-3] + expires_on[-2:]
 
         # Treat as datetime string "11/05/2021 15:18:31 +00:00"

--- a/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
@@ -92,6 +92,13 @@ def _normalize_expires_on(expires_on):
         expires_on_epoch_int = int(expires_on)
     except ValueError:
         import datetime
+
+        # Python 3.6 doesn't recognize timezone as +00:00.
+        # These lines can be dropped after Python 3.6 is dropped.
+        # https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon
+        if ":" == expires_on[-3]:
+            expires_on = expires_on[:-3] + expires_on[-2:]
+
         # Treat as datetime string "11/05/2021 15:18:31 +00:00"
         expires_on_epoch_int = int(datetime.datetime.strptime(expires_on, '%m/%d/%Y %H:%M:%S %z').timestamp())
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/pull/20215#issuecomment-1002446176

Python 3.6 doesn't recognize timezone `%z` as `+00:00`. It only recognizes `+0000`:

```py
> docker run -it --rm python:3.6

>>> import datetime
>>> datetime.datetime.strptime('12/30/2021 07:53:52 +00:00', '%m/%d/%Y %H:%M:%S %z')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data '12/30/2021 07:53:52 +00:00' does not match format '%m/%d/%Y %H:%M:%S %z'

>>> datetime.datetime.strptime('12/30/2021 07:53:52 +0000', '%m/%d/%Y %H:%M:%S %z')
datetime.datetime(2021, 12, 30, 7, 53, 52, tzinfo=datetime.timezone.utc)
```

which means `az login --identity` with managed identity in App Service container still doesn't work with DEB, RPM packages, etc.

https://docs.python.org/3/library/datetime.html#technical-detail

> Changed in version 3.7: When the %z directive is provided to the strptime() method, the UTC offsets can have a colon as a separator between hours, minutes and seconds. For example, '+01:00:00' will be parsed as an offset of one hour. In addition, providing 'Z' is identical to '+00:00'.

There is indeed a test `azure.cli.core.auth.tests.test_adal_authentication.TestUtil.test_normalize_expires_on` to verify this:

https://github.com/Azure/azure-cli/blob/af483f52df81f6b14932272e11b84d90d23460d5/src/azure-cli-core/azure/cli/core/auth/tests/test_adal_authentication.py#L13-L14

However, the test is not executed by CI for Python 3.6 due to `azdev` issue

- https://github.com/Azure/azure-cli-dev-tools/issues/318 