### PR TITLE
{Keyvault} Pin `azure-keyvault-keys==4.5.0b4`

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -60,7 +60,7 @@ DEPENDENCIES = [
     'azure-graphrbac~=0.60.0',
     'azure-identity',
     'azure-keyvault-administration==4.0.0b3',
-    'azure-keyvault-keys~=4.5.0b4',
+    'azure-keyvault-keys==4.5.0b4',
     'azure-keyvault~=1.1.0',
     'azure-loganalytics~=0.1.0',
     'azure-mgmt-advisor==9.0.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/issues/20856

`azure-keyvault-keys==4.5.0b5` made a breaking change for authentication:

- https://github.com/Azure/azure-sdk-for-python/pull/21290

It uses `azure-identity`'s new multi-tenant authentication API `get_token(tenant_id=...)` from

- https://github.com/Azure/azure-sdk-for-python/pull/20940

However, Azure CLI has its own multi-tenant authentication implementation using `CredentialAdaptor.get_auxiliary_tokens`:

- #19853

therefore not compatible with `azure-identity`'s implementation. 

This leads to failure as described in #20856.