### PR TITLE
[App Service] BREAKING CHANGE : `az webapp up` : Remove default argument loading for `--plan`; Fix bug when not providing `--plan` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_create_util.py
@@ -380,11 +380,11 @@ def detect_os_form_src(src_dir, html=False):
         or language.lower() == PYTHON_RUNTIME_NAME else OS_DEFAULT
 
 
-def get_plan_to_use(cmd, user, loc, sku, create_rg, resource_group_name, plan=None):
+def get_plan_to_use(cmd, user, loc, sku, create_rg, resource_group_name, is_linux=False, plan=None):
     _default_asp = _get_default_plan_name(user)
     if plan is None:  # --plan not provided by user
         # get the plan name to use
-        return _determine_if_default_plan_to_use(cmd, _default_asp, resource_group_name, loc, sku, create_rg)
+        return _determine_if_default_plan_to_use(cmd, _default_asp, resource_group_name, loc, sku, create_rg, is_linux)
     return plan
 
 
@@ -402,7 +402,7 @@ def get_current_stack_from_runtime(runtime):
 
 
 # if plan name not provided we need to get a plan name based on the OS, location & SKU
-def _determine_if_default_plan_to_use(cmd, plan_name, resource_group_name, loc, sku, create_rg):
+def _determine_if_default_plan_to_use(cmd, plan_name, resource_group_name, loc, sku, create_rg, is_linux):
     client = web_client_factory(cmd.cli_ctx)
     if create_rg:  # if new RG needs to be created use the default name
         return plan_name
@@ -416,7 +416,8 @@ def _determine_if_default_plan_to_use(cmd, plan_name, resource_group_name, loc, 
         # check if we have at least one app that can be used with the combination of loc, sku & os
         selected_asp = next((a for a in _asp_list if isinstance(a.sku, SkuDescription) and
                              a.sku.name.lower() == sku.lower() and
-                             (a.location.replace(" ", "").lower() == loc.lower())), None)
+                             (a.location.replace(" ", "").lower() == loc.lower()) and
+                             a.reserved == is_linux), None)
         if selected_asp is not None:
             return selected_asp.name
         # from the sorted data pick the last one & check if a new ASP needs to be created

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -615,10 +615,9 @@ def load_arguments(self, _):
                    local_context_attribute=LocalContextAttribute(name='web_name', actions=[LocalContextAction.GET,
                                                                                            LocalContextAction.SET],
                                                                  scopes=['webapp', 'cupertino']))
-        c.argument('plan', options_list=['--plan', '-p'], configured_default='appserviceplan',
+        c.argument('plan', options_list=['--plan', '-p'],
                    completer=get_resource_name_completion_list('Microsoft.Web/serverFarms'),
-                   help="name of the appserviceplan associated with the webapp",
-                   local_context_attribute=LocalContextAttribute(name='plan_name', actions=[LocalContextAction.GET]))
+                   help="name of the app service plan associated with the webapp")
         c.argument('sku', arg_type=sku_arg_type)
         c.argument('os_type', options_list=['--os-type'], arg_type=get_enum_type(OS_TYPES), help="Set the OS type for the app to be created.")
         c.argument('runtime', options_list=['--runtime', '-r'], help="canonicalized web runtime in the format of Framework|Version, e.g. \"PHP|7.2\". Allowed delimiters: \"|\" or \":\". "

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -67,20 +67,23 @@ def _polish_bad_errors(ex, creating_plan):
     import json
     from knack.util import CLIError
     try:
-        if 'text/plain' in ex.response.headers['Content-Type']:  # HTML Response
-            detail = ex.response.text
+        if hasattr(ex, "response"):
+            if 'text/plain' in ex.response.headers['Content-Type']:  # HTML Response
+                detail = ex.response.text
+            else:
+                detail = json.loads(ex.response.text())['Message']
+                if creating_plan:
+                    if 'Requested features are not supported in region' in detail:
+                        detail = ("Plan with requested features is not supported in current region. \n"
+                                    "If creating an App Service Plan with --zone-redundant/-z, "
+                                    "please see supported regions here: "
+                                    "https://docs.microsoft.com/en-us/azure/app-service/how-to-zone-redundancy#requirements")
+                    elif 'Not enough available reserved instance servers to satisfy' in detail:
+                        detail = ("Plan with Linux worker can only be created in a group " +
+                                    "which has never contained a Windows worker, and vice versa. " +
+                                    "Please use a new resource group. Original error:" + detail)
         else:
-            detail = json.loads(ex.response.text())['Message']
-            if creating_plan:
-                if 'Requested features are not supported in region' in detail:
-                    detail = ("Plan with requested features is not supported in current region. \n"
-                              "If creating an App Service Plan with --zone-redundant/-z, "
-                              "please see supported regions here: "
-                              "https://docs.microsoft.com/en-us/azure/app-service/how-to-zone-redundancy#requirements")
-                elif 'Not enough available reserved instance servers to satisfy' in detail:
-                    detail = ("Plan with Linux worker can only be created in a group " +
-                              "which has never contained a Windows worker, and vice versa. " +
-                              "Please use a new resource group. Original error:" + detail)
+            detail = json.loads(ex.error_msg.response.text())['Message']
         ex = CLIError(detail)
     except Exception:  # pylint: disable=broad-except
         pass

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -75,13 +75,13 @@ def _polish_bad_errors(ex, creating_plan):
                 if creating_plan:
                     if 'Requested features are not supported in region' in detail:
                         detail = ("Plan with requested features is not supported in current region. \n"
-                                    "If creating an App Service Plan with --zone-redundant/-z, "
-                                    "please see supported regions here: "
-                                    "https://docs.microsoft.com/en-us/azure/app-service/how-to-zone-redundancy#requirements")
+                                  "If creating an App Service Plan with --zone-redundant/-z, "
+                                  "please see supported regions here: "
+                                  "https://docs.microsoft.com/en-us/azure/app-service/how-to-zone-redundancy#requirements")
                     elif 'Not enough available reserved instance servers to satisfy' in detail:
                         detail = ("Plan with Linux worker can only be created in a group " +
-                                    "which has never contained a Windows worker, and vice versa. " +
-                                    "Please use a new resource group. Original error:" + detail)
+                                  "which has never contained a Windows worker, and vice versa. " +
+                                  "Please use a new resource group. Original error:" + detail)
         else:
             detail = json.loads(ex.error_msg.response.text())['Message']
         ex = CLIError(detail)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4054,7 +4054,6 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
     with ConfiguredDefaultSetter(cmd.cli_ctx.config, True):
         cmd.cli_ctx.config.set_value('defaults', 'group', rg_name)
         cmd.cli_ctx.config.set_value('defaults', 'sku', sku)
-        cmd.cli_ctx.config.set_value('defaults', 'appserviceplan', plan)
         cmd.cli_ctx.config.set_value('defaults', 'location', loc)
         cmd.cli_ctx.config.set_value('defaults', 'web', name)
     return create_json

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3964,7 +3964,8 @@ def webapp_up(cmd, name=None, resource_group_name=None, plan=None, location=None
                                sku=sku,
                                create_rg=_create_new_rg,
                                resource_group_name=rg_name,
-                               plan=plan)
+                               plan=plan,
+                               is_linux=_is_linux)
     dry_run_str = r""" {
                 "name" : "%s",
                 "appserviceplan" : "%s",

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_up_commands.py
@@ -67,6 +67,58 @@ class WebAppUpE2ETests(ScenarioTest):
         import shutil
         shutil.rmtree(temp_dir)
 
+
+    @live_only()
+    @ResourceGroupPreparer(random_name_length=24, name_prefix='clitest', location=LINUX_ASP_LOCATION_WEBAPP)
+    def test_webapp_up_no_plan_different_os_e2e(self, resource_group):
+        webapp_name = self.create_random_name('up-nodeapp', 24)
+        zip_file_name = os.path.join(TEST_DIR, 'node-Express-up.zip')
+
+        # create a temp directory and unzip the code to this folder
+        import zipfile
+        import tempfile
+        temp_dir = tempfile.mkdtemp()
+        zip_ref = zipfile.ZipFile(zip_file_name, 'r')
+        zip_ref.extractall(temp_dir)
+        current_working_dir = os.getcwd()
+
+        # change the working dir to the dir where the code has been extracted to
+        up_working_dir = os.path.join(temp_dir, 'myExpressApp')
+        os.chdir(up_working_dir)
+
+        # test the full E2E operation works
+        self.cmd('webapp up -n {} -g {} --os-type windows'.format(webapp_name, resource_group)).get_output_in_json()
+
+        # Verify app is created
+        # since we set local context, -n and -g are no longer required
+        self.cmd('webapp show', checks=[
+            JMESPathCheck('name', webapp_name),
+            JMESPathCheck('httpsOnly', True),
+            JMESPathCheck('kind', 'app'),
+            JMESPathCheck('resourceGroup', resource_group)
+        ])
+
+        # ensure we don't have conflicts when creating a linux app from the same directory with no --plan arg
+        webapp_name = self.create_random_name('up-nodeapp', 24)
+        self.cmd('webapp up -n {} -g {} --os-type linux'.format(webapp_name, resource_group)).get_output_in_json()
+
+        # Verify app is created
+        # since we set local context, -n and -g are no longer required
+        self.cmd('webapp show', checks=[
+            JMESPathCheck('name', webapp_name),
+            JMESPathCheck('httpsOnly', True),
+            JMESPathCheck('kind', 'app,linux'),
+            JMESPathCheck('resourceGroup', resource_group)
+        ])
+
+        # cleanup
+        # switch back the working dir
+        os.chdir(current_working_dir)
+        # delete temp_dir
+        import shutil
+        shutil.rmtree(temp_dir)
+
+
     @live_only()
     @ResourceGroupPreparer(random_name_length=24, name_prefix='clitest', location=LINUX_ASP_LOCATION_WEBAPP)
     def test_webapp_up_node_e2e(self, resource_group):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The command `az webapp up` writes out to and reads from a `.azure/config` file in the current directory. This can cause confusing behavior where for the first time running `az webapp up` without a `--plan` arg, a new App Service Plan is created, but on subsequent runs of the command in the current directory, the plan is reused. There was no documentation of this feature in the help text or any alert via the command line. This can be particularly annoying when the user tries to create an app with a different OS from the default plan's OS (lead to a 'bad request' error). 
To reduce confusion, this default loading behavior was removed for `--plan` in this PR. 

If no `--plan` argument is provided, then the CLI will attempt to create the app in an App Service Plan with matching RG, SKU, location and OS type. I fixed a bug where the OS type was not included in this matching process. A new plan is created if no matching plan is found. 

**Testing Guide**
<!--Example commands with explanations.-->
`azdev test --live test_webapp_up_commands`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[App Service] BREAKING CHANGE : `az webapp up` : Remove default argument loading for `--plan`
[App Service] `az webapp up` : Fix bug causing existing ASP with wrong OS type to be selected when not providing a `--plan` argument

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
