### PR TITLE
[Storage] Stop supporting `--auth-mode login` for `az storage blob sync` and `az storage fs directory upload/download`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -426,7 +426,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('storage blob', command_type=block_blob_sdk,
                             custom_command_type=get_custom_sdk('azcopy', blob_data_service_factory)) as g:
-        g.storage_custom_command_oauth('sync', 'storage_blob_sync', is_preview=True)
+        g.storage_custom_command('sync', 'storage_blob_sync', is_preview=True)
 
     with self.command_group('storage container', command_type=block_blob_sdk,
                             custom_command_type=get_custom_sdk('blob', blob_data_service_factory)) as g:
@@ -844,8 +844,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                                 transform=transform_metadata)
 
     with self.command_group('storage fs directory', custom_command_type=get_custom_sdk('azcopy', None))as g:
-        g.storage_custom_command_oauth('upload', 'storage_fs_directory_copy', is_preview=True)
-        g.storage_custom_command_oauth('download', 'storage_fs_directory_copy', is_preview=True)
+        g.storage_custom_command('upload', 'storage_fs_directory_copy', is_preview=True)
+        g.storage_custom_command('download', 'storage_fs_directory_copy', is_preview=True)
 
     with self.command_group('storage fs file', adls_file_sdk, resource_type=ResourceType.DATA_STORAGE_FILEDATALAKE,
                             custom_command_type=get_custom_sdk('fs_file', cf_adls_file), min_api='2018-11-09') as g:


### PR DESCRIPTION
**Backgrounds**
Storage module support several kinds of credential for data plane commands and `azcopy` commands:
1) `--account-key` with `--auth-mode key`(which can be omited)
2) `--connection-string`
3) `--sas-token`
4) `--auth-mode login`

`azcopy` has two kinds of auth:
a) SAS token auth
b) AAD auth

When customers provide 1) or 2), we generate a SAS token using the credential they give.
So with 1) 2) 3), we call `azcopy` by SAS token auth.
With 4), we call `azcopy` by AAD auth with login `access_token` and `refresh_token` stored in environment variable.

**Problems**
- After CLI core migrates from ADAL to MSAL, we can't get `refresh_token` any more. `azcopy` related commands fail with `--auth-mode login` (#20488)
- Setting `access_token` and `refresh_token` in env virable is unsafe.

**Changes**
This PR drops `--auth-mode login` support for `azcopy` related commands

PS. Some existing `azcopy` related commands don't support `--auth-mode login` from the very beginning, such as `az storage copy/remove`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
