### PR TITLE
[Compute] `az vm/vmss create`: Add warning log and modify help to inform that the default value `Contributor` of `--role` will be removed

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -1450,7 +1450,7 @@ examples:
           --image debian --secrets "$vm_secrets"
   - name: Create a CentOS VM with a system assigned identity. The VM will have a 'Contributor' role with access to a storage account.
     text: >
-        az vm create -n MyVm -g rg1 --image centos --assign-identity [system] --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1
+        az vm create -n MyVm -g rg1 --image centos --assign-identity [system] --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1 --role Contributor
   - name: Create a debian VM with a user assigned identity.
     text: >
         az vm create -n MyVm -g rg1 --image debian --assign-identity /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID
@@ -2820,7 +2820,7 @@ examples:
           --image debian --secrets "$vm_secrets"
   - name: Create a VM scaleset with system assigned identity. The VM will have a 'Contributor' Role with access to a storage account.
     text: >
-        az vmss create -n MyVmss -g MyResourceGroup --image centos --assign-identity --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1
+        az vmss create -n MyVmss -g MyResourceGroup --image centos --assign-identity --scope /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/MyResourceGroup/myRG/providers/Microsoft.Storage/storageAccounts/storage1 --role Contributor
   - name: Create a debian VM scaleset with a user assigned identity.
     text: >
         az vmss create -n MyVmss -g rg1 --image debian --assign-identity  /subscriptions/99999999-1bf0-4dda-aec3-cb9272f09590/resourcegroups/myRG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myID

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1014,7 +1014,7 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('identity_role', options_list=['--role'], arg_group='Managed Service Identity',
                        help='Role name or id the system assigned identity will have. '
-                            'Please note that the default value "Contributor" will be removed in the future. '
+                            'Please note that the default value "Contributor" will be removed in the future, '
                             "so please specify '--role' and '--scope' at the same time when assigning a role to the managed identity")
 
     for scope in ['vm identity assign', 'vmss identity assign']:

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1008,8 +1008,20 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
             c.argument('identity_scope', options_list=['--scope'], arg_group=arg_group, help="Scope that the system assigned identity can access")
-            c.argument('identity_role', options_list=['--role'], arg_group=arg_group, help="Role name or id the system assigned identity will have")
             c.ignore('identity_role_id')
+
+    for scope in ['vm create', 'vmss create']:
+        with self.argument_context(scope) as c:
+            arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
+            c.argument('identity_role', options_list=['--role'], arg_group=arg_group,
+                       help='Role name or id the system assigned identity will have. '
+                            'Please note that the default value "Contributor" will be removed in the future. '
+                            'So please specify the "--role" and "--scope" parameters at the same time when assigning role to the managed identity')
+
+    for scope in ['vm identity assign', 'vmss identity assign']:
+        with self.argument_context(scope) as c:
+            arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
+            c.argument('identity_role', options_list=['--role'], arg_group=arg_group, help="Role name or id the system assigned identity will have")
 
     with self.argument_context('vm auto-shutdown') as c:
         c.argument('off', action='store_true', help='Turn off auto-shutdown for VM. Configuration will be cleared.')

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1012,16 +1012,14 @@ def load_arguments(self, _):
 
     for scope in ['vm create', 'vmss create']:
         with self.argument_context(scope) as c:
-            arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
-            c.argument('identity_role', options_list=['--role'], arg_group=arg_group,
+            c.argument('identity_role', options_list=['--role'], arg_group='Managed Service Identity',
                        help='Role name or id the system assigned identity will have. '
                             'Please note that the default value "Contributor" will be removed in the future. '
                             'So please specify the "--role" and "--scope" parameters at the same time when assigning role to the managed identity')
 
     for scope in ['vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:
-            arg_group = 'Managed Service Identity' if scope.split()[-1] == 'create' else None
-            c.argument('identity_role', options_list=['--role'], arg_group=arg_group, help="Role name or id the system assigned identity will have")
+            c.argument('identity_role', options_list=['--role'], help="Role name or id the system assigned identity will have")
 
     with self.argument_context('vm auto-shutdown') as c:
         c.argument('off', action='store_true', help='Turn off auto-shutdown for VM. Configuration will be cleared.')

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1015,7 +1015,7 @@ def load_arguments(self, _):
             c.argument('identity_role', options_list=['--role'], arg_group='Managed Service Identity',
                        help='Role name or id the system assigned identity will have. '
                             'Please note that the default value "Contributor" will be removed in the future. '
-                            'So please specify the "--role" and "--scope" parameters at the same time when assigning role to the managed identity')
+                            "so please specify '--role' and '--scope' at the same time when assigning a role to the managed identity")
 
     for scope in ['vm identity assign', 'vmss identity assign']:
         with self.argument_context(scope) as c:

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1234,10 +1234,9 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
     # at the same time to reduce the impact of breaking change
     if not from_set_command and namespace.identity_scope and getattr(namespace.identity_role, 'is_default', None):
         logger.warning(
-            'Please note that the default value of parameter "--role" will be removed in the future. '
-            'so specify "--role" and "--scope" at the same time when assigning a role '
-            'to the managed identity to avoid breaking your automation script when the default value of '
-            '"--role" is removed.'
+            "Please note that the default value of parameter '--role' will be removed in the future. "
+            "So specify '--role' and '--scope' at the same time when assigning a role to the managed identity "
+            "to avoid breaking your automation script when the default value of '--role' is removed."
         )
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1235,8 +1235,8 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
     if not from_set_command and namespace.identity_scope and getattr(namespace.identity_role, 'is_default', None):
         logger.warning(
             'Please note that the default value of parameter "--role" will be removed in the future. '
-            'So please specify the "--role" and "--scope" parameters at the same time when assigning role '
-            'to the managed identity, so as to avoid breaking your automation script when the default value of '
+            'so specify "--role" and "--scope" at the same time when assigning a role '
+            'to the managed identity to avoid breaking your automation script when the default value of '
             '"--role" is removed.'
         )
 

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1213,20 +1213,32 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
                 identities[i] = _get_resource_id(cmd.cli_ctx, identities[i], namespace.resource_group_name,
                                                  'userAssignedIdentities', 'Microsoft.ManagedIdentity')
         if not namespace.identity_scope and getattr(namespace.identity_role, 'is_default', None) is None:
-            raise CLIError("usage error: '--role {}' is not applicable as the '--scope' is not provided".format(
-                namespace.identity_role))
+            raise ArgumentUsageError("usage error: '--role {}' is not applicable as the '--scope' is not provided".
+                                     format(namespace.identity_role))
         user_assigned_identities = [x for x in identities if x != MSI_LOCAL_ID]
         if user_assigned_identities and not cmd.supported_api_version(min_api='2017-12-01'):
-            raise CLIError('usage error: user assigned identity is only available under profile '
-                           'with minimum Compute API version of 2017-12-01')
+            raise ArgumentUsageError('usage error: user assigned identity is only available under profile '
+                                     'with minimum Compute API version of 2017-12-01')
         if namespace.identity_scope:
             if identities and MSI_LOCAL_ID not in identities:
-                raise CLIError("usage error: '--scope'/'--role' is only applicable when assign system identity")
+                raise ArgumentUsageError("usage error: '--scope'/'--role' is only applicable when "
+                                         "assign system identity")
             # keep 'identity_role' for output as logical name is more readable
             setattr(namespace, 'identity_role_id', _resolve_role_id(cmd.cli_ctx, namespace.identity_role,
                                                                     namespace.identity_scope))
     elif namespace.identity_scope or getattr(namespace.identity_role, 'is_default', None) is None:
-        raise CLIError('usage error: --assign-identity [--scope SCOPE] [--role ROLE]')
+        raise ArgumentUsageError('usage error: --assign-identity [--scope SCOPE] [--role ROLE]')
+
+    # For the creation of VM and VMSS, the default value "Contributor" of "--role" will be removed in the future.
+    # Therefore, the first step is to prompt users that parameters "--role" and "--scope"  should be passed in
+    # at the same time to reduce the impact of breaking change
+    if not from_set_command and namespace.identity_scope and getattr(namespace.identity_role, 'is_default', None):
+        logger.warning(
+            'Please note that the default value of parameter "--role" will be removed in the future. '
+            'So please specify the "--role" and "--scope" parameters at the same time when assigning role '
+            'to the managed identity, so as to avoid breaking your automation script when the default value of '
+            '"--role" is removed.'
+        )
 
 
 def _validate_vm_vmss_set_applications(cmd, namespace):  # pylint: disable=unused-argument


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
As the security team raised the security concern: the permission of  `Contributor` is too high to be used as the default role for the creation of VM and VMSS, so the default value `Contributor` of `--role` will be removed in the future. 

Therefore, the first step is to prompt users that parameters `--role` and `--scope`  should be passed in at the same time when assigning role to the managed identity to reduce the impact of breaking change.

The specific effects are as follows:
![Screenshot 2022-01-07 162306](https://user-images.githubusercontent.com/16612065/148519793-e996d22c-9491-43a6-80cf-b4ead65aaf05.png)
![Screenshot 2022-01-07 163257](https://user-images.githubusercontent.com/16612065/148519801-6bd4971c-1599-473e-b090-3686a704c7ff.png)
![Screenshot 2022-01-07 164258](https://user-images.githubusercontent.com/16612065/148519820-dd5e63ad-a444-49b6-b128-93cb4b71d564.png)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
