### PR TITLE
[App Service] `az staticwebapp` : Fix #20830 and remove unneeded properties from staticwebapp output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -978,6 +978,7 @@ def load_arguments(self, _):
         c.argument('hostname', options_list=['--hostname', '-n'], help='Name of the custom domain')
 
     with self.argument_context('staticwebapp', validator=validate_public_cloud) as c:
+        c.ignore('format_output')
         c.argument('name', options_list=['--name', '-n'], metavar='NAME', help="Name of the static site")
         c.argument('source', options_list=['--source', '-s'], help="URL for the repository of the static site.")
         c.argument('token', options_list=['--token', '-t'],

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -7,7 +7,7 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.util import sdk_no_wait
 
 from azure.cli.core.commands import LongRunningOperation
-from azure.cli.core.azclierror import ResourceNotFoundError, ValidationError, RequiredArgumentMissingError
+from azure.cli.core.azclierror import ValidationError, RequiredArgumentMissingError
 from knack.util import CLIError
 from knack.log import get_logger
 from msrestazure.tools import parse_resource_id
@@ -365,7 +365,7 @@ def update_staticsite_users(cmd, name, roles, authentication_provider=None, user
                                           static_site_user_envelope=user_envelope)
 
 
-def create_staticsites(cmd, resource_group_name, name, location,  # pylint: disable=too-many-locals
+def create_staticsites(cmd, resource_group_name, name, location,  # pylint: disable=too-many-locals,
                        source, branch, token=None,
                        app_location="/", api_location=None, output_location=None,
                        tags=None, no_wait=False, sku='Free', login_with_github=False, format_output=True):
@@ -420,7 +420,7 @@ def update_staticsite(cmd, name, source=None, branch=None, token=None,
                       tags=None, sku=None, no_wait=False, format_output=None):
     existing_staticsite = show_staticsite(cmd, name, format_output=False)
     if not existing_staticsite:
-        raise ResourceNotFoundError("No static web app found with name {0}".format(name))
+        raise CLIError("No static web app found with name {0}".format(name))
 
     if tags is not None:
         existing_staticsite.tags = tags

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -418,7 +418,7 @@ def create_staticsites(cmd, resource_group_name, name, location,  # pylint: disa
 
 def update_staticsite(cmd, name, source=None, branch=None, token=None,
                       tags=None, sku=None, no_wait=False, format_output=None):
-    existing_staticsite = show_staticsite(cmd, name)
+    existing_staticsite = show_staticsite(cmd, name, format_output=False)
     if not existing_staticsite:
         raise CLIError("No static web app found with name {0}".format(name))
 
@@ -554,7 +554,7 @@ def reset_staticsite_api_key(cmd, name, resource_group_name=None):
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
 
-    existing_staticsite = show_staticsite(cmd, name, resource_group_name)
+    existing_staticsite = show_staticsite(cmd, name, resource_group_name, format_output=False)
     ResetPropertiesEnvelope = cmd.get_models('StaticSiteResetPropertiesARMResource')
     reset_envelope = ResetPropertiesEnvelope(repository_token=existing_staticsite.repository_token)
     return client.reset_static_site_api_key(resource_group_name=resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -95,7 +95,7 @@ class TestStaticAppCommands(unittest.TestCase):
         output_location = '/.git/'
         tags = {'key1': 'value1'}
 
-        with mock.patch("azure.cli.command_modules.appservice.static_sites.show_staticsite", side_effect=ResourceNotFoundError("msg")):
+        with mock.patch("azure.cli.command_modules.appservice.static_sites.show_staticsite", side_effect=[ResourceNotFoundError("msg"), None]):
             create_staticsites(
                 self.mock_cmd, self.rg1, self.name1, self.location1,
                 self.source1, self.branch1, self.token1,
@@ -128,7 +128,7 @@ class TestStaticAppCommands(unittest.TestCase):
         from azure.mgmt.web.models import StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
         self.mock_cmd.get_models.return_value = StaticSiteARMResource, StaticSiteBuildProperties, SkuDescription
 
-        with mock.patch("azure.cli.command_modules.appservice.static_sites.show_staticsite", side_effect=ResourceNotFoundError("msg")):
+        with mock.patch("azure.cli.command_modules.appservice.static_sites.show_staticsite", side_effect=[ResourceNotFoundError("msg"), None]):
             create_staticsites(
                 self.mock_cmd, self.rg1, self.name1, self.location1,
                 self.source1, self.branch1, self.token1, sku='standard')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Removes the following properties from the staticwebapp objects returned from the create, show, list, and update commands: 

- allowConfigFileUpdates
- buildProperties
- contentDistributionEndpoint
- keyVaultReferenceIdentity
- kind                                                                                           
- privateEndpointConnections
- repositoryToken
- stagingEnvironmentPolicy
- templateProperties
- sku.capabilities
- sku.capacity
- sku.family
- sku.locations
- sku.size
- sku.skuCapacity

Also changes some default arguments for `az staticwebapp create` to fix #20830

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
 
[App Service] `az staticwebapp create` : Change default output location and API location to `None`. Change default app location to "/". Remove unnecessary properties from output 
[App Service] `az staticwebapp show` : Remove unnecessary properties from output 
[App Service] `az staticwebapp list` : Remove unnecessary properties from output 
[App Service] `az staticwebapp update` : Remove unnecessary properties from output 

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
