### PR TITLE
{Packaging} Bump `certifi` to 2021.10.8

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -93,7 +93,7 @@ azure-synapse-artifacts==0.10.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2019.6.16
+certifi==2021.10.8
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -93,7 +93,7 @@ azure-synapse-artifacts==0.10.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2019.6.16
+certifi==2021.10.8
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -93,7 +93,7 @@ azure-synapse-artifacts==0.10.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2019.6.16
+certifi==2021.10.8
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4


### PR DESCRIPTION
## Description
`certifi` hasn't been bumped since 2019-06-26 (#9785).

Some certificate will expire soon:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 144470 (0x23456)
        Signature Algorithm: sha1WithRSAEncryption
        Issuer: C=US, O=GeoTrust Inc., CN=GeoTrust Global CA
        Validity
            Not Before: May 21 04:00:00 2002 GMT
            Not After : May 21 04:00:00 2022 GMT
```

We should bump `certifi` to the latest version before it is too late.

## Additional information

In order to view decoded CA bundle, run

```
openssl storeutl -noout -text -certs D:\cli\py310\Lib\site-packages\certifi\cacert.pem
```

See https://serverfault.com/a/1079893/174062

