### PR TITLE
{Role} `az ad sp create-for-rbac`: Show warning when `--scopes` defaults to subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -419,8 +419,8 @@ examples:
     text: az ad sp create-for-rbac
   - name: Create using a custom display name.
     text: az ad sp create-for-rbac -n "MyApp"
-  - name: Create with a Contributor role assignments on specified scope.
-    text: az ad sp create-for-rbac -n "MyApp" --role Contributor --scopes /subscriptions/{SubID}/resourceGroups/{ResourceGroup1} /subscriptions/{SubID}/resourceGroups/{ResourceGroup2}
+  - name: Create with a Contributor role assignments on specified scopes. To retrieve current subscription ID, run `az account show --query id --output tsv`.
+    text: az ad sp create-for-rbac -n "MyApp" --role Contributor --scopes /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup1} /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup2}
   - name: Create using a self-signed certificate.
     text: az ad sp create-for-rbac --create-cert
   - name: Create using a self-signed certificate, and store it within KeyVault.

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -39,6 +39,9 @@ CREDENTIAL_WARNING = (
 
 logger = get_logger(__name__)
 
+SCOPE_WARNING = "In a future release, --scopes argument will become required for creating a role assignment. " \
+                "Please explicitly specify --scopes."
+
 # pylint: disable=too-many-lines
 
 
@@ -1403,7 +1406,11 @@ def create_service_principal_for_rbac(
 
     graph_client = _graph_client_factory(cmd.cli_ctx)
     role_client = _auth_client_factory(cmd.cli_ctx).role_assignments
-    scopes = scopes or ['/subscriptions/' + role_client.config.subscription_id]
+
+    if role and not scopes:
+        logger.warning(SCOPE_WARNING)
+        scopes = ['/subscriptions/' + role_client.config.subscription_id]
+
     years = years or 1
     _RETRY_TIMES = 36
     existing_sps = None


### PR DESCRIPTION
**Description**<!--Mandatory-->
A temporary warning for https://github.com/Azure/azure-cli/issues/20806

For `az ad sp create-for-rbac`, when `--role` is given, `--scope` defaults  to the subscription:

```
> az ad sp create-for-rbac --role Reader
...
Creating 'Reader' role assignment under scope '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590'
...
{
  "appId": "9eb7e5f0-7a0b-4601-9d72-3f438fcace9f",
  "displayName": "azure-cli-2021-12-22-08-39-11",
  "password": "",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
}
```

Without explicit consent from the user on the `--scope`, this behavior is considered Elevation of Privilege.

This PR adds a warning when `--role` is specified but `--scopes` is not:

```
> az ad sp create-for-rbac --role contributor
In a future release, --scopes argument will become required for creating a role asssignment. Please explicitly specify --scopes.
Creating 'contributor' role assignment under scope '/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590'
...
{
  "appId": "c337fa52-41d4-4234-8cf3-ac37b83f72c6",
  "displayName": "azure-cli-2022-01-13-06-17-22",
  "password": "",
  "tenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"
}
```
