### PR TITLE
{packaging} Update Fedora dockerfile to Fedora 35

### DIFF
--- a/scripts/release/rpm/Dockerfile.fedora
+++ b/scripts/release/rpm/Dockerfile.fedora
@@ -1,4 +1,4 @@
-ARG tag=29
+ARG tag=35
 
 FROM fedora:${tag} AS build-env
 ARG cli_version=dev


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fedora 29 has been EOL for quite some time and Fedora 35 is the current release. Update the tag to 35, which is the most recent stable release.

**Testing Guide**
No changes to the testing process.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
