### PR TITLE
{iot} Fix: typo in az iot hub route update docs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_help.py
@@ -723,7 +723,7 @@ examples:
 helps['iot hub route update'] = """
 type: command
 short-summary: Update a route in IoT Hub.
-long-summary: Updates a route in IoT Hub. You can change the source, enpoint or query on the route.
+long-summary: Updates a route in IoT Hub. You can change the source, endpoint or query on the route.
 examples:
   - name: Update source type of route "R1" from "MyIotHub" IoT Hub.
     text: >


### PR DESCRIPTION
**Description**<!--Mandatory-->
I found a typo in the documentation of the `az iot hub route update` documentation.  (enpoint must obviously be endpoint).

