### PR TITLE
{Core} Update warning message for auth code flow

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -159,7 +159,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
     def login_with_auth_code(self, scopes, **kwargs):
         # Emit a warning to inform that a browser is opened.
         # Only show the path part of the URL and hide the query string.
-        logger.warning("The default web browser has been opened at %s. Please continue the login in the web browser. "
+        logger.warning("A web browser has been opened at %s. Please continue the login in the web browser. "
                        "If no web browser is available or if the web browser fails to open, use device code flow "
                        "with `az login --use-device-code`.", self._msal_app.authority.authorization_endpoint)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

After the change of MSAL

- https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/388

The original statement "The default web browser" is no longer true and it causes user confusion:

- https://github.com/Azure/azure-cli/issues/21136

This PR updates the warning message according to the latest MSAL behavior.
