### PR TITLE
{Packaging} Keep py3 model files

### DIFF
--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -111,18 +111,6 @@ copy %REPO_ROOT%\build_scripts\windows\resources\CLI_LICENSE.rtf %BUILDING_DIR%
 copy %REPO_ROOT%\build_scripts\windows\resources\ThirdPartyNotices.txt %BUILDING_DIR%
 copy %REPO_ROOT%\NOTICE.txt %BUILDING_DIR%
 
-:: Use universal files and remove Py3 only files
-pushd %BUILDING_DIR%\Lib\site-packages\azure\mgmt
-for /f %%a in ('dir /b /s *_py3.py') do (
-    set PY3_FILE=%%a
-    if exist !PY3_FILE! del !PY3_FILE!
-)
-for /f %%a in ('dir /b /s *_py3.*.pyc') do (
-    set PY3_FILE=%%a
-    if exist !PY3_FILE! del !PY3_FILE!
-)
-popd
-
 :: Remove .py and only deploy .pyc files
 pushd %BUILDING_DIR%\Lib\site-packages
 for /f %%f in ('dir /b /s *.pyc') do (


### PR DESCRIPTION
An alternative solution to https://github.com/Azure/azure-cli/pull/21143

## Symptom

When building Windows MSI, `_models_py3.py` files are removed to reduce package size.

- `_models.py` are both Python 2 and 3 compatible
- `_models_py3.py` are only Python 3 compatible

Since 2022-01, Python 2 support has been dropped by Python SDK (https://github.com/Azure/azure-sdk-for-python/issues/20691).

- `_models.py` files are removed from new version Python SDKs
- That is, only `_models_py3.py` files are kept in Python SDKs

So far, this change has been done on `azure-mgmt-netapp` and `azure-mgmt-trafficmanager`. 

However, because CLI's build pipeline removes `_models_py3.py` files, no model files will exist in the MSI package. This leads to CI failure:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1332093&view=logs&j=fec5ba3f-cada-52e0-3c40-eb322e7bf2a6&t=50bad18b-08a9-5298-0f82-721960fdcd1c

```
2022-01-28T05:44:45.9762940Z ERROR: Error loading command module 'network': No module named 'azure.mgmt.trafficmanager.models._models_py3'
...
2022-01-28T05:45:03.8574497Z   File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/netapp/__init__.py", line 9, in <module>
2022-01-28T05:45:03.8575668Z   File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/netapp/_net_app_management_client.py", line 16, in <module>
2022-01-28T05:45:03.8576594Z   File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/netapp/models/__init__.py", line 9, in <module>
2022-01-28T05:45:03.8577404Z ModuleNotFoundError: No module named 'azure.mgmt.netapp.models._models_py3'
```

Full log: [557.txt](https://github.com/Azure/azure-cli/files/7956389/557.txt)

## Test guide

1. Remove the current installed Azure CLI from control panel to make the system clean
2. Install the built artifact MSI from build pipeline
3. Check files under `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure\mgmt\trafficmanager\models` to make sure `_models_py3.pyc` exists
4. Run `az self-test`

## Pros and Cons

- The MSI only increases from 48MB to 52MB which is acceptable. With the removal of `_models.py` files from SDKs in the future, the MSI size will decrease gradually
- If SDK renames `_models_py3.py` to `_models.py` in the future, no action will be required on CLI side

## TODO

The CI job `TestWindowsMSI` fails to detect this issue when there is no version update, possibly due to old `_models_py3.py` files not being removed when installing MSI with the same version. This requires further investigation.
