### PR TITLE
{Network} Close bastion session from cli

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8132,10 +8132,12 @@ def ssh_bastion_host(cmd, auth_type, target_resource_id, resource_group_name, ba
     command = command + ['-o', "StrictHostKeyChecking=no", '-o', "UserKnownHostsFile=/dev/null"]
     command = command + ['-o', "LogLevel=Error"]
     logger.debug("Running ssh command %s", ' '.join(command))
-    try:
+    try:        
         subprocess.call(command, shell=platform.system() == 'Windows')
     except Exception as ex:
         raise CLIInternalError(ex)
+    finally:
+        tunnel_server.cleanup()
 
 
 def rdp_bastion_host(cmd, target_resource_id, resource_group_name, bastion_host_name, resource_port=None):
@@ -8169,6 +8171,12 @@ def get_tunnel(cmd, resource_group_name, name, vm_id, resource_port, port=None):
     return tunnel_server
 
 
+def tunnel_close_handler(tunnel):
+    logger.info("Ctrl + C received. Clean up and then exit.")
+    tunnel.cleanup()
+    exit(0)
+
+
 def create_bastion_tunnel(cmd, target_resource_id, resource_group_name, bastion_host_name, resource_port, port, timeout=None):
     if not is_valid_resource_id(target_resource_id):
         raise InvalidArgumentValueError("Please enter a valid Virtual Machine resource Id.")
@@ -8179,6 +8187,10 @@ def create_bastion_tunnel(cmd, target_resource_id, resource_group_name, bastion_
     logger.warning('Opening tunnel on port: %s', tunnel_server.local_port)
     logger.warning('Tunnel is ready, connect on port %s', tunnel_server.local_port)
     logger.warning('Ctrl + C to close')
+
+    import signal
+    #handle closing the tunnel with an active session still connected
+    signal.signal(signal.SIGINT, lambda signum, frame: tunnel_close_handler(tunnel_server))
 
     if timeout:
         time.sleep(int(timeout))

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8174,7 +8174,8 @@ def get_tunnel(cmd, resource_group_name, name, vm_id, resource_port, port=None):
 def tunnel_close_handler(tunnel):
     logger.info("Ctrl + C received. Clean up and then exit.")
     tunnel.cleanup()
-    exit(0)
+    import sys
+    sys.exit()
 
 
 def create_bastion_tunnel(cmd, target_resource_id, resource_group_name, bastion_host_name, resource_port, port, timeout=None):

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8132,7 +8132,7 @@ def ssh_bastion_host(cmd, auth_type, target_resource_id, resource_group_name, ba
     command = command + ['-o', "StrictHostKeyChecking=no", '-o', "UserKnownHostsFile=/dev/null"]
     command = command + ['-o', "LogLevel=Error"]
     logger.debug("Running ssh command %s", ' '.join(command))
-    try:        
+    try:
         subprocess.call(command, shell=platform.system() == 'Windows')
     except Exception as ex:
         raise CLIInternalError(ex)
@@ -8189,7 +8189,7 @@ def create_bastion_tunnel(cmd, target_resource_id, resource_group_name, bastion_
     logger.warning('Ctrl + C to close')
 
     import signal
-    #handle closing the tunnel with an active session still connected
+    # handle closing the tunnel with an active session still connected
     signal.signal(signal.SIGINT, lambda signum, frame: tunnel_close_handler(tunnel_server))
 
     if timeout:

--- a/src/azure-cli/azure/cli/command_modules/network/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tunnel.py
@@ -193,7 +193,7 @@ class TunnelServer:
 
             web_address = 'https://{}/api/tokens/{}'.format(self.bastion.dns_name, self.last_token)
             response = requests.delete(web_address, headers=custom_header,
-                                verify=(not should_disable_connection_verify()))
+                                       verify=(not should_disable_connection_verify()))
             if response.status_code == 404:
                 logger.info('Session already deleted')
             elif response.status_code not in [200, 204]:

--- a/src/azure-cli/azure/cli/command_modules/network/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tunnel.py
@@ -190,26 +190,20 @@ class TunnelServer:
                 custom_header = {'X-Node-Id': self.node_id}
             else:
                 custom_header = {}
-            logger.warning(f"custom_header = {custom_header}")
 
             web_address = 'https://{}/api/tokens/{}'.format(self.bastion.dns_name, self.last_token)
-            logger.warning(f"web_address = {web_address}")
-
             response = requests.delete(web_address, headers=custom_header,
                                 verify=(not should_disable_connection_verify()))
-            logger.warning(f"response = {response.status_code}")
             if response.status_code == 404:
-                logger.warning("session already deleted")
+                logger.info('Session already deleted')
             elif response.status_code not in [200, 204]:
                 exp = CloudError(response)
                 raise exp
 
-            logger.warning("setting last_token to null")
             self.last_token = None
-            logger.warning("setting node_id to null")
             self.node_id = None
         else:
-            logger.debug("Nothing to clean up")
+            logger.debug('Nothing to clean up')
 
     def get_port(self):
         return self.local_port


### PR DESCRIPTION
**Description**<!--Mandatory-->
Clean up the Bastion session established from the az cli after disconnecting.

**Testing Guide**
Azure SSH
1. Connect to an existing VM via `az network bastion ssh`
2. Verify session in the Azure portal
3. Exit the session from the command line by typing `exit` and pressing enter
4. Verify session is no longer present in Azure portal

Azure tunnel + SSH exit
1. Establish a tunnel to an existing VM via `az network bastion tunnel`
2. SSH into the VM (e.g., via putty)
3. Verify session in the Azure portal
4. Exit from the SSH session
5. Verify session is no longer present in Azure portal

Azure tunnel + SSH close tunnel
1. Establish a tunnel to an existing VM via `az network bastion tunnel`
2. SSH into the VM (e.g., via putty)
3. Verify session in the Azure portal
4. Close the tunnel as specified with "Ctrl + C"
5. Verify session is no longer present in Azure portal 

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
