### PR TITLE
[Packaging] BREAKING CHANGE: Drop `jmespath-terminal` from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN apk add --no-cache bash openssh ca-certificates jq curl openssl perl git zip
 ARG JP_VERSION="0.1.3"
 
 RUN curl -L https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
- && chmod +x /usr/local/bin/jp \
- && pip install --no-cache-dir --upgrade jmespath-terminal
+ && chmod +x /usr/local/bin/jp
 
 WORKDIR azure-cli
 COPY . /azure-cli


### PR DESCRIPTION
**Description**<!--Mandatory-->

`jmespath-terminal` no longer installes with latest `setuptools` because it uses very old `urwid==1.2.2` (https://github.com/jmespath/jmespath.terminal/issues/19). This issue was reported in 2018 but per https://pypi.org/project/jmespath-terminal/, the latest version of `jmespath-terminal` was released on Oct 6, 2015.

This causes CI failure and blocks PR (https://github.com/Azure/azure-cli/pull/21057#issuecomment-1031013267):

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1341309&view=logs&j=a3141784-dfa9-5792-78cc-844daee2d774&t=b2b6de04-64e4-5812-4fff-06c02d19f4c2&l=214

```
    error in urwid setup command: use_2to3 is invalid.
    Couldn't build the extension module, trying without it...
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/0c/6a/c6eceee1b52004d791b1249d798e3a6ef280a8ab5645b5e5246e8e73c7cb/urwid-1.2.2.tar.gz#sha256=e122e2dee122314f5626945af4dbe15bf3de9f318c552a4c0b68c1c480852d92 (from https://pypi.org/simple/urwid/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
Collecting jmespath-terminal
  Downloading jmespath-terminal-0.2.0.tar.gz (6.2 kB)
Collecting Pygments<=2.0,>=1.6
  Downloading Pygments-2.0-py3-none-any.whl (672 kB)
Collecting jmespath-terminal
  Downloading jmespath-terminal-0.1.1.tar.gz (5.1 kB)
  Downloading jmespath-terminal-0.1.0.tar.gz (3.8 kB)
  Downloading jmespath-terminal-0.0.1.tar.gz (3.4 kB)
ERROR: Cannot install jmespath-terminal==0.0.1, jmespath-terminal==0.1.0, jmespath-terminal==0.1.1, jmespath-terminal==0.2.0 and jmespath-terminal==0.2.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    jmespath-terminal 0.2.1 depends on urwid==1.2.2
    jmespath-terminal 0.2.0 depends on urwid==1.2.2
    jmespath-terminal 0.1.1 depends on urwid==1.2.2
    jmespath-terminal 0.1.0 depends on urwid==1.2.2
    jmespath-terminal 0.0.1 depends on urwid==1.2.2
```

Since `jmespath-terminal` seems to be no longer maintained, we should drop it.
