### PR TITLE
{Packaging} Fix CI job "Test Yum Package" by using `centos7`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -743,9 +743,10 @@ jobs:
        YUM_FILE=$SYSTEM_ARTIFACTSDIRECTORY/yum/$YUM_NAME
 
        echo "== Test yum package on CentOS =="
-
-       docker pull centos:centos8
-       docker run --rm -e YUM_NAME=$YUM_NAME -v $SYSTEM_ARTIFACTSDIRECTORY/yum:/mnt/yum -v $(pwd):/azure-cli centos:centos8 /bin/bash "/azure-cli/scripts/release/rpm/test_rpm_in_docker.sh"
+      
+       IMAGE=centos:centos7
+       docker pull $IMAGE
+       docker run --rm -e YUM_NAME=$YUM_NAME -v $SYSTEM_ARTIFACTSDIRECTORY/yum:/mnt/yum -v $(pwd):/azure-cli $IMAGE /bin/bash "/azure-cli/scripts/release/rpm/test_rpm_in_docker.sh"
 
     displayName: 'Test Yum Package'
 

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -9,8 +9,8 @@ yum --nogpgcheck localinstall /mnt/yum/$YUM_NAME -y
 
 yum install git gcc python3-devel -y
 
-ln -s /usr/bin/python3 /usr/bin/python
-ln -s /usr/bin/pip3 /usr/bin/pip
+ln -s -f /usr/bin/python3 /usr/bin/python
+ln -s -f /usr/bin/pip3 /usr/bin/pip
 time az self-test
 time az --version
 

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script should be run in a centos8 docker.
+# This script should be run in a centos7 docker.
 set -exv
 
 export USERNAME=azureuser


### PR DESCRIPTION
**Description**<!--Mandatory-->

Since CentOS 8 has been deprecated, `centos8` image no longer works:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1348614&view=logs&j=1e6fba43-bdcf-51f0-a062-3712c33fbb51&t=a1e787eb-ec67-5c3d-79ec-0c68f4f59d65

```
yum --nogpgcheck localinstall /mnt/yum/$YUM_NAME -y
+ yum --nogpgcheck localinstall /mnt/yum/azure-cli-2.33.0-1.el7.x86_64.rpm -y
CentOS Linux 8 - AppStream                      445  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

This PR is only a quick fix to unblock CI by reverting to `centos7` which is still supported. (However, `centos7` has its own complication.)

See https://forums.centos.org/viewtopic.php?f=54&t=78708

