### PR TITLE
{CI} Move verify_rpm_in_docker.sh to upstream repo

### DIFF
--- a/scripts/release/rpm/verify_rpm_in_docker.sh
+++ b/scripts/release/rpm/verify_rpm_in_docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This script should be run in a docker to verify installing rpm package from the yum repository.
+
+rpm --import https://packages.microsoft.com/keys/microsoft.asc
+sh -c 'echo -e "[azure-cli]
+name=Azure CLI
+baseurl=https://packages.microsoft.com/yumrepos/azure-cli
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc" > /etc/yum.repos.d/azure-cli.repo'
+
+counter=4
+
+while [ $counter -gt 0 ]
+do
+    yum install azure-cli -y
+    ACTUAL_VERSION=$(az version | sed -n 's|"azure-cli": "\(.*\)",|\1|p' | sed 's|[[:space:]]||g')
+    echo "actual version:${ACTUAL_VERSION}"
+    echo "expected version:${CLI_VERSION}"
+
+    if [ "$ACTUAL_VERSION" != "$CLI_VERSION" ]; then
+        if [ ! -z "$ACTUAL_VERSION" ]; then
+            echo "Latest package is not in the repo."
+            exit 1
+        fi
+        echo "wait 5m"
+        sleep 300
+        counter=$(( $counter - 1 ))
+    else
+        echo "Latest package is verified."
+        exit 0
+    fi
+done
+echo "Timeout!"
+exit 1


### PR DESCRIPTION
**Description**<!--Mandatory-->

Similar to https://github.com/Azure/azure-cli/pull/19463

CI task [Verify RPM](https://dev.azure.com/azure-sdk/internal/_releaseDefinition?definitionId=79&_a=definition-tasks&environmentId=190) relies on https://raw.githubusercontent.com/fengzhou-msft/azure-cli/release_scripts/scripts/release/rpm/verify_rpm_in_docker.sh

This PR moves this script to upstream repo.

