### PR TITLE
{RDBMS}: Switch to Offline migration by default for PG single to flex migrations

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -332,8 +332,6 @@ examples:
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --db-names db1 db2
   - name: Allow the migration workflow to overwrite the DB on the target.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --overwrite-dbs
-  - name: Cutover the data migration. After this is complete, subsequent updates to the source DB will not be migrated to the target.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --cutover
   - name: This command helps in starting the data migration immediately between the source and target. Any migration scheduled for a future date and time will be cancelled.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --start-data-migration
 """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -637,8 +637,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                                help='Space-separated list of DBs to migrate. A minimum of 1 and a maximum of 8 DBs can be specified. You can migrate more DBs concurrently using additional migrations. Note that each additional DB affects the performance of the source server.')
                     c.argument('overwrite_dbs', options_list=['--overwrite-dbs'], action='store_true', required=False,
                                help='Allow the migration workflow to overwrite the DB on the target.')
-                    c.argument('cutover', options_list=['--cutover'], action='store_true', required=False,
-                               help='Cut-over the data migration. After this is complete, subsequent updates to the source DB will not be migrated to the target.')
                     c.argument('start_data_migration', options_list=['--start-data-migration'], action='store_true', required=False,
                                help='Reschedule the data migration to start right now.')
                 elif scope == "delete":

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -55,7 +55,7 @@ def migration_create_func(cmd, client, resource_group_name, server_name, propert
     with open(properties_filepath, "r") as f:
         try:
             request_payload = json.load(f)
-            request_payload.get("properties")['TriggerCutover']='true'
+            request_payload.get("properties")['TriggerCutover'] = 'true'
             json_data = json.dumps(request_payload)
         except ValueError as err:
             logger.error(err)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -54,11 +54,12 @@ def migration_create_func(cmd, client, resource_group_name, server_name, propert
         raise FileOperationError("Properties file does not exist in the given location")
     with open(properties_filepath, "r") as f:
         try:
-            json_data = json.dumps(json.load(f))
+            request_payload = json.load(f)
+            request_payload.get("properties")['TriggerCutover']='true'
+            json_data = json.dumps(request_payload)
         except ValueError as err:
             logger.error(err)
             raise BadRequestError("Invalid json file. Make sure that the json file content is properly formatted.")
-
     if migration_name is None:
         # Convert a UUID to a string of hex digits in standard form
         migration_name = str(uuid.uuid4())
@@ -85,7 +86,7 @@ def migration_list_func(cmd, client, resource_group_name, server_name, migration
     return r.json()
 
 
-def migration_update_func(cmd, client, resource_group_name, server_name, migration_name, setup_logical_replication=None, db_names=None, overwrite_dbs=None, cutover=None, start_data_migration=None):
+def migration_update_func(cmd, client, resource_group_name, server_name, migration_name, setup_logical_replication=None, db_names=None, overwrite_dbs=None, start_data_migration=None):
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
@@ -108,12 +109,6 @@ def migration_update_func(cmd, client, resource_group_name, server_name, migrati
             raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
         operationSpecified = True
         properties = "{\"properties\": {\"overwriteDBsInTarget\": \"true\"} }"
-
-    if cutover is True:
-        if operationSpecified is True:
-            raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
-        operationSpecified = True
-        properties = "{\"properties\": {\"triggerCutover\": \"true\"} }"
 
     if start_data_migration is True:
         if operationSpecified is True:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
1. In create migration, sending {"cutover":"true"} flag always to automatically cutover a migration and not go in logical migration phase.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
