### PR TITLE
[FunctionAPP] `az functionapp plan`: Update the max_val of `--max-burst` to 100

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -116,10 +116,10 @@ def validate_functionapp_asp_create(namespace):
     if namespace.max_burst is not None:
         if tier.lower() != "elasticpremium":
             raise ArgumentUsageError("--max-burst is only supported for Elastic Premium (EP) plans")
-        namespace.max_burst = validate_range_of_int_flag('--max-burst', namespace.max_burst, min_val=0, max_val=20)
+        namespace.max_burst = validate_range_of_int_flag('--max-burst', namespace.max_burst, min_val=0, max_val=100)
     if namespace.number_of_workers is not None:
         namespace.number_of_workers = validate_range_of_int_flag('--number-of-workers / --min-elastic-worker-count',
-                                                                 namespace.number_of_workers, min_val=0, max_val=20)
+                                                                 namespace.number_of_workers, min_val=0, max_val=100)
 
 
 def validate_app_or_slot_exists_in_rg(cmd, namespace):


### PR DESCRIPTION
As per below article for PremiumPlan Max scale out is 100. 
https://docs.microsoft.com/en-us/azure/azure-functions/functions-premium-plan?tabs=portal#region-max-scale-out

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

Fixes #21225