### PR TITLE
{Compute} `az vm update`: Remove space from one license type value 'SLES_STANDARD'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -69,7 +69,7 @@ def load_arguments(self, _):
              "Windows Server, use 'Windows_Server'. To enable Multi-tenant Hosting Rights for Windows 10, "
              "use 'Windows_Client'. For more information see the Azure Windows VM online docs.",
         arg_type=get_enum_type(['Windows_Server', 'Windows_Client', 'RHEL_BYOS', 'SLES_BYOS', 'RHEL_BASE',
-                                'RHEL_SAPAPPS', 'RHEL_SAPHA', 'RHEL_EUS', 'RHEL_BASESAPAPPS', 'RHEL_BASESAPHA', 'SLES_STANDARD ', 'SLES_SAP', 'SLES_HPC',
+                                'RHEL_SAPAPPS', 'RHEL_SAPHA', 'RHEL_EUS', 'RHEL_BASESAPAPPS', 'RHEL_BASESAPHA', 'SLES_STANDARD', 'SLES_SAP', 'SLES_HPC',
                                 'None', 'RHEL_ELS_6']))
 
     # StorageAccountTypes renamed to DiskStorageAccountTypes in 2018_06_01 of azure-mgmt-compute


### PR DESCRIPTION
Remove space from SLES_STANDARD license type enum

**Description**<!--Mandatory-->
Remove space from SLES_STANDARD license type enum


**Testing Guide**
az vm update --license-type 'SLES_STANDARD'

**History Notes**
Customer got issue: > az vm update: 'SLES_STANDARD' is not a valid value for '--license-type'. 
> Allowed values: Windows_Server, Windows_Client, RHEL_BYOS, SLES_BYOS, 
> RHEL_BASE, RHEL_SAPAPPS, RHEL_SAPHA, RHEL_EUS, SLES_STANDARD , SLES_SAP, 
> SLES_HPC, None, RHEL_ELS_6

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ Y] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ Y] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ Y] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
