### PR TITLE
{Core} Discard `tenant_id` in `get_token`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -56,6 +56,11 @@ class CredentialAdaptor:
 
     def get_token(self, *scopes, **kwargs):
         logger.debug("CredentialAdaptor.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
+
+        # SDK azure-keyvault-keys 4.5.0b5 passes tenant_id as kwargs, but we don't support tenant_id for now,
+        # so discard it.
+        kwargs.pop('tenant_id', None)
+
         scopes = _normalize_scopes(scopes)
         token, _ = self._get_token(scopes, **kwargs)
         return token


### PR DESCRIPTION
**Description**<!--Mandatory-->

`azure-keyvault-keys==4.5.0b5` made a breaking change for authentication:

- https://github.com/Azure/azure-sdk-for-python/pull/21290

It uses `azure-identity`'s new multi-tenant authentication API `get_token(tenant_id=...)` from

- https://github.com/Azure/azure-sdk-for-python/pull/20940

However, the current authentication of Azure CLI cannot handle `get_token(tenant_id=...)` because **a credential inherits from an MSAL application**, so `tenant_id` is fixed during the initialization of a credential/MSAL application. In order to support `get_token(tenant_id=...)`, the MSAL application must be created during `get_token`, which requires a total overhaul of the authentication mechanism.

As currently Azure CLI can't automatically get an access token from another tenant for keyvault data-plane operations, we discard `tenant_id` in `get_token` so that there will be no behavior change while supporting `azure-keyvault-keys==4.5.0b5`.

Also see: https://github.com/Azure/azure-cli/pull/20880