### PR TITLE
{Packaging} Build RPM with Mariner 2.0 image

### DIFF
--- a/scripts/release/rpm/Dockerfile.mariner
+++ b/scripts/release/rpm/Dockerfile.mariner
@@ -1,6 +1,6 @@
-ARG tag=1.0
+ARG tag=2.0.20211216-amd64
 
-FROM cblmariner.azurecr.io/base/core:${tag} AS build-env
+FROM cblmariner2preview.azurecr.io/base/core:${tag} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y

--- a/scripts/release/rpm/Dockerfile.mariner
+++ b/scripts/release/rpm/Dockerfile.mariner
@@ -1,4 +1,4 @@
-ARG tag=2.0.20211216-amd64
+ARG tag=2.0
 
 FROM cblmariner2preview.azurecr.io/base/core:${tag} AS build-env
 ARG cli_version=dev

--- a/scripts/release/rpm/Dockerfile.mariner
+++ b/scripts/release/rpm/Dockerfile.mariner
@@ -14,7 +14,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
 
-FROM cblmariner.azurecr.io/base/core:${tag} AS execution-env
+FROM cblmariner2preview.azurecr.io/base/core:${tag} AS execution-env
 
 RUN tdnf update -y
 RUN tdnf install -y python3 python3-virtualenv


### PR DESCRIPTION
**Description**<!--Mandatory-->

According to the mail conversation, Mariner 1.0 is a little outdated. Mariner 2.0 is latest. As public access to cblmariner2preview.azurecr.io has been granted, we should be able to access Mariner 2.0 anonymously.

Email: _Use Mariner 2.0 to build Azure CLI_
