### PR TITLE
{az} use runpy instead of os.execl

### DIFF
--- a/src/azure-cli/az
+++ b/src/azure-cli/az
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import runpy
 import sys
 import os
 
@@ -16,4 +17,4 @@ else:
 if os.environ.get('AZ_INSTALLER') is None:
     os.environ['AZ_INSTALLER'] = 'PIP'
 
-os.execl(sys.executable, sys.executable, '-m', 'azure.cli', *sys.argv[1:])
+runpy.run_module('azure.cli')


### PR DESCRIPTION
**Description**

python -m adds the current working directory to the start of sys.path,
which means running from say /tmp with a fake azure.py causes az to load
it and run it:

  $ cd /tmp
  $ echo 'raise RuntimeError(pwned)' > azure.py
  $ az --help
    Traceback (most recent call last):
      File "/usr/lib/python3.9/runpy.py", line 188, in _run_module_as_main
        mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
      File "/usr/lib/python3.9/runpy.py", line 111, in _get_module_details
        __import__(pkg_name)
      File "/tmp/azure.py", line 1, in <module>
        raise RuntimeError("pwned")
    RuntimeError: pwned

Use runpy instead.

Original report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1005251

Reported-by: Jakub Wilk <jwilk@jwilk.net>


<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Breaking Changes | Tests |
| :--: | :--: |
| ️✔️ None | ️✔️ 130/130 |

<!-- act-bot:section title="AzureCLI-BreakingChangeTest" category="breaking_change" label="Breaking Changes" status="Succeeded" summary="None" -->

<!-- act-bot:section-end -->

<!-- act-bot:section title="AzureCLI-FullTest" category="test" label="Tests" status="Succeeded" summary="130/130" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->