### PR TITLE
{Misc} Restore debugger to execute `--help` out-of-the-box

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,7 @@
             "program": "${workspaceRoot}/src/azure-cli/azure/cli/__main__.py",
             "cwd": "${workspaceRoot}",
             "args": [
-                "ts",
-                "export",
-                "-s",
-                 "/subscriptions/a1bfa635-f2bf-42f1-86b5-848c674fc321/resourceGroups/Gokul-TestRG4/providers/Microsoft.Resources/templateSpecs/testTS/versions/1",
-                "--output-folder",
-                 "C:\\Users\\daetienn\\Desktop\\ExportBugOutput2"
+                "--help"
             ],
             "console": "integratedTerminal",
             "debugOptions": [


### PR DESCRIPTION
**Description**

A previous change wrote arguments into launch.json's integrated console debugger.

This change reverts that change and sets the default args collection to execute `--help`.

**Testing Guide**

1. Setup your machine following the Developer Setup: https://github.com/azure/azure-cli#developer-setup
1. Open the repository in Visual Studio Code
1. Debug the Azure CLI

**History Notes**

n/a

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
