### PR TITLE
[RDBMS] Fix bug for private dns zone provisioning to vnet resource group in different subscription 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -209,7 +209,7 @@ def prepare_private_dns_zone(db_context, database_engine, resource_group, server
     server_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=get_subscription_id(cmd.cli_ctx))
     vnet_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=vnet_subscription)
     dns_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=dns_subscription)
-    
+
     # check existence DNS zone and change resource group
     if dns_rg is not None:
         _create_and_verify_resource_group(dns_sub_resource_client, dns_rg, location, yes)

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_virtual_network.py
@@ -181,9 +181,9 @@ def prepare_private_dns_zone(db_context, database_engine, resource_group, server
         private_dns_zone_suffix = '.' + private_dns_zone_suffix
 
     # Get Vnet Components
-    vnet_sub, vnet_rg, vnet_name, _ = get_id_components(subnet_id)
-    nw_client = network_client_factory(cmd.cli_ctx, subscription_id=vnet_sub)
-    vnet_id = resource_id(subscription=vnet_sub,
+    vnet_subscription, vnet_rg, vnet_name, _ = get_id_components(subnet_id)
+    nw_client = network_client_factory(cmd.cli_ctx, subscription_id=vnet_subscription)
+    vnet_id = resource_id(subscription=vnet_subscription,
                           resource_group=vnet_rg,
                           namespace='Microsoft.Network',
                           type='virtualNetworks',
@@ -192,7 +192,7 @@ def prepare_private_dns_zone(db_context, database_engine, resource_group, server
 
     # Process private dns zone (no input or Id input)
     dns_rg = None
-    dns_subscription = get_subscription_id(cmd.cli_ctx)
+    dns_subscription = vnet_subscription
     if private_dns_zone is None:
         if 'private' in private_dns_zone_suffix:
             private_dns_zone = server_name + private_dns_zone_suffix
@@ -206,34 +206,33 @@ def prepare_private_dns_zone(db_context, database_engine, resource_group, server
                               private_dns_zone=private_dns_zone,
                               private_dns_zone_suffix=private_dns_zone_suffix)
 
-    # client factories
-    if dns_subscription != get_subscription_id(cmd.cli_ctx):
-        logger.warning('The provided private DNS zone ID is in different subscription from the server')
-        subscription_id = dns_subscription
-    else:
-        subscription_id = get_subscription_id(cmd.cli_ctx)
-    resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=subscription_id)
-    private_dns_client = private_dns_client_factory(cmd.cli_ctx, subscription_id=subscription_id)
-    private_dns_link_client = private_dns_link_client_factory(cmd.cli_ctx, subscription_id=subscription_id)
-
+    server_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=get_subscription_id(cmd.cli_ctx))
+    vnet_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=vnet_subscription)
+    dns_sub_resource_client = resource_client_factory(cmd.cli_ctx, subscription_id=dns_subscription)
+    
     # check existence DNS zone and change resource group
     if dns_rg is not None:
-        _create_and_verify_resource_group(resource_client, dns_rg, location, yes)
+        _create_and_verify_resource_group(dns_sub_resource_client, dns_rg, location, yes)
 
     # decide which resource group the dns zone provision
     zone_exist_flag = False
-    if dns_rg is not None and check_existence(resource_client, private_dns_zone, dns_rg, 'Microsoft.Network', 'privateDnsZones'):
+    if dns_rg is not None and check_existence(dns_sub_resource_client, private_dns_zone, dns_rg, 'Microsoft.Network', 'privateDnsZones'):
         zone_exist_flag = True
-    elif dns_rg is None and check_existence(resource_client, private_dns_zone, resource_group, 'Microsoft.Network', 'privateDnsZones'):
+    elif dns_rg is None and check_existence(server_sub_resource_client, private_dns_zone, resource_group, 'Microsoft.Network', 'privateDnsZones'):
         zone_exist_flag = True
         dns_rg = resource_group
-    elif dns_rg is None and check_existence(resource_client, private_dns_zone, vnet_rg, 'Microsoft.Network', 'privateDnsZones'):
+        dns_subscription = get_subscription_id(cmd.cli_ctx)
+    elif dns_rg is None and check_existence(vnet_sub_resource_client, private_dns_zone, vnet_rg, 'Microsoft.Network', 'privateDnsZones'):
         zone_exist_flag = True
+        dns_subscription = vnet_subscription
         dns_rg = vnet_rg
     elif dns_rg is None:
         zone_exist_flag = False
+        dns_subscription = vnet_subscription
         dns_rg = vnet_rg
 
+    private_dns_client = private_dns_client_factory(cmd.cli_ctx, subscription_id=dns_subscription)
+    private_dns_link_client = private_dns_link_client_factory(cmd.cli_ctx, subscription_id=dns_subscription)
     link = VirtualNetworkLink(location='global', virtual_network=SubResource(id=vnet.id))
     link.registration_enabled = False
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix for:
Creating private dns zone for Postgres/MySQL server when vnet exists in another subscription fails

**Testing Guide**
<!--Example commands with explanations.-->
Since test recording doesn't support multiple subscriptions (marked to 0000), cannot implement a separate tests for this. 
Live testing will need exposing subscription ID in public repo. 

Manual tests and existing comprehensive vnet / private dns zone tests passed

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
