### PR TITLE
{CI} Generate SBOM manifest for built packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,8 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
+      PackageName: 'Azure CLI'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'
@@ -263,7 +265,7 @@ jobs:
       filePath: scripts/release/docker/pipeline.sh
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 'SBOM'
+    displayName: 'SBOM'
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
@@ -322,6 +324,11 @@ jobs:
     inputs:
       versionSpec: 3.10
 
+  - bash: |
+       set -exv
+       CLI_VERSION=`cat $SYSTEM_ARTIFACTSDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
+
   - script: |
       if [[ "$(Build.Reason)" == "PullRequest" ]]; then
         branch=$(System.PullRequest.TargetBranch)
@@ -335,6 +342,8 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure CLI'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,20 +264,20 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/docker/pipeline.sh
 
-  - bash: |
-       #!/bin/bash
-       root=$(cd $(dirname $0); pwd)
-       set -evx
-       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-    displayName: 'SBOM Prepare'
-
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 'SBOM'
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
-      DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
+#  - bash: |
+#       #!/bin/bash
+#       root=$(cd $(dirname $0); pwd)
+#       set -evx
+#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+#    displayName: 'SBOM Prepare'
+#
+#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#      displayName: 'SBOM'
+#    inputs:
+#      BuildDropPath: $(Build.ArtifactStagingDirectory)
+#      DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
+#      PackageName: 'Azure Cli'
+#      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: docker image'
@@ -342,19 +342,19 @@ jobs:
       scripts/release/pypi/build.sh $branch
     displayName: 'Run Wheel Build Script'
 
-  - bash: |
-       #!/bin/bash
-       root=$(cd $(dirname $0); pwd)
-       set -evx
-       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-    displayName: 'SBOM Prepare'
-
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'SBOM'
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
+#  - bash: |
+#       #!/bin/bash
+#       root=$(cd $(dirname $0); pwd)
+#       set -evx
+#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+#    displayName: 'SBOM Prepare'
+#
+#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#    displayName: 'SBOM'
+#    inputs:
+#      BuildDropPath: $(Build.ArtifactStagingDirectory)
+#      PackageName: 'Azure Cli'
+#      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'
@@ -733,19 +733,19 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
 
-  - bash: |
-       #!/bin/bash
-       root=$(cd $(dirname $0); pwd)
-       set -evx
-       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-    displayName: 'SBOM Prepare'
-
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'SBOM'
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
+#  - bash: |
+#       #!/bin/bash
+#       root=$(cd $(dirname $0); pwd)
+#       set -evx
+#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+#    displayName: 'SBOM Prepare'
+#
+#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#    displayName: 'SBOM'
+#    inputs:
+#      BuildDropPath: $(Build.ArtifactStagingDirectory)
+#      PackageName: 'Azure Cli'
+#      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum-mariner'
@@ -765,19 +765,19 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
 
-  - bash: |
-       #!/bin/bash
-       root=$(cd $(dirname $0); pwd)
-       set -evx
-       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-    displayName: 'SBOM Prepare'
-
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'SBOM'
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
+#  - bash: |
+#       #!/bin/bash
+#       root=$(cd $(dirname $0); pwd)
+#       set -evx
+#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+#    displayName: 'SBOM Prepare'
+#
+#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#    displayName: 'SBOM'
+#    inputs:
+#      BuildDropPath: $(Build.ArtifactStagingDirectory)
+#      PackageName: 'Azure Cli'
+#      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum'
@@ -875,19 +875,19 @@ jobs:
       DISTRO: $(distro)
       DISTRO_BASE_IMAGE: $(deb_system):$(distro)
 
-  - bash: |
-       #!/bin/bash
-       root=$(cd $(dirname $0); pwd)
-       set -evx
-       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-    displayName: 'SBOM Prepare'
-
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'SBOM'
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
+#  - bash: |
+#       #!/bin/bash
+#       root=$(cd $(dirname $0); pwd)
+#       set -evx
+#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+#    displayName: 'SBOM Prepare'
+#
+#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+#    displayName: 'SBOM'
+#    inputs:
+#      BuildDropPath: $(Build.ArtifactStagingDirectory)
+#      PackageName: 'Azure Cli'
+#      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: debian'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ jobs:
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'
@@ -265,12 +265,12 @@ jobs:
       filePath: scripts/release/docker/pipeline.sh
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'SBOM'
+      displayName: 'SBOM'
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: docker image'
@@ -340,7 +340,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'
@@ -632,7 +632,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: homebrew'
@@ -724,7 +724,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum-mariner'
@@ -749,7 +749,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum'
@@ -852,7 +852,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '2.33.0'
+      PackageVersion: '$CLI_VERSION'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: debian'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -324,11 +324,6 @@ jobs:
     inputs:
       versionSpec: 3.10
 
-  - bash: |
-       set -exv
-       CLI_VERSION='2.33.0'
-    displayName: 'SBOM Prepare'
-
   - script: |
       if [[ "$(Build.Reason)" == "PullRequest" ]]; then
         branch=$(System.PullRequest.TargetBranch)
@@ -342,8 +337,6 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure CLI'
-      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,6 +172,13 @@ jobs:
        build_scripts/windows/scripts/build.cmd
     displayName: 'Build Windows MSI'
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: 'build_scripts/windows/out/'
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
+
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'
     inputs:
@@ -257,6 +264,13 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/docker/pipeline.sh
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: docker image'
@@ -312,7 +326,6 @@ jobs:
     inputs:
       versionSpec: 3.10
 
-
   - script: |
       if [[ "$(Build.Reason)" == "PullRequest" ]]; then
         branch=$(System.PullRequest.TargetBranch)
@@ -322,12 +335,19 @@ jobs:
       scripts/release/pypi/build.sh $branch
     displayName: 'Run Wheel Build Script'
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'
     inputs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: pypi
+
 
 - job: TestPythonWheel
   displayName: Test Python Wheels
@@ -607,6 +627,13 @@ jobs:
        docker rm --force azurecli
     displayName: 'Build homebrew formula'
 
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
+
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: homebrew'
     inputs:
@@ -691,6 +718,14 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
+
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum-mariner'
     inputs:
@@ -708,6 +743,14 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
+
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum'
     inputs:
@@ -803,6 +846,13 @@ jobs:
     env:
       DISTRO: $(distro)
       DISTRO_BASE_IMAGE: $(deb_system):$(distro)
+
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      PackageName: 'Azure Cli'
+      PackageVersion: '2.33.0'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: debian'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,8 +176,6 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'
@@ -645,8 +643,6 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
-      PackageName: 'Azure Cli'
-      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: homebrew'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,6 +264,13 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/docker/pipeline.sh
 
+  - bash: |
+       #!/bin/bash
+       root=$(cd $(dirname $0); pwd)
+       set -evx
+       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'SBOM'
     inputs:
@@ -334,6 +341,13 @@ jobs:
       fi
       scripts/release/pypi/build.sh $branch
     displayName: 'Run Wheel Build Script'
+
+  - bash: |
+       #!/bin/bash
+       root=$(cd $(dirname $0); pwd)
+       set -evx
+       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
@@ -719,6 +733,13 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
 
+  - bash: |
+       #!/bin/bash
+       root=$(cd $(dirname $0); pwd)
+       set -evx
+       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
+
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
     inputs:
@@ -743,6 +764,13 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
+
+  - bash: |
+       #!/bin/bash
+       root=$(cd $(dirname $0); pwd)
+       set -evx
+       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
@@ -846,6 +874,13 @@ jobs:
     env:
       DISTRO: $(distro)
       DISTRO_BASE_IMAGE: $(deb_system):$(distro)
+
+  - bash: |
+       #!/bin/bash
+       root=$(cd $(dirname $0); pwd)
+       set -evx
+       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
+    displayName: 'SBOM Prepare'
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,8 +176,6 @@ jobs:
     displayName: 'SBOM'
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
-      PackageName: 'Azure CLI'
-      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,7 +177,7 @@ jobs:
     inputs:
       BuildDropPath: 'build_scripts/windows/out/'
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: MSI'
@@ -277,7 +277,7 @@ jobs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: docker image'
@@ -354,7 +354,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'
@@ -646,7 +646,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: homebrew'
@@ -745,7 +745,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum-mariner'
@@ -777,7 +777,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum'
@@ -887,7 +887,7 @@ jobs:
     inputs:
       BuildDropPath: $(Build.ArtifactStagingDirectory)
       PackageName: 'Azure Cli'
-      PackageVersion: '$CLI_VERSION'
+      PackageVersion: $CLI_VERSION
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: debian'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,20 +262,11 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/docker/pipeline.sh
 
-#  - bash: |
-#       #!/bin/bash
-#       root=$(cd $(dirname $0); pwd)
-#       set -evx
-#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-#    displayName: 'SBOM Prepare'
-#
-#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#      displayName: 'SBOM'
-#    inputs:
-#      BuildDropPath: $(Build.ArtifactStagingDirectory)
-#      DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
-#      PackageName: 'Azure Cli'
-#      PackageVersion: $CLI_VERSION
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
+      DockerImagesToScan: 'clibuild$BUILD_BUILDNUMBER:latest'
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: docker image'
@@ -340,19 +331,10 @@ jobs:
       scripts/release/pypi/build.sh $branch
     displayName: 'Run Wheel Build Script'
 
-#  - bash: |
-#       #!/bin/bash
-#       root=$(cd $(dirname $0); pwd)
-#       set -evx
-#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-#    displayName: 'SBOM Prepare'
-#
-#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#    displayName: 'SBOM'
-#    inputs:
-#      BuildDropPath: $(Build.ArtifactStagingDirectory)
-#      PackageName: 'Azure Cli'
-#      PackageVersion: $CLI_VERSION
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: pypi'
@@ -729,19 +711,10 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
 
-#  - bash: |
-#       #!/bin/bash
-#       root=$(cd $(dirname $0); pwd)
-#       set -evx
-#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-#    displayName: 'SBOM Prepare'
-#
-#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#    displayName: 'SBOM'
-#    inputs:
-#      BuildDropPath: $(Build.ArtifactStagingDirectory)
-#      PackageName: 'Azure Cli'
-#      PackageVersion: $CLI_VERSION
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum-mariner'
@@ -761,19 +734,10 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
 
-#  - bash: |
-#       #!/bin/bash
-#       root=$(cd $(dirname $0); pwd)
-#       set -evx
-#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-#    displayName: 'SBOM Prepare'
-#
-#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#    displayName: 'SBOM'
-#    inputs:
-#      BuildDropPath: $(Build.ArtifactStagingDirectory)
-#      PackageName: 'Azure Cli'
-#      PackageVersion: $CLI_VERSION
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: yum'
@@ -871,19 +835,10 @@ jobs:
       DISTRO: $(distro)
       DISTRO_BASE_IMAGE: $(deb_system):$(distro)
 
-#  - bash: |
-#       #!/bin/bash
-#       root=$(cd $(dirname $0); pwd)
-#       set -evx
-#       CLI_VERSION=`cat $BUILD_ARTIFACTSTAGINGDIRECTORY/metadata/version`
-#    displayName: 'SBOM Prepare'
-#
-#  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-#    displayName: 'SBOM'
-#    inputs:
-#      BuildDropPath: $(Build.ArtifactStagingDirectory)
-#      PackageName: 'Azure Cli'
-#      PackageVersion: $CLI_VERSION
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM'
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)
 
   - task: PublishPipelineArtifact@0
     displayName: 'Publish Artifact: debian'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -326,7 +326,7 @@ jobs:
 
   - bash: |
        set -exv
-       CLI_VERSION=`cat $SYSTEM_ARTIFACTSDIRECTORY/metadata/version`
+       CLI_VERSION='2.33.0'
     displayName: 'SBOM Prepare'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -343,7 +343,6 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: pypi
 
-
 - job: TestPythonWheel
   displayName: Test Python Wheels
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -322,6 +322,7 @@ jobs:
     inputs:
       versionSpec: 3.10
 
+
   - script: |
       if [[ "$(Build.Reason)" == "PullRequest" ]]; then
         branch=$(System.PullRequest.TargetBranch)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add [ado-sbom-generator-task](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator) to support Generate SBOM (Software Bill of Materials) manifest for built packages.

We need generate SBOM manifest in every artifacts directory.

![image](https://user-images.githubusercontent.com/18628534/156689788-3ffb277a-8c79-44a3-928b-4e57a9df9fdc.png)

But there are two remaining problems：
1. Required packages like azure-mgmt-resource are missing from the built artifact. SBOM team use [component-detection](https://github.com/microsoft/component-detection/blob/main/src/Microsoft.ComponentDetection.Detectors/pip/PipComponentDetector.cs#L18) to detect python packages.
Open two issues in component-detection repo.
[Component detection only find the setup.py file in tools directory.](https://github.com/microsoft/component-detection/issues/73)
[Component detection only match setup.py and requirement.txt file.](https://github.com/microsoft/component-detection/issues/74)
3. Pipeline fail when variables `Packaging.EnableSBOMSigning: true` is set.
error message: 
```diff
- ##[error]The signing feature is not available for your organization yet.
```
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
