### PR TITLE
[SQL] Add federated client id support for sql

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1425,7 +1425,7 @@ def load_arguments(self, _):
                    'UserAssigned, SystemAssigned,UserAssigned and None.')
 
         c.argument('federated_client_id',
-                   options_list=['--federated-client-id', '-fid'],
+                   options_list=['--federated-client-id', '--fid'],
                    help='The federated client id used in cross tenant CMK scenario.')
 
     with self.argument_context('sql server create') as c:

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1424,6 +1424,10 @@ def load_arguments(self, _):
                    help='Type of Identity to be used. Possible values are SystemAsssigned,'
                    'UserAssigned, SystemAssigned,UserAssigned and None.')
 
+        c.argument('federated_client_id',
+                   options_list=['--federated-client-id', '-fid'],
+                   help='The federated client id used in cross tenant CMK scenario.')
+
     with self.argument_context('sql server create') as c:
         c.argument('location',
                    arg_type=get_location_type_with_default_from_resource_group(self.cli_ctx))

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -3535,6 +3535,7 @@ def server_create(
         enable_public_network=None,
         restrict_outbound_network_access=None,
         key_id=None,
+        federated_client_id=None,
         user_assigned_identity_id=None,
         primary_user_assigned_identity_id=None,
         identity_type=None,
@@ -3563,6 +3564,7 @@ def server_create(
             else ServerNetworkAccessFlag.DISABLED)
 
     kwargs['key_id'] = key_id
+    kwargs['federated_client_id'] = federated_client_id
 
     kwargs['primary_user_assigned_identity_id'] = primary_user_assigned_identity_id
 
@@ -3634,6 +3636,7 @@ def server_update(
         restrict_outbound_network_access=None,
         primary_user_assigned_identity_id=None,
         key_id=None,
+        federated_client_id=None,
         identity_type=None,
         user_assigned_identity_id=None):
     '''
@@ -3670,6 +3673,7 @@ def server_update(
         primary_user_assigned_identity_id or instance.primary_user_assigned_identity_id)
 
     instance.key_id = (key_id or instance.key_id)
+    instance.federated_client_id = (federated_client_id or instance.federated_client_id)
 
     return instance
 

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_server_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_server_mgmt.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-02-15T22:01:02Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-02-15T22:28:00Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:11 GMT
+      - Tue, 15 Feb 2022 22:28:09 GMT
       expires:
       - '-1'
       pragma:
@@ -65,10 +65,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -76,11 +76,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:16 GMT
+      - Tue, 15 Feb 2022 22:28:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -110,10 +110,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -122,7 +122,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:18 GMT
+      - Tue, 15 Feb 2022 22:28:16 GMT
       expires:
       - '-1'
       pragma:
@@ -156,10 +156,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -168,7 +168,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:19 GMT
+      - Tue, 15 Feb 2022 22:28:18 GMT
       expires:
       - '-1'
       pragma:
@@ -202,10 +202,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -214,7 +214,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:20 GMT
+      - Tue, 15 Feb 2022 22:28:19 GMT
       expires:
       - '-1'
       pragma:
@@ -248,10 +248,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -260,7 +260,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:21 GMT
+      - Tue, 15 Feb 2022 22:28:20 GMT
       expires:
       - '-1'
       pragma:
@@ -294,10 +294,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -306,7 +306,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:01:41 GMT
+      - Tue, 15 Feb 2022 22:28:40 GMT
       expires:
       - '-1'
       pragma:
@@ -340,10 +340,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"InProgress","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -352,7 +352,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:01 GMT
+      - Tue, 15 Feb 2022 22:29:00 GMT
       expires:
       - '-1'
       pragma:
@@ -386,10 +386,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b005a26a-915f-4238-9a05-326c1e6affa7?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"Succeeded","startTime":"2022-02-15T22:01:16.807Z"}'
+      string: '{"name":"b005a26a-915f-4238-9a05-326c1e6affa7","status":"Succeeded","startTime":"2022-02-15T22:28:15.697Z"}'
     headers:
       cache-control:
       - no-cache
@@ -398,7 +398,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:21 GMT
+      - Tue, 15 Feb 2022 22:29:20 GMT
       expires:
       - '-1'
       pragma:
@@ -444,7 +444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:21 GMT
+      - Tue, 15 Feb 2022 22:29:20 GMT
       expires:
       - '-1'
       pragma:
@@ -490,7 +490,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:23 GMT
+      - Tue, 15 Feb 2022 22:29:22 GMT
       expires:
       - '-1'
       pragma:
@@ -536,7 +536,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:24 GMT
+      - Tue, 15 Feb 2022 22:29:22 GMT
       expires:
       - '-1'
       pragma:
@@ -580,22 +580,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:02:28.527Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:29:27.66Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '74'
+      - '73'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:28 GMT
+      - Tue, 15 Feb 2022 22:29:27 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -625,240 +625,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:02:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:02:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:02:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:02:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:02:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"Succeeded","startTime":"2022-02-15T22:02:28.527Z"}'
+      string: '{"name":"4cbf90af-0081-4f24-8538-3ff14a2ea9c9","status":"InProgress","startTime":"2022-02-15T22:29:27.66Z"}'
     headers:
       cache-control:
       - no-cache
@@ -867,7 +637,191 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:54 GMT
+      - Tue, 15 Feb 2022 22:29:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"4cbf90af-0081-4f24-8538-3ff14a2ea9c9","status":"InProgress","startTime":"2022-02-15T22:29:27.66Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:29:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"4cbf90af-0081-4f24-8538-3ff14a2ea9c9","status":"InProgress","startTime":"2022-02-15T22:29:27.66Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:29:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"4cbf90af-0081-4f24-8538-3ff14a2ea9c9","status":"InProgress","startTime":"2022-02-15T22:29:27.66Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:29:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/4cbf90af-0081-4f24-8538-3ff14a2ea9c9?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"4cbf90af-0081-4f24-8538-3ff14a2ea9c9","status":"Succeeded","startTime":"2022-02-15T22:29:27.66Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:29:52 GMT
       expires:
       - '-1'
       pragma:
@@ -904,7 +858,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -913,7 +867,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:54 GMT
+      - Tue, 15 Feb 2022 22:29:52 GMT
       expires:
       - '-1'
       pragma:
@@ -950,7 +904,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -959,7 +913,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:02:55 GMT
+      - Tue, 15 Feb 2022 22:29:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1003,10 +957,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1014,11 +968,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:00 GMT
+      - Tue, 15 Feb 2022 22:29:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -1048,10 +1002,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"InProgress","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1060,7 +1014,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:01 GMT
+      - Tue, 15 Feb 2022 22:29:58 GMT
       expires:
       - '-1'
       pragma:
@@ -1094,10 +1048,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"InProgress","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1106,7 +1060,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:02 GMT
+      - Tue, 15 Feb 2022 22:29:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1140,10 +1094,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"InProgress","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1152,7 +1106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:03 GMT
+      - Tue, 15 Feb 2022 22:30:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1186,10 +1140,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"InProgress","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1198,7 +1152,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:04 GMT
+      - Tue, 15 Feb 2022 22:30:02 GMT
       expires:
       - '-1'
       pragma:
@@ -1232,10 +1186,56 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"Succeeded","startTime":"2022-02-15T22:03:00.077Z"}'
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"InProgress","startTime":"2022-02-15T22:29:58.183Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/a6217e3d-84f7-45b6-8093-88ac1ab086eb?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"a6217e3d-84f7-45b6-8093-88ac1ab086eb","status":"Succeeded","startTime":"2022-02-15T22:29:58.183Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1244,7 +1244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:24 GMT
+      - Tue, 15 Feb 2022 22:30:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1281,7 +1281,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -1290,7 +1290,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:25 GMT
+      - Tue, 15 Feb 2022 22:30:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1333,22 +1333,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:03:35.807Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:30:32.34Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '74'
+      - '73'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:03:35 GMT
+      - Tue, 15 Feb 2022 22:30:31 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -1378,286 +1378,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:03:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:03:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:03:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:03:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:04:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:04:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"Succeeded","startTime":"2022-02-15T22:03:35.807Z"}'
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1666,7 +1390,329 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:42 GMT
+      - Tue, 15 Feb 2022 22:30:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:30:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"InProgress","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:31:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/76f4cb68-8319-4099-94c5-f227834b5fcc?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"76f4cb68-8319-4099-94c5-f227834b5fcc","status":"Succeeded","startTime":"2022-02-15T22:30:32.34Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:31:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1703,7 +1749,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"08aaf393-148b-49e8-9efb-93e675ff2d36","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -1712,7 +1758,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:42 GMT
+      - Tue, 15 Feb 2022 22:31:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1749,7 +1795,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"value":[{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}]}'
+      string: '{"value":[{"identity":{"principalId":"08aaf393-148b-49e8-9efb-93e675ff2d36","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}]}'
     headers:
       cache-control:
       - no-cache
@@ -1758,7 +1804,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:42 GMT
+      - Tue, 15 Feb 2022 22:31:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1794,7 +1840,7 @@ interactions:
   response:
     body:
       string: '{"value":[{"kind":"v12.0","properties":{"administratorLogin":"perm-test-admin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"perm-test-server.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"User","login":"David
-        Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/perm-test-server","name":"perm-test-server","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"rajatjbottest.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rajatjTestBot/providers/Microsoft.Sql/servers/rajatjbottest","name":"rajatjbottest","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"viditgupta","version":"12.0","state":"Ready","fullyQualifiedDomainName":"viditgupta-aev2-server.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"User","login":"viditgupta@microsoft.com","sid":"0c575f28-5872-44f9-b0bc-c58aaa5dca7f","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"uksouth","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/viditgupta-uksouth-resource-group/providers/Microsoft.Sql/servers/viditgupta-aev2-server","name":"viditgupta-aev2-server","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"thebrave","version":"12.0","state":"Ready","fullyQualifiedDomainName":"david-brookler.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"Group","login":"David
+        Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/perm-test-server","name":"perm-test-server","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"rajatjbottest.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rajatjTestBot/providers/Microsoft.Sql/servers/rajatjbottest","name":"rajatjbottest","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"viditgupta","version":"12.0","state":"Ready","fullyQualifiedDomainName":"viditgupta-aev2-server.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"User","login":"viditgupta@microsoft.com","sid":"0c575f28-5872-44f9-b0bc-c58aaa5dca7f","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"uksouth","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/viditgupta-uksouth-resource-group/providers/Microsoft.Sql/servers/viditgupta-aev2-server","name":"viditgupta-aev2-server","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"08aaf393-148b-49e8-9efb-93e675ff2d36","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"thebrave","version":"12.0","state":"Ready","fullyQualifiedDomainName":"david-brookler.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"Group","login":"David
         Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/david-brookler","name":"david-brookler","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"st-admin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"semantic-tables.database.windows.net","privateEndpointConnections":[],"administrators":{"administratorType":"ActiveDirectory","principalType":"Group","login":"David
         Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"restrictOutboundNetworkAccess":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/semantic-tables","name":"semantic-tables","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"43763251-7fb7-466b-852e-de6f83fe6460","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"dctestadmin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"dabrookl-dc-test.database.windows.net","privateEndpointConnections":[],"restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/dabrookl-dc-test","name":"dabrookl-dc-test","type":"Microsoft.Sql/servers"},{"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansoTestumi":{"principalId":"d9db8af7-b98c-4788-83be-04de40f6600d","clientId":"474cad2d-d417-4faa-8589-0462a2407de9"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansonoperm":{"principalId":"39c5ff5e-2157-42dd-a631-0b132f48162d","clientId":"9ef25eb7-3227-46f3-9e8b-55072a8284f3"}},"principalId":"88a4fc29-a1ce-4790-9784-fb2512f3420c","type":"SystemAssigned,UserAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"alswanso","version":"12.0","state":"Disabled","fullyQualifiedDomainName":"alswansocanary2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","primaryUserAssignedIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansonoperm","keyId":"https://alswansotestkv2.vault.azure.net/keys/testkey/0880af041d3c478795c4496fddc94cd3","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alswansotest3-rg/providers/Microsoft.Sql/servers/alswansocanary2","name":"alswansocanary2","type":"Microsoft.Sql/servers"}]}'
     headers:
@@ -1805,7 +1851,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:43 GMT
+      - Tue, 15 Feb 2022 22:31:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1817,11 +1863,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - 8f2cce3d-2f3f-455a-a54c-840c766dc2ea
-      - d92ff06a-f536-4c22-b2de-1ab4e203fea3
-      - 929109c6-0309-4ed8-8bd5-6c503635813d
-      - 39ffb4bd-eca6-4455-ab58-c788cc46922b
-      - 8ff89ad0-19b8-4318-b68d-ff9e331655b7
+      - 5ae05fe5-27ee-4001-9cc1-241bcd52ab12
+      - 4f6d2cbd-b05f-4268-aa0c-1421ca9a5bb4
+      - 09770df6-2986-4bcc-b6f8-c06aeec5b5aa
+      - dad66351-d244-434d-b209-ea534b48f29e
+      - 540fd5e8-375b-4af1-b59f-aaa096ebbaaf
     status:
       code: 200
       message: OK
@@ -1844,7 +1890,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -1853,7 +1899,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:43 GMT
+      - Tue, 15 Feb 2022 22:31:41 GMT
       expires:
       - '-1'
       pragma:
@@ -1890,7 +1936,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"18e8a3c2-45dc-40ae-ba2a-5744b9327ed5","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -1899,7 +1945,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:44 GMT
+      - Tue, 15 Feb 2022 22:31:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1949,7 +1995,7 @@ interactions:
       dataserviceversion:
       - 3.0;
       date:
-      - Tue, 15 Feb 2022 22:04:45 GMT
+      - Tue, 15 Feb 2022 22:31:42 GMT
       server:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
@@ -1984,10 +2030,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:04:49.127Z"}'
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:31:46.523Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/561c7c4e-497a-4c7d-934a-3112f774d90e?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1995,11 +2041,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:04:48 GMT
+      - Tue, 15 Feb 2022 22:31:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/561c7c4e-497a-4c7d-934a-3112f774d90e?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -2029,10 +2075,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/561c7c4e-497a-4c7d-934a-3112f774d90e?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"c7678375-808c-44ce-88b4-4d64932bb916","status":"Succeeded","startTime":"2022-02-15T22:04:49.127Z"}'
+      string: '{"name":"561c7c4e-497a-4c7d-934a-3112f774d90e","status":"Succeeded","startTime":"2022-02-15T22:31:46.523Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2041,7 +2087,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:05:03 GMT
+      - Tue, 15 Feb 2022 22:32:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2080,10 +2126,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:05:06.243Z"}'
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:32:03.873Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/3d4bfb5f-570b-4882-8c2e-5cd8417923bb?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -2091,11 +2137,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:05:05 GMT
+      - Tue, 15 Feb 2022 22:32:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/3d4bfb5f-570b-4882-8c2e-5cd8417923bb?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -2125,10 +2171,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/3d4bfb5f-570b-4882-8c2e-5cd8417923bb?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"fa30863b-07ce-4fc3-87f0-772b9d2f86f6","status":"Succeeded","startTime":"2022-02-15T22:05:06.243Z"}'
+      string: '{"name":"3d4bfb5f-570b-4882-8c2e-5cd8417923bb","status":"Succeeded","startTime":"2022-02-15T22:32:03.873Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2137,7 +2183,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:05:21 GMT
+      - Tue, 15 Feb 2022 22:32:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2183,7 +2229,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:05:22 GMT
+      - Tue, 15 Feb 2022 22:32:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2223,22 +2269,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:05:29.313Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:32:26.45Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '74'
+      - '73'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:05:28 GMT
+      - Tue, 15 Feb 2022 22:32:26 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -2268,332 +2314,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:05:54 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:06:15 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name -l -i --admin-user --admin-password --federated-client-id
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"Succeeded","startTime":"2022-02-15T22:05:29.313Z"}'
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2602,7 +2326,329 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:35 GMT
+      - Tue, 15 Feb 2022 22:32:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:32:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:32:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:32:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:32:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:32:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"InProgress","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/113b4ce1-4dad-4435-b32a-a6922440ef63?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"113b4ce1-4dad-4435-b32a-a6922440ef63","status":"Succeeded","startTime":"2022-02-15T22:32:26.45Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2639,7 +2685,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -2648,7 +2694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:36 GMT
+      - Tue, 15 Feb 2022 22:33:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2685,7 +2731,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -2694,7 +2740,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:36 GMT
+      - Tue, 15 Feb 2022 22:33:34 GMT
       expires:
       - '-1'
       pragma:
@@ -2731,7 +2777,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -2740,7 +2786,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:37 GMT
+      - Tue, 15 Feb 2022 22:33:34 GMT
       expires:
       - '-1'
       pragma:
@@ -2784,10 +2830,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:06:42.203Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:33:38.683Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/62cab30e-8409-4235-9671-95a65ddf08a0?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -2795,11 +2841,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:41 GMT
+      - Tue, 15 Feb 2022 22:33:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/62cab30e-8409-4235-9671-95a65ddf08a0?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -2829,10 +2875,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/62cab30e-8409-4235-9671-95a65ddf08a0?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+      string: '{"name":"62cab30e-8409-4235-9671-95a65ddf08a0","status":"InProgress","startTime":"2022-02-15T22:33:38.683Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2841,7 +2887,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:06:42 GMT
+      - Tue, 15 Feb 2022 22:33:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2875,194 +2921,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/62cab30e-8409-4235-9671-95a65ddf08a0?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:06:44 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password --federated-client-id -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:06:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password --federated-client-id -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:06:46 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password --federated-client-id -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '108'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 15 Feb 2022 22:06:47 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sql server update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name --admin-password --federated-client-id -i
-      User-Agent:
-      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
-  response:
-    body:
-      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"Succeeded","startTime":"2022-02-15T22:06:42.203Z"}'
+      string: '{"name":"62cab30e-8409-4235-9671-95a65ddf08a0","status":"Succeeded","startTime":"2022-02-15T22:33:38.683Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3071,7 +2933,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:07:07 GMT
+      - Tue, 15 Feb 2022 22:33:41 GMT
       expires:
       - '-1'
       pragma:
@@ -3108,7 +2970,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"17deee33-9da7-40ce-a33c-8a96f2f8f07d","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"17deee33-9da7-40ce-a33c-8a96f2f8f07d","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
@@ -3117,7 +2979,430 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:07:07 GMT
+      - Tue, 15 Feb 2022 22:33:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"17deee33-9da7-40ce-a33c-8a96f2f8f07d","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '699'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "identity": {"type": "SystemAssigned"}, "properties":
+      {"administratorLogin": "admin123", "administratorLoginPassword": "SecretPassword789",
+      "version": "12.0", "publicNetworkAccess": "Enabled", "federatedClientId": "00000000-0000-0000-0000-000000000000",
+      "restrictOutboundNetworkAccess": "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '326'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '73'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"InProgress","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"InProgress","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"InProgress","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"InProgress","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"InProgress","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:33:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/ca389b99-bb48-4219-bfec-aaead268090e?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"ca389b99-bb48-4219-bfec-aaead268090e","status":"Succeeded","startTime":"2022-02-15T22:33:46.28Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:34:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"053cbe84-7826-498f-be05-c674f9576c20","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '640'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:34:12 GMT
       expires:
       - '-1'
       pragma:
@@ -3156,22 +3441,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:07:11.527Z"}'
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:34:15.43Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/3a60dbf8-c61f-4635-b27f-d09882d5edf4?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '72'
+      - '71'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:07:11 GMT
+      - Tue, 15 Feb 2022 22:34:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/3a60dbf8-c61f-4635-b27f-d09882d5edf4?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -3201,19 +3486,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/3a60dbf8-c61f-4635-b27f-d09882d5edf4?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"fa324c9f-223f-4093-8ea4-1ab33690254a","status":"Succeeded","startTime":"2022-02-15T22:07:11.527Z"}'
+      string: '{"name":"3a60dbf8-c61f-4635-b27f-d09882d5edf4","status":"Succeeded","startTime":"2022-02-15T22:34:15.43Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 15 Feb 2022 22:07:26 GMT
+      - Tue, 15 Feb 2022 22:34:30 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_server_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_server_mgmt.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-azure-mgmt-resource/18.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2021-06-28T20:10:42Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-02-15T22:01:02Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '432'
+      - '314'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:47 GMT
+      - Tue, 15 Feb 2022 22:01:11 GMT
       expires:
       - '-1'
       pragma:
@@ -60,15 +60,15 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -76,11 +76,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:51 GMT
+      - Tue, 15 Feb 2022 22:01:16 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -108,12 +108,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -122,7 +122,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:53 GMT
+      - Tue, 15 Feb 2022 22:01:18 GMT
       expires:
       - '-1'
       pragma:
@@ -154,12 +154,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -168,7 +168,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:54 GMT
+      - Tue, 15 Feb 2022 22:01:19 GMT
       expires:
       - '-1'
       pragma:
@@ -200,12 +200,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -214,7 +214,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:55 GMT
+      - Tue, 15 Feb 2022 22:01:20 GMT
       expires:
       - '-1'
       pragma:
@@ -246,12 +246,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -260,7 +260,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:10:56 GMT
+      - Tue, 15 Feb 2022 22:01:21 GMT
       expires:
       - '-1'
       pragma:
@@ -292,12 +292,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -306,7 +306,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:17 GMT
+      - Tue, 15 Feb 2022 22:01:41 GMT
       expires:
       - '-1'
       pragma:
@@ -338,12 +338,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"InProgress","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"InProgress","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -352,7 +352,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:37 GMT
+      - Tue, 15 Feb 2022 22:02:01 GMT
       expires:
       - '-1'
       pragma:
@@ -384,12 +384,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/6854e90c-37b6-4769-933b-d7094b38bfd7?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00582b3f-f7b3-4505-b41c-999798e5b5b5?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"6854e90c-37b6-4769-933b-d7094b38bfd7","status":"Succeeded","startTime":"2021-06-28T20:10:51.507Z"}'
+      string: '{"name":"00582b3f-f7b3-4505-b41c-999798e5b5b5","status":"Succeeded","startTime":"2022-02-15T22:01:16.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -398,7 +398,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:57 GMT
+      - Tue, 15 Feb 2022 22:02:21 GMT
       expires:
       - '-1'
       pragma:
@@ -430,7 +430,7 @@ interactions:
       ParameterSetName:
       - -g --name --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
@@ -440,11 +440,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '500'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:58 GMT
+      - Tue, 15 Feb 2022 22:02:21 GMT
       expires:
       - '-1'
       pragma:
@@ -476,7 +476,7 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers?api-version=2021-02-01-preview
   response:
@@ -486,11 +486,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '700'
+      - '512'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:58 GMT
+      - Tue, 15 Feb 2022 22:02:23 GMT
       expires:
       - '-1'
       pragma:
@@ -522,7 +522,7 @@ interactions:
       ParameterSetName:
       - -g --name --admin-password -i
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
@@ -532,11 +532,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '688'
+      - '500'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:11:59 GMT
+      - Tue, 15 Feb 2022 22:02:24 GMT
       expires:
       - '-1'
       pragma:
@@ -575,15 +575,15 @@ interactions:
       ParameterSetName:
       - -g --name --admin-password -i
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2021-06-28T20:12:04.397Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:02:28.527Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/77362575-2d52-4053-83ad-a743734f093c?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -591,11 +591,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:04 GMT
+      - Tue, 15 Feb 2022 22:02:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/77362575-2d52-4053-83ad-a743734f093c?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -623,12 +623,12 @@ interactions:
       ParameterSetName:
       - -g --name --admin-password -i
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/77362575-2d52-4053-83ad-a743734f093c?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"77362575-2d52-4053-83ad-a743734f093c","status":"InProgress","startTime":"2021-06-28T20:12:04.397Z"}'
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
     headers:
       cache-control:
       - no-cache
@@ -637,7 +637,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:05 GMT
+      - Tue, 15 Feb 2022 22:02:29 GMT
       expires:
       - '-1'
       pragma:
@@ -669,12 +669,196 @@ interactions:
       ParameterSetName:
       - -g --name --admin-password -i
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/77362575-2d52-4053-83ad-a743734f093c?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"77362575-2d52-4053-83ad-a743734f093c","status":"Succeeded","startTime":"2021-06-28T20:12:04.397Z"}'
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:02:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:02:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:02:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"InProgress","startTime":"2022-02-15T22:02:28.527Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:02:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/220b45ad-ae6b-49c6-902c-820666d335f3?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"220b45ad-ae6b-49c6-902c-820666d335f3","status":"Succeeded","startTime":"2022-02-15T22:02:28.527Z"}'
     headers:
       cache-control:
       - no-cache
@@ -683,7 +867,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:06 GMT
+      - Tue, 15 Feb 2022 22:02:54 GMT
       expires:
       - '-1'
       pragma:
@@ -715,21 +899,21 @@ interactions:
       ParameterSetName:
       - -g --name --admin-password -i
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:06 GMT
+      - Tue, 15 Feb 2022 22:02:54 GMT
       expires:
       - '-1'
       pragma:
@@ -761,21 +945,21 @@ interactions:
       ParameterSetName:
       - --ids --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:07 GMT
+      - Tue, 15 Feb 2022 22:02:55 GMT
       expires:
       - '-1'
       pragma:
@@ -814,15 +998,15 @@ interactions:
       ParameterSetName:
       - --ids --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2021-06-28T20:12:10.563Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:03:00.077Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/028a6de4-87bd-4dac-8d52-f0be0dcda2c8?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -830,11 +1014,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:10 GMT
+      - Tue, 15 Feb 2022 22:03:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/028a6de4-87bd-4dac-8d52-f0be0dcda2c8?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -862,12 +1046,12 @@ interactions:
       ParameterSetName:
       - --ids --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/028a6de4-87bd-4dac-8d52-f0be0dcda2c8?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"028a6de4-87bd-4dac-8d52-f0be0dcda2c8","status":"InProgress","startTime":"2021-06-28T20:12:10.563Z"}'
+      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
     headers:
       cache-control:
       - no-cache
@@ -876,7 +1060,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:11 GMT
+      - Tue, 15 Feb 2022 22:03:01 GMT
       expires:
       - '-1'
       pragma:
@@ -908,12 +1092,150 @@ interactions:
       ParameterSetName:
       - --ids --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/028a6de4-87bd-4dac-8d52-f0be0dcda2c8?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"028a6de4-87bd-4dac-8d52-f0be0dcda2c8","status":"Succeeded","startTime":"2021-06-28T20:12:10.563Z"}'
+      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:03:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:03:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"InProgress","startTime":"2022-02-15T22:03:00.077Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:03:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --ids --admin-password
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/7f79b3ce-89eb-4624-8258-18b730dbc22a?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"7f79b3ce-89eb-4624-8258-18b730dbc22a","status":"Succeeded","startTime":"2022-02-15T22:03:00.077Z"}'
     headers:
       cache-control:
       - no-cache
@@ -922,7 +1244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:13 GMT
+      - Tue, 15 Feb 2022 22:03:24 GMT
       expires:
       - '-1'
       pragma:
@@ -954,21 +1276,21 @@ interactions:
       ParameterSetName:
       - --ids --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:13 GMT
+      - Tue, 15 Feb 2022 22:03:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1006,15 +1328,15 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1022,11 +1344,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:19 GMT
+      - Tue, 15 Feb 2022 22:03:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -1054,12 +1376,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1068,7 +1390,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:20 GMT
+      - Tue, 15 Feb 2022 22:03:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1100,12 +1422,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1114,7 +1436,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:22 GMT
+      - Tue, 15 Feb 2022 22:03:38 GMT
       expires:
       - '-1'
       pragma:
@@ -1146,12 +1468,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1160,7 +1482,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:23 GMT
+      - Tue, 15 Feb 2022 22:03:39 GMT
       expires:
       - '-1'
       pragma:
@@ -1192,12 +1514,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1206,7 +1528,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:24 GMT
+      - Tue, 15 Feb 2022 22:03:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1238,12 +1560,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1252,7 +1574,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:12:44 GMT
+      - Tue, 15 Feb 2022 22:04:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1284,12 +1606,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"InProgress","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"InProgress","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1298,7 +1620,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:04 GMT
+      - Tue, 15 Feb 2022 22:04:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1330,12 +1652,12 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/40cd40cf-33b9-4c3c-99c1-8b759d45d850?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/b69de77f-ef14-488d-aec4-20751ff9b45f?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"40cd40cf-33b9-4c3c-99c1-8b759d45d850","status":"Succeeded","startTime":"2021-06-28T20:12:20.033Z"}'
+      string: '{"name":"b69de77f-ef14-488d-aec4-20751ff9b45f","status":"Succeeded","startTime":"2022-02-15T22:03:35.807Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1344,7 +1666,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:25 GMT
+      - Tue, 15 Feb 2022 22:04:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1376,21 +1698,21 @@ interactions:
       ParameterSetName:
       - -g --name -l -i --admin-user --admin-password
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"8f0928e0-7991-4c10-8822-bb1801c28b38","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:26 GMT
+      - Tue, 15 Feb 2022 22:04:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1422,21 +1744,21 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"value":[{"identity":{"principalId":"8f0928e0-7991-4c10-8822-bb1801c28b38","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}]}'
+      string: '{"value":[{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '840'
+      - '652'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:26 GMT
+      - Tue, 15 Feb 2022 22:04:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1466,22 +1788,24 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Sql/servers?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"value":[{"kind":"v12.0","properties":{"administratorLogin":"rootuser","version":"12.0","state":"Ready","fullyQualifiedDomainName":"serojatest.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-sero/providers/Microsoft.Sql/servers/serojatest","name":"serojatest","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"mylogin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"jt-northeuropetest.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"northeurope","tags":{"date":"08-10-2020
-        04:02:08Z"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jamestao/providers/Microsoft.Sql/servers/jt-northeuropetest","name":"jt-northeuropetest","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver2dazz4jykcd2ulbavpq6nfls5uaeilb3rqlwc32kywjb6vys6.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgbt4izvfa24kne4x4rhp7i53zvicewj7toa3amx36c3qaxnxcosotfeqxcd4vdo3f3/providers/Microsoft.Sql/servers/clitestserver2dazz4jykcd2ulbavpq6nfls5uaeilb3rqlwc32kywjb6vys6","name":"clitestserver2dazz4jykcd2ulbavpq6nfls5uaeilb3rqlwc32kywjb6vys6","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver2quh22cwet22rv2pfzizx5by4ikyolm66ilwc3ehdppeoyd2c.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rgbt4izvfa24kne4x4rhp7i53zvicewj7toa3amx36c3qaxnxcosotfeqxcd4vdo3f3/providers/Microsoft.Sql/servers/clitestserver2quh22cwet22rv2pfzizx5by4ikyolm66ilwc3ehdppeoyd2c","name":"clitestserver2quh22cwet22rv2pfzizx5by4ikyolm66ilwc3ehdppeoyd2c","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"8f0928e0-7991-4c10-8822-bb1801c28b38","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"mylogin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"jt-westeurope-test.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","tags":{"resourceType":"sql"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jamestao/providers/Microsoft.Sql/servers/jt-westeurope-test","name":"jt-westeurope-test","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"jpacheco","version":"12.0","state":"Ready","fullyQualifiedDomainName":"4aftest-svr.database.windows.net","privateEndpointConnections":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jpacheco/providers/Microsoft.Sql/servers/4aftest-svr/privateEndpointConnections/svr-pl-4elasticjobs-205faf84-207b-4277-8586-eb8a0fa20fc6","properties":{"privateEndpoint":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jpacheco/providers/Microsoft.Network/privateEndpoints/svr-pl-4elasticjobs"},"privateLinkServiceConnectionState":{"status":"Approved","description":"Auto-approved","actionsRequired":"None"},"provisioningState":"Ready"}}],"publicNetworkAccess":"Disabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jpacheco/providers/Microsoft.Sql/servers/4aftest-svr","name":"4aftest-svr","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"mylogin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"jttest1sqlsvreastus.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jamestao/providers/Microsoft.Sql/servers/jttest1sqlsvreastus","name":"jttest1sqlsvreastus","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"mylogin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"jttest1sqlsvrsoutheastasia.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jamestao/providers/Microsoft.Sql/servers/jttest1sqlsvrsoutheastasia","name":"jttest1sqlsvrsoutheastasia","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"4f5d62cd-0111-4da9-9652-f4471a350a8c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"controlplanetelemetryserver.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus2","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Committer-ThrottlingAndQueueing/providers/Microsoft.Sql/servers/controlplanetelemetryserver","name":"controlplanetelemetryserver","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"CloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"mwories-testsvr1.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus2","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Committer-ThrottlingAndQueueing/providers/Microsoft.Sql/servers/mwories-testsvr1","name":"mwories-testsvr1","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"rootuser","version":"12.0","state":"Ready","fullyQualifiedDomainName":"temp-sero-sql.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/temp-sero/providers/Microsoft.Sql/servers/temp-sero-sql","name":"temp-sero-sql","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"ansinh-useuapcentral.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"centraluseuap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-ansinh/providers/Microsoft.Sql/servers/ansinh-useuapcentral","name":"ansinh-useuapcentral","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"ansinh-useuapcentral2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"centraluseuap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-ansinh/providers/Microsoft.Sql/servers/ansinh-useuapcentral2","name":"ansinh-useuapcentral2","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"rootuser","version":"12.0","state":"Ready","fullyQualifiedDomainName":"serocan2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"centraluseuap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-sero/providers/Microsoft.Sql/servers/serocan2","name":"serocan2","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"5e7c7df6-df27-4a24-88ca-189f3c089a78","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"ansinh-useuapeas2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-ansinh/providers/Microsoft.Sql/servers/ansinh-useuapeas2","name":"ansinh-useuapeas2","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"bradrich-canary2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-bradrich/providers/Microsoft.Sql/servers/bradrich-canary2","name":"bradrich-canary2","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"mylogin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"jteuaptest1.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Temp-jamestao/providers/Microsoft.Sql/servers/jteuaptest1","name":"jteuaptest1","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"sqlbuildoutvalidationxstore-1808600.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"swedencentral","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sqlBuildoutRgThatDoesNotExist/providers/Microsoft.Sql/servers/sqlbuildoutvalidationxstore-1808600","name":"sqlbuildoutvalidationxstore-1808600","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"sqlbuildoutvalidationxio-1808603.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"swedensouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sqlBuildoutRgThatDoesNotExist/providers/Microsoft.Sql/servers/sqlbuildoutvalidationxio-1808603","name":"sqlbuildoutvalidationxio-1808603","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"sqlbuildoutvalidationxio-1808637.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"swedensouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sqlBuildoutRgThatDoesNotExist/providers/Microsoft.Sql/servers/sqlbuildoutvalidationxio-1808637","name":"sqlbuildoutvalidationxio-1808637","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudsa","version":"12.0","state":"Ready","fullyQualifiedDomainName":"sqlbuildoutvalidationxio-1819210.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"swedensouth","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sqlBuildoutRgThatDoesNotExist/providers/Microsoft.Sql/servers/sqlbuildoutvalidationxio-1819210","name":"sqlbuildoutvalidationxio-1819210","type":"Microsoft.Sql/servers"}]}'
+      string: '{"value":[{"kind":"v12.0","properties":{"administratorLogin":"perm-test-admin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"perm-test-server.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"User","login":"David
+        Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/perm-test-server","name":"perm-test-server","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"cloudSA","version":"12.0","state":"Ready","fullyQualifiedDomainName":"rajatjbottest.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rajatjTestBot/providers/Microsoft.Sql/servers/rajatjbottest","name":"rajatjbottest","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"viditgupta","version":"12.0","state":"Ready","fullyQualifiedDomainName":"viditgupta-aev2-server.database.windows.net","privateEndpointConnections":[],"minimalTlsVersion":"1.2","publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"User","login":"viditgupta@microsoft.com","sid":"0c575f28-5872-44f9-b0bc-c58aaa5dca7f","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","azureADOnlyAuthentication":false},"restrictOutboundNetworkAccess":"Disabled"},"location":"uksouth","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/viditgupta-uksouth-resource-group/providers/Microsoft.Sql/servers/viditgupta-aev2-server","name":"viditgupta-aev2-server","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"bf314243-8c60-4a07-ba90-55b489dea17f","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000004.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004","name":"clitestserver000004","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"thebrave","version":"12.0","state":"Ready","fullyQualifiedDomainName":"david-brookler.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","administrators":{"administratorType":"ActiveDirectory","principalType":"Group","login":"David
+        Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","tags":{},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/david-brookler","name":"david-brookler","type":"Microsoft.Sql/servers"},{"kind":"v12.0","properties":{"administratorLogin":"st-admin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"semantic-tables.database.windows.net","privateEndpointConnections":[],"administrators":{"administratorType":"ActiveDirectory","principalType":"Group","login":"David
+        Brookler","sid":"329da5b1-48b3-4f6d-8735-ad2b345f8313","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"restrictOutboundNetworkAccess":"Disabled"},"location":"westus2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/semantic-tables","name":"semantic-tables","type":"Microsoft.Sql/servers"},{"identity":{"principalId":"43763251-7fb7-466b-852e-de6f83fe6460","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"dctestadmin","version":"12.0","state":"Ready","fullyQualifiedDomainName":"dabrookl-dc-test.database.windows.net","privateEndpointConnections":[],"restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RCS-dabrookl-rg/providers/Microsoft.Sql/servers/dabrookl-dc-test","name":"dabrookl-dc-test","type":"Microsoft.Sql/servers"},{"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansoTestumi":{"principalId":"d9db8af7-b98c-4788-83be-04de40f6600d","clientId":"474cad2d-d417-4faa-8589-0462a2407de9"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansonoperm":{"principalId":"39c5ff5e-2157-42dd-a631-0b132f48162d","clientId":"9ef25eb7-3227-46f3-9e8b-55072a8284f3"}},"principalId":"88a4fc29-a1ce-4790-9784-fb2512f3420c","type":"SystemAssigned,UserAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"alswanso","version":"12.0","state":"Disabled","fullyQualifiedDomainName":"alswansocanary2.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","primaryUserAssignedIdentityId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/alswansotest3-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/alswansonoperm","keyId":"https://alswansotestkv2.vault.azure.net/keys/testkey/0880af041d3c478795c4496fddc94cd3","restrictOutboundNetworkAccess":"Disabled"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/alswansotest3-rg/providers/Microsoft.Sql/servers/alswansocanary2","name":"alswansocanary2","type":"Microsoft.Sql/servers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '13655'
+      - '6819'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:27 GMT
+      - Tue, 15 Feb 2022 22:04:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1493,15 +1817,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - 4f14516c-f7dc-448f-8c82-0bd9ecc84fb2
-      - ad596a6b-e213-4dfc-ae64-a9d88781a3cd
-      - 89e896dc-0ba3-40bd-b246-c7f0602fad56
-      - 6dd2af8d-ccd7-4146-989b-914df767a57b
-      - cab1378e-501a-4608-83d5-3ae15f833cb8
-      - 69eeabed-a632-475c-b342-405e7e95bfc7
-      - e9fa3609-c295-4243-a560-cd834906a85b
-      - 367a7940-9d2b-4515-92ff-fe1abea18167
-      - 3bb60014-2cf6-45f3-a6c7-2cf90bc0a489
+      - 8f2cce3d-2f3f-455a-a54c-840c766dc2ea
+      - d92ff06a-f536-4c22-b2de-1ab4e203fea3
+      - 929109c6-0309-4ed8-8bd5-6c503635813d
+      - 39ffb4bd-eca6-4455-ab58-c788cc46922b
+      - 8ff89ad0-19b8-4318-b68d-ff9e331655b7
     status:
       code: 200
       message: OK
@@ -1519,21 +1839,21 @@ interactions:
       ParameterSetName:
       - -g --name
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:28 GMT
+      - Tue, 15 Feb 2022 22:04:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1565,21 +1885,21 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"identity":{"principalId":"f45250ef-b121-4b16-a268-406a33910b0c","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
+      string: '{"identity":{"principalId":"22634200-1112-4d5e-9512-d8cf69b1da14","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000003.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003","name":"clitestserver000003","type":"Microsoft.Sql/servers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '828'
+      - '640'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:28 GMT
+      - Tue, 15 Feb 2022 22:04:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1611,7 +1931,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003/usages?api-version=2014-04-01
   response:
@@ -1623,13 +1943,13 @@ interactions:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '469'
+      - '383'
       content-type:
       - application/json; odata=minimalmetadata; streaming=true; charset=utf-8
       dataserviceversion:
       - 3.0;
       date:
-      - Mon, 28 Jun 2021 20:13:30 GMT
+      - Tue, 15 Feb 2022 22:04:45 GMT
       server:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
@@ -1659,15 +1979,15 @@ interactions:
       ParameterSetName:
       - --id --yes
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000003?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"DropLogicalServer","startTime":"2021-06-28T20:13:32.473Z"}'
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:04:49.127Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/5ba5003d-331a-4cd7-b557-2b04d3262bd1?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1675,11 +1995,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:31 GMT
+      - Tue, 15 Feb 2022 22:04:48 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/5ba5003d-331a-4cd7-b557-2b04d3262bd1?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -1707,12 +2027,12 @@ interactions:
       ParameterSetName:
       - --id --yes
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/5ba5003d-331a-4cd7-b557-2b04d3262bd1?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/c7678375-808c-44ce-88b4-4d64932bb916?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"5ba5003d-331a-4cd7-b557-2b04d3262bd1","status":"Succeeded","startTime":"2021-06-28T20:13:32.473Z"}'
+      string: '{"name":"c7678375-808c-44ce-88b4-4d64932bb916","status":"Succeeded","startTime":"2022-02-15T22:04:49.127Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1721,7 +2041,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:47 GMT
+      - Tue, 15 Feb 2022 22:05:03 GMT
       expires:
       - '-1'
       pragma:
@@ -1755,27 +2075,27 @@ interactions:
       ParameterSetName:
       - -g --name --yes
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/servers/clitestserver000004?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"DropLogicalServer","startTime":"2021-06-28T20:13:49.39Z"}'
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:05:06.243Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00412af1-11b2-4d5c-89f4-262972725069?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '71'
+      - '72'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:13:48 GMT
+      - Tue, 15 Feb 2022 22:05:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/00412af1-11b2-4d5c-89f4-262972725069?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -1803,21 +2123,21 @@ interactions:
       ParameterSetName:
       - -g --name --yes
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/00412af1-11b2-4d5c-89f4-262972725069?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa30863b-07ce-4fc3-87f0-772b9d2f86f6?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"00412af1-11b2-4d5c-89f4-262972725069","status":"Succeeded","startTime":"2021-06-28T20:13:49.39Z"}'
+      string: '{"name":"fa30863b-07ce-4fc3-87f0-772b9d2f86f6","status":"Succeeded","startTime":"2022-02-15T22:05:06.243Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:14:04 GMT
+      - Tue, 15 Feb 2022 22:05:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1849,7 +2169,7 @@ interactions:
       ParameterSetName:
       - -g
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers?api-version=2021-02-01-preview
   response:
@@ -1863,13 +2183,1047 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 28 Jun 2021 20:14:04 GMT
+      - Tue, 15 Feb 2022 22:05:22 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "identity": {"type": "SystemAssigned"}, "properties":
+      {"administratorLogin": "admin123", "administratorLoginPassword": "SecretPassword123",
+      "federatedClientId": "748eaea0-6dbc-4be9-a50b-6a2d3dad00d4", "administrators":
+      {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '250'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:05:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"InProgress","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"9977b21c-b85a-4fa0-8c31-3f9ff21ebcb2","status":"Succeeded","startTime":"2022-02-15T22:05:29.313Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name -l -i --admin-user --admin-password --federated-client-id
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '699'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '699'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"748eaea0-6dbc-4be9-a50b-6a2d3dad00d4","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '699'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westeurope", "identity": {"type": "SystemAssigned"}, "properties":
+      {"administratorLogin": "admin123", "administratorLoginPassword": "SecretPassword789",
+      "version": "12.0", "publicNetworkAccess": "Enabled", "federatedClientId": "17deee33-9da7-40ce-a33c-8a96f2f8f07d",
+      "restrictOutboundNetworkAccess": "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '326'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertLogicalServer","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"InProgress","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:06:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/25528eed-dd52-440f-acc0-26976b2d5d67?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"25528eed-dd52-440f-acc0-26976b2d5d67","status":"Succeeded","startTime":"2022-02-15T22:06:42.203Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:07:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --admin-password --federated-client-id -i
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"identity":{"principalId":"170e2c5b-344d-44c5-8da5-231f52fed384","type":"SystemAssigned","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000005.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","federatedClientId":"17deee33-9da7-40ce-a33c-8a96f2f8f07d","restrictOutboundNetworkAccess":"Disabled"},"location":"westeurope","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005","name":"clitestserver000005","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '699'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:07:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g --name --yes
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000005?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"operation":"DropLogicalServer","startTime":"2022-02-15T22:07:11.527Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '72'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:07:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverOperationResults/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name --yes
+      User-Agent:
+      - AZURECLI/2.33.0 azsdk-python-mgmt-sql/3.0.1 Python/3.9.10 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/westeurope/serverAzureAsyncOperation/fa324c9f-223f-4093-8ea4-1ab33690254a?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"fa324c9f-223f-4093-8ea4-1ab33690254a","status":"Succeeded","startTime":"2022-02-15T22:07:11.527Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 15 Feb 2022 22:07:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
       vary:
       - Accept-Encoding
       x-content-type-options:

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -257,7 +257,7 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
 
         # test create third sql server, with identity and federated client id
         self.cmd('sql server create -g {} --name {} -l {} -i '
-                 '--admin-user {} --admin-password {} --federated_client_id {}'
+                 '--admin-user {} --admin-password {} --federated-client-id {}'
                  .format(resource_group_1, server_name_3, resource_group_location, admin_login, admin_passwords[0], federated_client_id_1),
                  checks=[
                      JMESPathCheck('name', server_name_3),

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -265,7 +265,7 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('resourceGroup', resource_group_1),
                      JMESPathCheck('administratorLogin', admin_login),
                      JMESPathCheck('identity.type', 'SystemAssigned'),
-                     JMESPathCheck('federated_client_id_1', federated_client_id_1)])
+                     JMESPathCheck('federatedClientId', federated_client_id_1)])
         
         self.cmd('sql server show -g {} --name {}'
                  .format(resource_group_1, server_name_3),

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -176,6 +176,7 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
         admin_passwords = ['SecretPassword123', 'SecretPassword456', 'SecretPassword789']
         federated_client_id_1 = '748eaea0-6dbc-4be9-a50b-6a2d3dad00d4'
         federated_client_id_2 = '17deee33-9da7-40ce-a33c-8a96f2f8f07d'
+        federated_client_id_3 = '00000000-0000-0000-0000-000000000000'
 
         # test create sql server with minimal required parameters
         server_1 = self.cmd('sql server create -g {} --name {} '
@@ -282,6 +283,15 @@ class SqlServerMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('resourceGroup', resource_group_1),
                      JMESPathCheck('administratorLogin', admin_login),
                      JMESPathCheck('federatedClientId', federated_client_id_2)])
+
+        # test update sql server's federated client id to empty guid
+        self.cmd('sql server update -g {} --name {} --admin-password {} --federated-client-id {} -i'
+                 .format(resource_group_1, server_name_3, admin_passwords[2], federated_client_id_3),
+                 checks=[
+                     JMESPathCheck('name', server_name_3),
+                     JMESPathCheck('resourceGroup', resource_group_1),
+                     JMESPathCheck('administratorLogin', admin_login),
+                     JMESPathCheck('federatedClientId', None)])
                      
         # delete sql server
         self.cmd('sql server delete -g {} --name {} --yes'


### PR DESCRIPTION
**Description**<!--Mandatory-->
This PR adds server level support for federated client id used in cross tenant CMK scenario

**Testing Guide**
az sql server create --federated-client-id should create a server with corresponding federated client id value
az sql server update--federated-client-id should update a server with new federated client id value

**History Notes**
[SQL] `az sql server create/update`: Add federated client id support.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
