### PR TITLE
[RDBMS] enable rdbms-connect extension in Cloud Shell

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -213,9 +213,6 @@ def _install_deps_for_psycopg2():  # pylint: disable=too-many-statements
         distname, _ = get_linux_distro()
         distname = distname.lower().strip()
         if installer == 'DEB' or any(x in distname for x in ['ubuntu', 'debian']):
-            from azure.cli.core.util import in_cloud_console
-            if in_cloud_console():
-                raise CLIError("This extension is not supported in Cloud Shell as you do not have permission to install extra dependencies.")
             exit_code = subprocess.call(['dpkg', '-s', 'gcc', 'libpq-dev', 'python3-dev'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if exit_code != 0:
                 logger.warning('This extension depends on gcc, libpq-dev, python3-dev and they will be installed first.')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
rdbms-connect extension requires dependencies to be installed beforehand in Linux System including Cloud Shell. 
Originally this was prevented since there was no agreement from CloudShell team. 
This change is to enable rdbms-connect extension in Cloud Shell, we are installing the dependencies in cloud shell https://github.com/Azure/CloudShell/pull/143 and remove the existing restriction in CLI

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
