### PR TITLE
[Role] Add warning to `role` and `ad` commands about Microsoft Graph migration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/role/__init__.py
@@ -24,8 +24,9 @@ class RoleCommandsLoader(AzCommandsLoader):
             from knack.log import get_logger
             logger = get_logger(__name__)
             logger.warning("The underlying Active Directory Graph API will be replaced by Microsoft Graph API in "
-                           "Azure CLI 2.35.0. Please carefully review all breaking changes introduced during this "
-                           "migration: https://docs.microsoft.com/cli/azure/microsoft-graph-migration")
+                           "a future version of Azure CLI. "
+                           "Please carefully review all breaking changes introduced during this migration: "
+                           "https://docs.microsoft.com/cli/azure/microsoft-graph-migration")
         from azure.cli.command_modules.role.commands import load_command_table
         load_command_table(self, args)
         return self.command_table

--- a/src/azure-cli/azure/cli/command_modules/role/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/role/__init__.py
@@ -20,6 +20,12 @@ class RoleCommandsLoader(AzCommandsLoader):
                                                  custom_command_type=role_custom)
 
     def load_command_table(self, args):
+        if args[0] in ('role', 'ad'):
+            from knack.log import get_logger
+            logger = get_logger(__name__)
+            logger.warning("The underlying Active Directory Graph API will be replaced by Microsoft Graph API in "
+                           "Azure CLI 2.35.0. Please carefully review all breaking changes introduced during this "
+                           "migration: https://docs.microsoft.com/cli/azure/microsoft-graph")
         from azure.cli.command_modules.role.commands import load_command_table
         load_command_table(self, args)
         return self.command_table

--- a/src/azure-cli/azure/cli/command_modules/role/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/role/__init__.py
@@ -25,7 +25,7 @@ class RoleCommandsLoader(AzCommandsLoader):
             logger = get_logger(__name__)
             logger.warning("The underlying Active Directory Graph API will be replaced by Microsoft Graph API in "
                            "Azure CLI 2.35.0. Please carefully review all breaking changes introduced during this "
-                           "migration: https://docs.microsoft.com/cli/azure/microsoft-graph")
+                           "migration: https://docs.microsoft.com/cli/azure/microsoft-graph-migration")
         from azure.cli.command_modules.role.commands import load_command_table
         load_command_table(self, args)
         return self.command_table

--- a/src/azure-cli/azure/cli/command_modules/role/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/role/__init__.py
@@ -20,7 +20,7 @@ class RoleCommandsLoader(AzCommandsLoader):
                                                  custom_command_type=role_custom)
 
     def load_command_table(self, args):
-        if args[0] in ('role', 'ad'):
+        if args and args[0] in ('role', 'ad'):
             from knack.log import get_logger
             logger = get_logger(__name__)
             logger.warning("The underlying Active Directory Graph API will be replaced by Microsoft Graph API in "


### PR DESCRIPTION
**Description**<!--Mandatory-->

Close https://github.com/Azure/azure-cli/issues/20946

As Azure CLI is  migrating to Microsoft Graph (https://github.com/Azure/azure-cli/issues/12946), this PR adds an in-tool warning to notify the user about upcoming breaking changes in the migration.

**Testing Guide**

Run any `az role` or `az ad` commands, like

```
az ad app list -h
az ad app show --id xxx
az role assignment -h
```
