### PR TITLE
{Role} `az ad sp create-for-rbac`: Add version to the warning when `--scopes` defaults to subscription

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -390,7 +390,7 @@ long-summary: >-
 
 
     By default, this command does not assign any role to the service principal.
-    Specify both --role and --scopes to assign a specific role and narrow the scope to a resource or resource group.
+    You may use --role and --scopes to assign a specific role and narrow the scope to a resource or resource group.
     You may also use `az role assignment create` to create role assignments for this service principal later.
     See [steps to add a role assignment](https://aka.ms/azadsp-more) for more information.
 parameters:

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -390,7 +390,7 @@ long-summary: >-
 
 
     By default, this command does not assign any role to the service principal.
-    You may use --role and --scopes to assign a specific role and narrow the scope to a resource or resource group.
+    Specify both --role and --scopes to assign a specific role and narrow the scope to a resource or resource group.
     You may also use `az role assignment create` to create role assignments for this service principal later.
     See [steps to add a role assignment](https://aka.ms/azadsp-more) for more information.
 parameters:
@@ -409,6 +409,7 @@ parameters:
   - name: --scopes
     short-summary: >
         Space-separated list of scopes the service principal's role assignment applies to.
+        Starting from Azure CLI 2.35.0, --scopes argument will become required for creating role assignments.
         Defaults to the root of the current subscription. e.g., /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333,
         /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup, or
         /subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -39,8 +39,8 @@ CREDENTIAL_WARNING = (
 
 logger = get_logger(__name__)
 
-SCOPE_WARNING = "Starting from Azure CLI 2.35.0, --scopes argument will become required for creating a role " \
-                "assignment. Please explicitly specify --scopes."
+SCOPE_WARNING = "Starting from Azure CLI 2.35.0, --scopes argument will become required for creating role " \
+                "assignments. Please explicitly specify --scopes."
 
 # pylint: disable=too-many-lines
 

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -39,8 +39,8 @@ CREDENTIAL_WARNING = (
 
 logger = get_logger(__name__)
 
-SCOPE_WARNING = "In a future release, --scopes argument will become required for creating a role assignment. " \
-                "Please explicitly specify --scopes."
+SCOPE_WARNING = "Starting from Azure CLI 2.35.0, --scopes argument will become required for creating a role " \
+                "assignment. Please explicitly specify --scopes."
 
 # pylint: disable=too-many-lines
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Refine the warning introduced by #20965 to explicitly call out the breaking change schedule.

Related: https://github.com/Azure/azure-cli/pull/21326