### PR TITLE
{Compute} Add target version to warning and help message for deprecating default value for `--role`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1019,7 +1019,7 @@ def load_arguments(self, _):
         with self.argument_context(scope) as c:
             c.argument('identity_role', options_list=['--role'], arg_group='Managed Service Identity',
                        help='Role name or id the system assigned identity will have. '
-                            'Please note that the default value "Contributor" will be removed in the future, '
+                            'Please note that the default value "Contributor" will be removed in the future version 2.35.0, '
                             "so please specify '--role' and '--scope' at the same time when assigning a role to the managed identity")
 
     for scope in ['vm identity assign', 'vmss identity assign']:

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1234,7 +1234,7 @@ def _validate_vm_vmss_msi(cmd, namespace, from_set_command=False):
     # at the same time to reduce the impact of breaking change
     if not from_set_command and namespace.identity_scope and getattr(namespace.identity_role, 'is_default', None):
         logger.warning(
-            "Please note that the default value of parameter '--role' will be removed in the future. "
+            "Please note that the default value of parameter '--role' will be removed in the future version 2.35.0. "
             "So specify '--role' and '--scope' at the same time when assigning a role to the managed identity "
             "to avoid breaking your automation script when the default value of '--role' is removed."
         )


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Refine the warning and help message introduced by #20924 to explicitly call out the breaking change schedule.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
