### PR TITLE
{CI} Modify verb check to warning level

### DIFF
--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -43,7 +43,6 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-#
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()

--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -43,6 +43,7 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+#
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()

--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -78,7 +78,7 @@ def regex_line(line):
     sub_pattern = r'\b(added|adding|adds|changed|changing|changes|deprecated|deprecating|deprecates|fixed|fixing|fixes|made|making|makes|removed|removing|removes|updated|updating|updates)\b'
     ref = re.findall(sub_pattern, line, re.IGNORECASE)
     if ref:
-        logger.warning('Please use the right verb of%s %s %swith present-tense in base form and capitalized first letter to describe what is done, '
+        logger.warning('Please use the right verb of%s %s %swith simple present tense in base form and capitalized first letter to describe what is done, '
                        'follow https://aka.ms/submitAzPR\n', red, ref, yellow)
         error_flag = True
     # Check Fix #number in title, just give a warning here, because it is not necessarily

--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -74,14 +74,13 @@ def check_pull_request(title, body):
 
 def regex_line(line):
     error_flag = False
-    # Check each line for these words, case insensitive
+    # Check each line for these words, case insensitive, just give a warning here, because it is impossible to judge accurately.
     sub_pattern = r'\b(added|adding|adds|changed|changing|changes|deprecated|deprecating|deprecates|fixed|fixing|fixes|made|making|makes|removed|removing|removes|updated|updating|updates)\b'
     ref = re.findall(sub_pattern, line, re.IGNORECASE)
     if ref:
         logger.warning('Please use the right verb of%s %s %swith simple present tense in base form and capitalized first letter to describe what is done, '
                        'follow https://aka.ms/submitAzPR\n', red, ref, yellow)
-        error_flag = True
-    # Check Fix #number in title, just give a warning here, because it is not necessarily
+    # Check Fix #number in title, just give a warning here, because it is not necessarily.
     if 'Fix' in line:
         sub_pattern = r'#\d'
         ref = re.findall(sub_pattern, line)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
It is impossible to judge verb accurately.

Instead, it may cause pr to be blocked.

So modify verb check to warning level.

Consider using a bot to add a comment about verb check result in the future.

For example：[support doing something](https://github.com/Azure/azure-cli/pull/21350)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
