### PR TITLE
{Core} Additional logic to judge whether `client` is track2

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -634,7 +634,7 @@ def is_track2(client_class):
     """
     from inspect import getfullargspec as get_arg_spec
     args = get_arg_spec(client_class.__init__).args
-    return "credential" in args
+    return "credential" in args or hasattr(client_class, "_send_request")
 
 
 DISABLE_VERIFY_VARIABLE_NAME = "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION"


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Current logic of [is_track2](https://github.com/Azure/azure-cli/blob/67568014e3df1f183b92ee1ad7699b3b86f35dc0/src/azure-cli-core/azure/cli/core/util.py#L631-L637)  is not accurate, especially when the client is patched with hidden signature: https://github.com/Azure/azure-sdk-for-python/pull/23089#discussion_r808768258.
