### PR TITLE
[Keyvault] `az keyvault key create/import/set-attributes`: Support `--immutable` to mark release policy immutable

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -445,6 +445,10 @@ def load_arguments(self, _):
                        validator=process_key_release_policy, is_preview=True,
                        help='The policy rules under which the key can be exported. '
                             'Policy definition as JSON, or a path to a file containing JSON policy definition.')
+            c.extra('immutable', arg_type=get_three_state_flag(), is_preview=True,
+                    help='Mark a release policy as immutable. '
+                         'An immutable release policy cannot be changed or updated after being marked immutable. '
+                         'Release policies are mutable by default.')
 
     with self.argument_context('keyvault key create') as c:
         c.argument('kty', arg_type=get_enum_type(JsonWebKeyType), validator=validate_key_type,
@@ -505,6 +509,10 @@ def load_arguments(self, _):
                 validator=process_key_release_policy, is_preview=True,
                 help='The policy rules under which the key can be exported. '
                      'Policy definition as JSON, or a path to a file containing JSON policy definition.')
+        c.extra('immutable', arg_type=get_three_state_flag(), is_preview=True,
+                help='Mark a release policy as immutable. '
+                     'An immutable release policy cannot be changed or updated after being marked immutable. '
+                     'Release policies are mutable by default.')
         c.extra('tags', tags_type)
 
     with self.argument_context('keyvault key rotation-policy update') as c:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -106,3 +106,12 @@ def transform_key_output(result, **command_args):
         'releasePolicy': result.properties.release_policy
     }
     return output
+
+
+# pylint: disable=unused-argument
+def transform_key_random_output(result, **command_args):
+    if result and isinstance(result, bytes):
+        import base64
+        return {"value": base64.b64encode(result)}
+
+    return result

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -222,7 +222,9 @@ def process_key_release_policy(cmd, ns):
     import json
     KeyReleasePolicy = cmd.loader.get_sdk('KeyReleasePolicy', mod='_models',
                                           resource_type=ResourceType.DATA_KEYVAULT_KEYS)
-    ns.release_policy = KeyReleasePolicy(data=json.dumps(data).encode('utf-8'))
+    ns.release_policy = KeyReleasePolicy(encoded_policy=json.dumps(data).encode('utf-8'),
+                                         immutable=ns.immutable)
+    del ns.immutable
 
 
 def validate_policy_permissions(ns):

--- a/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/commands.py
@@ -14,7 +14,7 @@ from azure.cli.command_modules.keyvault._client_factory import (
 from azure.cli.command_modules.keyvault._transformers import (
     extract_subresource_name, filter_out_managed_resources,
     multi_transformers, transform_key_decryption_output, keep_max_results,
-    transform_key_output, transform_key_encryption_output)
+    transform_key_output, transform_key_encryption_output, transform_key_random_output)
 
 from azure.cli.command_modules.keyvault._format import transform_secret_list
 
@@ -182,7 +182,7 @@ def load_command_table(self, _):
 
     if not is_azure_stack_profile(self):
         with self.command_group('keyvault key', data_key_entity.command_type) as g:
-            g.keyvault_command('random', 'get_random_bytes', is_preview=True)
+            g.keyvault_command('random', 'get_random_bytes', is_preview=True, transform=transform_key_random_output)
             g.keyvault_command('rotate', 'rotate_key', transform=transform_key_output, is_preview=True)
 
         with self.command_group('keyvault key rotation-policy', data_key_entity.command_type,

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -1151,7 +1151,7 @@ def encrypt_key(cmd, client, algorithm, value, iv=None, aad=None, name=None, ver
     EncryptionAlgorithm = cmd.loader.get_sdk('EncryptionAlgorithm', mod='crypto._enums',
                                              resource_type=ResourceType.DATA_KEYVAULT_KEYS)
     import binascii
-    crypto_client = client.get_cryptography_client(name, version=version)
+    crypto_client = client.get_cryptography_client(name, key_version=version)
     return crypto_client.encrypt(EncryptionAlgorithm(algorithm), value,
                                  iv=binascii.unhexlify(iv) if iv else None,
                                  additional_authenticated_data=binascii.unhexlify(aad) if aad else None)
@@ -1162,7 +1162,7 @@ def decrypt_key(cmd, client, algorithm, value, iv=None, tag=None, aad=None,
     EncryptionAlgorithm = cmd.loader.get_sdk('EncryptionAlgorithm', mod='crypto._enums',
                                              resource_type=ResourceType.DATA_KEYVAULT_KEYS)
     import binascii
-    crypto_client = client.get_cryptography_client(name, version=version)
+    crypto_client = client.get_cryptography_client(name, key_version=version)
     return crypto_client.decrypt(EncryptionAlgorithm(algorithm), value,
                                  iv=binascii.unhexlify(iv) if iv else None,
                                  authentication_tag=binascii.unhexlify(tag) if tag else None,

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -14,7 +14,7 @@ azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
-azure-keyvault-keys==4.5.0b4
+azure-keyvault-keys==4.5.0b6
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -14,7 +14,7 @@ azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
-azure-keyvault-keys==4.5.0b4
+azure-keyvault-keys==4.5.0b6
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -14,7 +14,7 @@ azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
-azure-keyvault-keys==4.5.0b4
+azure-keyvault-keys==4.5.0b6
 azure-keyvault==1.1.0
 azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0

--- a/src/azure-cli/service_name.json
+++ b/src/azure-cli/service_name.json
@@ -6,7 +6,7 @@
   },
   {
     "Command": "az acr",
-    "AzureServiceName": "Azure Container Registries",
+    "AzureServiceName": "Azure Container Registry",
     "URL": "https://docs.microsoft.com/azure/container-registry/"
   },
   {
@@ -226,7 +226,7 @@
   },
   {
     "Command": "az feature",
-    "AzureServiceName": "Azure resource providers",
+    "AzureServiceName": "Azure Resource Manager",
     "URL": "https://docs.microsoft.com/azure/azure-resource-manager/management/resource-providers-and-types"
   },
   {
@@ -306,7 +306,7 @@
   },
   {
     "Command": "az logicapp",
-    "AzureServiceName": "Azure Logic App",
+    "AzureServiceName": "Azure Logic Apps",
     "URL": "https://docs.microsoft.com/azure/logic-apps/logic-apps-overview"
   },
   {

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -60,7 +60,7 @@ DEPENDENCIES = [
     'azure-graphrbac~=0.60.0',
     'azure-identity',
     'azure-keyvault-administration==4.0.0b3',
-    'azure-keyvault-keys==4.5.0b4',
+    'azure-keyvault-keys==4.5.0b6',
     'azure-keyvault~=1.1.0',
     'azure-loganalytics~=0.1.0',
     'azure-mgmt-advisor==9.0.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Apply https://github.com/Azure/azure-rest-api-specs/pull/17270
Add `--immutable` for `az keyvault key create/import/set-attributes`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Keyvault] `az keyvault key create/import/set-attributes`: Support `--immutable` to mark release policy immutable

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
