### PR TITLE
[App Service] Fix `az webapp deployment github-actions remove` bug.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -5158,7 +5158,7 @@ def remove_github_actions(cmd, resource_group, name, repo, token=None, slot=None
         branch.replace('/', '-'), name.lower(), slot) if slot else "{}_{}.yml".format(
             branch.replace('/', '-'), name.lower())
     dir_path = "{}/{}".format('.github', 'workflows')
-    file_path = "/{}/{}".format(dir_path, file_name)
+    file_path = "{}/{}".format(dir_path, file_name)
     existing_publish_profile_name = None
     try:
         existing_workflow_file = github_repo.get_contents(path=file_path, ref=branch)


### PR DESCRIPTION
**Description**<!--Mandatory-->
Issue in #20808 was already fixed (`az webapp deployment github-actions add` command) but the same bug in the `remove` command wasn't fixed

This PR makes the same change in the `remove` command

**Testing Guide**
<!--Example commands with explanations.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
