### PR TITLE
[CosmosDb] `az managed-cassandra cluster update`: Fix `--external-seed-nodes` and `--external-gossip-certificates`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -2416,7 +2416,7 @@ def cli_cosmosdb_managed_cassandra_datacenter_update(client,
                                                      managed_disk_customer_key_uri=None,
                                                      backup_storage_customer_key_uri=None):
 
-    """Updates an Azure Managed Cassandra Datacenter"""
+    """Updates an Azure Managed Cassandra DataCenter"""
 
     data_center_resource = client.get(resource_group_name, cluster_name, data_center_name)
 

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -2385,7 +2385,7 @@ def cli_cosmosdb_managed_cassandra_datacenter_create(client,
                                                      disk_capacity=None,
                                                      availability_zone=None):
 
-    """Creates an Azure Managed Cassandra Datacenter"""
+    """Creates an Azure Managed Cassandra DataCenter"""
 
     data_center_properties = DataCenterResourceProperties(
         data_center_location=data_center_location,

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -2258,7 +2258,7 @@ def cli_cosmosdb_managed_cassandra_cluster_update(client,
     if client_certificates is None:
         client_certificates = cluster_resource.properties.client_certificates
 
-    if external_gossip_certificates is not None:
+    if external_gossip_certificates is None:
         external_gossip_certificates = cluster_resource.properties.external_gossip_certificates
 
     if external_seed_nodes is None:
@@ -2297,7 +2297,7 @@ def cli_cosmosdb_managed_cassandra_cluster_update(client,
         client_certificates=client_certificates,
         external_gossip_certificates=external_gossip_certificates,
         gossip_certificates=cluster_resource.properties.gossip_certificates,
-        external_seed_nodes=cluster_resource.properties.external_seed_nodes,
+        external_seed_nodes=external_seed_nodes,
         seed_nodes=cluster_resource.properties.seed_nodes
     )
 


### PR DESCRIPTION
managed-cassandra cluster update: bugfix in custom.py in the handling of values passed to --external-seed-nodes and --external-gossip-certificates parameters.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Customer was not able to update external-seed-nodes and external-gossip-certificates because CLI was ignoring the values passed to these parameters. This fix allows these two to be updated.

**Testing Guide**
<!--Example commands with explanations.-->
az managed-cassandra cluster update -g $resourceGroup -c $cluster --external-seed-nodes 10.52.221.2 10.52.221.3 10.52.221.4 --external-gossip-certificates "/path/to/gossipcert.pem" --debug

The --external-seed-nodes and --external-gossip-certificates passed in above command now gets propagated to our RP.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[managed-cassandra] `az managed-cassandra cluster update`: Fix to allow `--external-seed-nodes` and `--external-gossip-certificates` to be updated by the user.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
