### PR TITLE
{CI} Fix generate history notes error: Compute component get an extra space character

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -176,7 +176,7 @@ Release History
 
 * `az bot create`: Add location as specified by user to bot creation for regionality/EUDB (#20716)
 
-**Compute **
+**Compute**
 
 * `az image builder create`: Add new parameter `--proxy-vm-size` to support proxy VM size customization (#20904)
 * `az image builder create`: Add new parameter `--build-vm-identities` to support user assigned identities customization (#20904)
@@ -258,7 +258,7 @@ Release History
 * `az backup protectable-item list/show`: Add auto-protection policy and node-list field in the response for SQLInstance SQLAG (#20821)
 * `az backup protection auto-enable-for-azurewl/auto-disable-for-azurewl`: Add support for SQLAG (#20821)
 
-**Compute **
+**Compute**
 
 * `az vm/vmss create/update`: Expand validate license types for `--license-type` parameter (#20724)
 * `az sig image-definition list-shared`: Add new parameters `--marker` and `--show-next-marker` to support paging (#20618)
@@ -366,7 +366,7 @@ Release History
 * `az cognitiveservices account commitment-plan`: Add new commands `show`, `list`, `create`, `delete` (#20551)
 * `az cognitiveservices commitment-tier`: Add new command `list` (#20551)
 
-**Compute **
+**Compute**
 
 * Fix #20182: `az snapshot create`: Fix auto-detection bug for `--copy-start` (#20190)
 * Fix #20133: `az vm create`: Fix `--data-disk-delete-option` not working when no `--attach-data-disks` are provided (#20165)
@@ -469,7 +469,7 @@ Release History
 
 * `az aro create`: Remove Identifier URIs (#20095)
 
-**Compute **
+**Compute**
 
 * `az disk update`: Fix the problem that updating network access policy to `AllowPrivate` failed (#19862)
 * `az vm update`: Add `--host` argument and `--host-group` argument to support assign an existing VM to a specific ADH (#19819)
@@ -603,7 +603,7 @@ Hotfix: Fix #19897,#19903: Fix static webapp commands that are broken due to the
 * `az backup`: Add CRR functionality for Azure Workload (#19664)
 * `az backup`: Add support for MAB backup management type in some sub commands (#19710)
 
-**Compute **
+**Compute**
 
 * `az sig create/update`: Add new parameter `--soft-delete` to support soft delete (#19569)
 * `az sig image-version`: Add new parameter `--replication-mode` to support setting replication mode (#19580)
@@ -906,7 +906,7 @@ Upgrade batch management-plane to [azure-batch-mgmt 16.0.0](https://pypi.org/pro
 
 * `az cdn endpoint rule`: Add OriginGroupOverride action support (#18711)
 
-**Compute **
+**Compute**
 
 * `az sig image-version create`: Support mixing disks, snapshots, and vhd (#18741)
 * `az vmss update`: Upgrade package version to fix securityProfile issue (#18788)
@@ -1082,7 +1082,7 @@ Workload container registration fix, SDK upgraded to 0.12.0, Fixed and Re-ran te
 
 * `az cognitiveservices account`: Add list-deleted, show-deleted, recover, purge commands (#18464)
 
-**Compute **
+**Compute**
 
 * `az sig create/update`: Add --permissions to specify the permission of sharing gallery. (#18503)
 * `az sig share`: Manage gallery sharing profile. (#18503)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When auto generate history notes, Compute component get an extra space.
![image](https://user-images.githubusercontent.com/18628534/155681643-c09a88a1-6ee1-4eb5-a0e3-7110538d5b0e.png)
Can fix this issue by simply delete all the extra space character.
`python generate_history_notes.py` test screenshot:
![image](https://user-images.githubusercontent.com/18628534/155681919-c1ea8f53-d718-4b42-89e4-54545f99380d.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
