### PR TITLE
[App Service] Fix #21439: `az webapp deploy`: Fix `--async` argument value in help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2608,7 +2608,7 @@ helps['webapp deploy'] = """
     short-summary: Deploys a provided artifact to Azure Web Apps.
     examples:
     - name: Deploy a war file asynchronously.
-      text: az webapp deploy --resource-group ResouceGroup --name AppName --src-path SourcePath --type war --async IsAsync
+      text: az webapp deploy --resource-group ResouceGroup --name AppName --src-path SourcePath --type war --async true
     - name: Deploy a static text file to wwwroot/staticfiles/test.txt
       text: az webapp deploy --resource-group ResouceGroup --name AppName --src-path SourcePath --type static --target-path staticfiles/test.txt
 """


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This fixes a typo in an example for [`az webapp deploy`](https://docs.microsoft.com/en-us/cli/azure/webapp?view=azure-cli-latest#az-webapp-deploy) in its reference doc.

**Testing Guide**
<!--Example commands with explanations.-->

N/A

resolves #21439