### PR TITLE
{Packaging} Update websocket-client for python3 compatibility

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -135,6 +135,6 @@ tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
-websocket-client==0.56.0
+websocket-client==1.3.1
 wrapt==1.11.2
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -136,6 +136,6 @@ tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
-websocket-client==0.56.0
+websocket-client==1.3.1
 wrapt==1.11.2
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -136,5 +136,5 @@ tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
-websocket-client==0.56.0
+websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,7 +149,7 @@ DEPENDENCIES = [
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
     'urllib3[secure]',
-    'websocket-client~=1.31.0',
+    'websocket-client~=1.3.1',
     'xmltodict~=0.12'
 ]
 

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,7 +149,7 @@ DEPENDENCIES = [
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
     'urllib3[secure]',
-    'websocket-client~=0.56.0',
+    'websocket-client~=1.31.0',
     'xmltodict~=0.12'
 ]
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
This PR aims to bump the version of Websocket-Client from `0.56.0` -> `1.3.1` which is a more recent & python3 compatible version of the library. The version of the WebSocket client  used inside the Azure-CLI (And more specifically, `WebSocketApplication`) relies on functionality from the python2 threading module that is no longer present in version 3. Any project explicitly using websocket-client & azure-cli currently have to use version `0.56.0` and any application using the `WebSocketApplication` from the websocket client will throw with: `AttributeError: 'Thread' object has no attribute 'isAlive'` on the websocket's teardown.

**Testing Guide**
This change doesn't touch any of the Azure-CLI or extensions code & only changes the dependency version of websocket-client within the Azure-CLI's `setup.py`. Extensions or components that rely on explicitly on websocket-client 0.56.0 should most likely see no changes from a functionality or API usage so long as their codebase is already using python 3.0 & up.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{Packaging}: Update websocket-client from 0.56.0 -> 1.31.0

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
