### PR TITLE
[Storage] Add a parameter for using storage-account-url directly.

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/client_factory.py
+++ b/src/azure-cli-core/azure/cli/core/commands/client_factory.py
@@ -237,12 +237,13 @@ def _get_mgmt_service_client(cli_ctx,
     return client, subscription_id
 
 
-def get_data_service_client(cli_ctx, service_type, account_name, account_key, connection_string=None,
+def get_data_service_client(cli_ctx, service_type, storage_account_url, account_name, account_key, connection_string=None,
                             sas_token=None, socket_timeout=None, token_credential=None, endpoint_suffix=None,
                             location_mode=None):
     logger.debug('Getting data service client service_type=%s', service_type.__name__)
     try:
-        client_kwargs = {'account_name': account_name,
+        client_kwargs = {'storage_account_url': storage_account_url,
+                         'account_name': account_name,
                          'account_key': account_key,
                          'connection_string': connection_string,
                          'sas_token': sas_token}

--- a/src/azure-cli/azure/cli/command_modules/storage/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/__init__.py
@@ -295,6 +295,9 @@ Authentication failure. This may be caused by either invalid account key, connec
             return
 
         group_name = 'Storage Account'
+        command.add_argument('storage_account_url', '--storage-account-url', required=False, default=None,
+                             arg_group=group_name,
+                             help='It will come later.')
         command.add_argument('account_name', '--account-name', required=False, default=None,
                              arg_group=group_name,
                              completer=get_resource_name_completion_list('Microsoft.Storage/storageAccounts'),


### PR DESCRIPTION
**Description**<!--Mandatory-->
Allow a custom storage account URL in az storage module. Right now we only have option of using account name (which translated to <account name>.blob.core.windows.net) or a connection string. e.g.

`az storage container list --account-name "contosoimages" --account-key "some_secret"`

This connects to `https://contosoimages.blob.core.windows.net`. I want to connect to "https://storage.contosoimagesproxy.net" for my storage account.

**Testing Guide**
Following should work:
`az storage container list --storage-account-url "https://storage.contosoimagesproxy.net" --account-key "some_secret"`

Additional changes required in underlying SDK here: https://github.com/Azure/azure-multiapi-storage-python/pull/48

**History Notes**
NA

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
