### PR TITLE
[Profile] `az login`: Format output 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -14,6 +14,8 @@ long-summary: >-
     By default, this command logs in with a user account. CLI will try to launch a web browser to log in interactively.
     If a web browser is not available, CLI will fall back to device code login.
 
+    Default output type is table (not json).
+
     To login with a service principal, specify --service-principal.
 examples:
     - name: Log in interactively.

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -104,7 +104,9 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
           identity=False, use_device_code=False, use_cert_sn_issuer=None, scopes=None, client_assertion=None):
     """Log in to access Azure subscriptions"""
 
-    set_output_format(cmd.cli_ctx, "table")
+    global_params = cmd.cli_ctx.data.get("safe_params", [])
+    if "--output" not in global_params and "-o" not in global_params:
+        set_output_format(cmd.cli_ctx, "table")
 
     # quick argument usage check
     if any([password, service_principal, tenant]) and identity:

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -164,7 +164,7 @@ def login(cmd, username=None, password=None, service_principal=None, tenant=None
         formatted["isDefault"] = sub["isDefault"]
         formatted["name"] = sub["name"]
         formatted["state"] = sub["state"]
-        formatted["tenantId"] = sub["tenantId"]
+        formatted["subscriptionId"] = sub["id"]
         formatted_subs.append(formatted)
 
     if default_sub:

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-from email.policy import default
 import os
 from typing import OrderedDict
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Changes the output for `az login` to be more human-readable / user-friendly in response to internal feedback. 
- the default output format is table instead of JSON
- the only fields included are `isDefault`, `name`, `state`, and `subscriptionId`
- the default subscription is sorted to the top of the table 
- includes debug text to help new users 

The user can still get a json response by running `az login --output json` 

Output before the proposed change: 
<img width="1440" alt="Screen Shot 2022-03-03 at 4 47 02 PM" src="https://user-images.githubusercontent.com/10121214/156677824-e36b09df-dfd8-49f0-baf7-5c778525e05d.png">

Output after proposed change: 
<img width="1440" alt="Screen Shot 2022-03-03 at 4 41 56 PM" src="https://user-images.githubusercontent.com/10121214/156677329-e396ea7b-a720-4c62-962b-89b85be792e6.png">

**Testing Guide**
<!--Example commands with explanations.-->
`az login`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
