### PR TITLE
[App Service] `az appservice ase create-inbound-services`: Add support for Azure private DNS zone creation in ASEv3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2255,7 +2255,7 @@ helps['appservice ase create'] = """
 
 helps['appservice ase create-inbound-services'] = """
     type: command
-    short-summary: Private DNS Zone for Internal ASEv2.
+    short-summary: Private DNS Zone for Internal (ILB) App Service Environments.
     examples:
     - name: Create Private DNS Zone and A records.
       text: |

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -950,11 +950,12 @@ def load_arguments(self, _):
     with self.argument_context('appservice ase create-inbound-services') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment',
                    local_context_attribute=LocalContextAttribute(name='ase_name', actions=[LocalContextAction.GET]))
-        c.argument('subnet', help='Name or ID of existing subnet for inbound traffic to ASEv3. \
+        c.argument('subnet', help='Name or ID of existing subnet for DNS Zone link. \
                    To create vnet and/or subnet use `az network vnet [subnet] create`')
         c.argument('vnet_name', help='Name of the vNet. Mandatory if only subnet name is specified.')
         c.argument('skip_dns', arg_type=get_three_state_flag(),
-                   help='Do not create Private DNS Zone and DNS records.')
+                   help='Do not create Private DNS Zone and DNS records.',
+                   deprecate_info=c.deprecate(expiration='3.0.0'))
 
     # App Service Domain Commands
     with self.argument_context('appservice domain create') as c:

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -19,7 +19,7 @@ from azure.cli.core.commands import LongRunningOperation
 from azure.cli.core.commands.client_factory import (get_mgmt_service_client, get_subscription_id)
 from azure.cli.core.commands.arm import ArmTemplateBuilder
 from azure.cli.core.util import (sdk_no_wait, random_string)
-from azure.cli.core.azclierror import (ResourceNotFoundError, ValidationError, CommandNotFoundError,
+from azure.cli.core.azclierror import (ResourceNotFoundError, ValidationError,
                                        MutuallyExclusiveArgumentError)
 from knack.log import get_logger
 from msrestazure.tools import (parse_resource_id, is_valid_resource_id, resource_id)

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -152,11 +152,12 @@ def create_ase_inbound_services(cmd, resource_group_name, name, subnet, vnet_nam
         raise ValidationError('Private DNS Zone is not relevant for External ASE.')
 
     if ase.kind.lower() == 'asev3':
-        # pending SDK update (ase_client.get_ase_v3_networking_configuration(resource_group_name, name))
-        raise CommandNotFoundError('create-inbound-services is currently not supported for ASEv3.')
+        ase_network_conf = ase_client.get_ase_v3_networking_configuration(resource_group_name, name)
+        inbound_ip_address = ase_network_conf.internal_inbound_ip_addresses[0]
+    else:
+        ase_vip_info = ase_client.get_vip_info(resource_group_name, name)
+        inbound_ip_address = ase_vip_info.internal_ip_address
 
-    ase_vip_info = ase_client.get_vip_info(resource_group_name, name)
-    inbound_ip_address = ase_vip_info.internal_ip_address
     inbound_subnet_id = _validate_subnet_id(cmd.cli_ctx, subnet, vnet_name, resource_group_name)
     inbound_vnet_id = _get_vnet_id_from_subnet(cmd.cli_ctx, inbound_subnet_id)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
ASEv3 support has been pending azure-mgmt-web update to 5.0.0+. With update to 6.1.0 we can unblock this scenario.

**Testing Guide**
az appservice ase create -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet --kind asev3 --virtual-ip-type Internal
az appservice ase create-inbound-services -n MyASEv3Name -g ASEv3ResourceGroup --vnet-name MyASEv3VirtualNetwork --subnet MyASEv3Subnet

Result: Azure private DNS zone is created with the necessary inbound ILB ip DNS records configured and zone linked to vnet.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
