### PR TITLE
{AKS} Refactor aks nodepool add - part 2

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -13,6 +13,10 @@ from azure.cli.core.azclierror import (
     CLIInternalError,
     InvalidArgumentValueError,
 )
+from azure.cli.command_modules.acs._validators import (
+    extract_comma_separated_string,
+)
+from azure.cli.core.util import sdk_no_wait
 from azure.cli.core.commands import AzCliCommand
 from azure.cli.core.profiles import ResourceType
 from knack.log import get_logger
@@ -129,12 +133,15 @@ class AKSAgentPoolContext:
         # this parameter does not need validation
         return cluster_name
 
-    def get_nodepool_name(self) -> str:
-        """Obtain the value of nodepool_name.
+    def _get_nodepool_name(self, enable_validation: bool = False) -> str:
+        """Internal function to obtain the value of nodepool_name.
 
         Note: SDK performs the following validation {'required': True, 'pattern': r'^[a-z][a-z0-9]{0,11}$'}.
 
         This is a required parameter and its value should be provided by user explicitly.
+
+        This function supports the option of enable_validation. When enabled, it will check if the given nodepool name
+        is used by any nodepool of the cluster, if so, raise the InvalidArgumentValueError.
 
         :return: string
         """
@@ -146,16 +153,88 @@ class AKSAgentPoolContext:
 
         # this parameter does not need dynamic completion
         # validation
-        instances = cf_agent_pools.list(self.get_resource_group_name, self.get_cluster_name)
-        for agentpool_profile in instances:
-            if agentpool_profile.name == nodepool_name:
-                raise InvalidArgumentValueError(
-                    "Node pool {} already exists, please try a different name, "
-                    "use 'aks nodepool list' to get current list of node pool".format(
-                        nodepool_name
+        if enable_validation:
+            instances = cf_agent_pools.list(self.get_resource_group_name, self.get_cluster_name)
+            for agentpool_profile in instances:
+                if agentpool_profile.name == nodepool_name:
+                    raise InvalidArgumentValueError(
+                        "Node pool {} already exists, please try a different name, "
+                        "use 'aks nodepool list' to get current list of node pool".format(
+                            nodepool_name
+                        )
                     )
-                )
         return nodepool_name
+
+    def get_nodepool_name(self) -> str:
+        """Obtain the value of nodepool_name.
+
+        Note: SDK performs the following validation {'required': True, 'pattern': r'^[a-z][a-z0-9]{0,11}$'}.
+
+        This is a required parameter and its value should be provided by user explicitly.
+
+        This function will verify the parameter by default. It will check if the given nodepool name is used by any
+        nodepool of the cluster, if so, raise the InvalidArgumentValueError.
+
+        :return: string
+        """
+        return self._get_nodepool_name(enable_validation=True)
+
+    def get_max_surge(self):
+        """Obtain the value of max_surge.
+
+        :return: string
+        """
+        # read the original value passed by the command
+        max_surge = self.raw_param.get("max_surge")
+        # try to read the property value corresponding to the parameter from the `mc` object.
+        if (
+            self.agentpool and
+            self.agentpool.upgrade_settings and
+            self.agentpool.upgrade_settings.max_surge is not None
+        ):
+            max_surge = self.agentpool.upgrade_settings.max_surge
+
+        # this parameter does not need dynamic completion
+        # this parameter does not need validation
+        return max_surge
+
+    def get_aks_custom_headers(self) -> Dict[str, str]:
+        """Obtain the value of aks_custom_headers.
+
+        Note: aks_custom_headers will not be decorated into the `agentpool` object.
+
+        This function will normalize the parameter by default. It will call "extract_comma_separated_string" to extract
+        comma-separated key value pairs from the string.
+
+        :return: dictionary
+        """
+        # read the original value passed by the command
+        aks_custom_headers = self.raw_param.get("aks_custom_headers")
+        # normalize user-provided header
+        # usually the purpose is to enable (preview) features through AKSHTTPCustomFeatures
+        aks_custom_headers = extract_comma_separated_string(
+            aks_custom_headers,
+            enable_strip=True,
+            extract_kv=True,
+            default_value={},
+        )
+
+        # this parameter does not need validation
+        return aks_custom_headers
+
+    def get_no_wait(self) -> bool:
+        """Obtain the value of no_wait.
+
+        Note: no_wait will not be decorated into the `agentpool` object.
+
+        :return: bool
+        """
+        # read the original value passed by the command
+        no_wait = self.raw_param.get("no_wait")
+
+        # this parameter does not need dynamic completion
+        # this parameter does not need validation
+        return no_wait
 
 
 class AKSAgentPoolAddDecorator:
@@ -180,19 +259,85 @@ class AKSAgentPoolAddDecorator:
         # store the context in the process of assemble the AgentPool object
         self.context = AKSAgentPoolContext(cmd, raw_parameters, self.models, decorator_mode=DecoratorMode.CREATE)
 
+    def _ensure_agentpool(self, agentpool: AgentPool) -> None:
+        """Internal function to ensure that the incoming `agentpool` object is valid and the same as the attached
+        `agentpool` object in the context.
+
+        If the incomding `agentpool` is not valid or is inconsistent with the `agentpool` in the context, raise a
+        CLIInternalError.
+
+        :return: None
+        """
+        if not isinstance(agentpool, self.models.AgentPool):
+            raise CLIInternalError(
+                "Unexpected agentpool object with type '{}'.".format(type(agentpool))
+            )
+
+        if self.context.agentpool != agentpool:
+            raise CLIInternalError(
+                "Inconsistent state detected. The incoming `agentpool` "
+                "is not the same as the `agentpool` in the context."
+            )
+
     def init_agentpool(self) -> AgentPool:
-        """Initialize an AgentPool object with name and attach it to internal context.
+        """Initialize an AgentPool object and attach it to internal context.
 
         :return: the AgentPool object
         """
-        # Initialize a AgentPool object with name.
-        agentpool = self.models.AgentPool(
-            name=self.context.get_nodepool_name(),
-        )
+        # Initialize a AgentPool object.
+        agentpool = self.models.AgentPool()
 
         # attach mc to AKSContext
         self.context.attach_agentpool(agentpool)
         return agentpool
+
+    def set_up_upgrade_settings(self, agentpool: AgentPool) -> AgentPool:
+        """Set up upgrade settings for the AgentPool object.
+
+        :return: the AgentPool object
+        """
+        self._ensure_agentpool(agentpool)
+
+        upgrade_settings = self.models.AgentPoolUpgradeSettings()
+        max_surge = self.context.get_max_surge()
+        if max_surge:
+            upgrade_settings.max_surge = max_surge
+        agentpool.upgrade_settings = upgrade_settings
+        return agentpool
+
+    def construct_default_agentpool(self) -> AgentPool:
+        """The overall controller used to construct the default AgentPool profile.
+
+        The completely constructed AgentPool object will later be passed as a parameter to the underlying SDK
+        (mgmt-containerservice) to send the actual request.
+
+        :return: the AgentPool object
+        """
+        # initialize the AgentPool object
+        agentpool = self.init_agentpool()
+        # set up upgrade settings
+        agentpool = self.set_up_upgrade_settings(agentpool)
+        return agentpool
+
+    def add_agentpool(self, agentpool: AgentPool) -> AgentPool:
+        """Send request to add a new agentpool.
+
+        The function "sdk_no_wait" will be called to use the ContainerServiceClient to send a reqeust to add a new agent
+        pool to the cluster.
+
+        :return: the ManagedCluster object
+        """
+        self._ensure_agentpool(agentpool)
+
+        return sdk_no_wait(
+            self.context.get_no_wait(),
+            self.client.begin_create_or_update,
+            self.context.get_resource_group_name(),
+            self.context.get_cluster_name(),
+            self.context.get_nodepool_name(),
+            agentpool,
+            headers=self.context.get_aks_custom_headers(),
+        )
 
 
 class AKSAgentPoolUpdateDecorator:

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -305,7 +305,7 @@ class AKSAgentPoolAddDecorator:
         agentpool.upgrade_settings = upgrade_settings
         return agentpool
 
-    def construct_default_agentpool(self) -> AgentPool:
+    def construct_default_agentpool_profile(self) -> AgentPool:
         """The overall controller used to construct the default AgentPool profile.
 
         The completely constructed AgentPool object will later be passed as a parameter to the underlying SDK

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -292,7 +292,7 @@ class AKSAgentPoolAddDecorator:
         agentpool = self.models.AgentPool()
         # Note: As a read only property, name would be ignored when serialized.
         # Set the name property by explicit assignment, otherwise it will be ignored by initialization.
-        agentpool.name = self.context._get_nodepool_name(enable_validation=False)
+        agentpool.name = self.context.get_nodepool_name()
 
         # attach mc to AKSContext
         self.context.attach_agentpool(agentpool)
@@ -326,6 +326,7 @@ class AKSAgentPoolAddDecorator:
         agentpool = self.set_up_upgrade_settings(agentpool)
         return agentpool
 
+    # pylint: disable=protected-access
     def add_agentpool(self, agentpool: AgentPool) -> AgentPool:
         """Send request to add a new agentpool.
 
@@ -341,7 +342,8 @@ class AKSAgentPoolAddDecorator:
             self.client.begin_create_or_update,
             self.context.get_resource_group_name(),
             self.context.get_cluster_name(),
-            self.context.get_nodepool_name(),
+            # validated in "init_agentpool", skip to avoid duplicate api calls
+            self.context._get_nodepool_name(enable_validation=False),
             agentpool,
             headers=self.context.get_aks_custom_headers(),
         )

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -282,12 +282,17 @@ class AKSAgentPoolAddDecorator:
             )
 
     def init_agentpool(self) -> AgentPool:
-        """Initialize an AgentPool object and attach it to internal context.
+        """Initialize an AgentPool object with name and attach it to internal context.
+
+        Note: As a read only property, name would be ignored when serialized.
 
         :return: the AgentPool object
         """
-        # Initialize a AgentPool object.
+        # Initialize a AgentPool object with name.
         agentpool = self.models.AgentPool()
+        # Note: As a read only property, name would be ignored when serialized.
+        # Set the name property by explicit assignment, otherwise it will be ignored by initialization.
+        agentpool.name = self.context._get_nodepool_name(enable_validation=False)
 
         # attach mc to AKSContext
         self.context.attach_agentpool(agentpool)

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -141,7 +141,8 @@ class AKSAgentPoolContext:
         This is a required parameter and its value should be provided by user explicitly.
 
         This function supports the option of enable_validation. When enabled, it will check if the given nodepool name
-        is used by any nodepool of the cluster, if so, raise the InvalidArgumentValueError.
+        is used by any nodepool of the cluster, if so, raise the InvalidArgumentValueError. This verification operation
+        will send a get request, skip the validation appropriately to avoid multiple api calls.
 
         :return: string
         """
@@ -173,7 +174,8 @@ class AKSAgentPoolContext:
         This is a required parameter and its value should be provided by user explicitly.
 
         This function will verify the parameter by default. It will check if the given nodepool name is used by any
-        nodepool of the cluster, if so, raise the InvalidArgumentValueError.
+        nodepool of the cluster, if so, raise the InvalidArgumentValueError. This verification operation will send a
+        get request, may use the internal function to skip the validation appropriately and avoid multiple api calls.
 
         :return: string
         """
@@ -263,7 +265,7 @@ class AKSAgentPoolAddDecorator:
         """Internal function to ensure that the incoming `agentpool` object is valid and the same as the attached
         `agentpool` object in the context.
 
-        If the incomding `agentpool` is not valid or is inconsistent with the `agentpool` in the context, raise a
+        If the incoming `agentpool` is not valid or is inconsistent with the `agentpool` in the context, raise a
         CLIInternalError.
 
         :return: None

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -216,11 +216,12 @@ class AKSAgentPoolAddDecoratorTestCase(unittest.TestCase):
         dec_1 = AKSAgentPoolAddDecorator(
             self.cmd,
             self.client,
-            {},
+            {"nodepool_name": "test_nodepool_name"},
             ResourceType.MGMT_CONTAINERSERVICE,
         )
         dec_agentpool_1 = dec_1.init_agentpool()
         ground_truth_agentpool_1 = self.models.AgentPool()
+        ground_truth_agentpool_1.name = "test_nodepool_name"
         self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
         self.assertEqual(dec_agentpool_1, dec_1.context.agentpool)
 
@@ -283,6 +284,7 @@ class AKSAgentPoolAddDecoratorTestCase(unittest.TestCase):
 
         upgrade_settings_1 = self.models.AgentPoolUpgradeSettings()
         agentpool_1 = self.models.AgentPool(upgrade_settings=upgrade_settings_1)
+        agentpool_1.name = "test_nodepool_name"
         self.assertEqual(dec_agentpool_1, agentpool_1)
         raw_param_dict.print_usage_statistics()
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -219,7 +219,11 @@ class AKSAgentPoolAddDecoratorTestCase(unittest.TestCase):
             {"nodepool_name": "test_nodepool_name"},
             ResourceType.MGMT_CONTAINERSERVICE,
         )
-        dec_agentpool_1 = dec_1.init_agentpool()
+        with patch(
+            "azure.cli.command_modules.acs.agentpool_decorator.cf_agent_pools",
+            return_value=Mock(),
+        ):
+            dec_agentpool_1 = dec_1.init_agentpool()
         ground_truth_agentpool_1 = self.models.AgentPool()
         ground_truth_agentpool_1.name = "test_nodepool_name"
         self.assertEqual(dec_agentpool_1, ground_truth_agentpool_1)
@@ -280,7 +284,11 @@ class AKSAgentPoolAddDecoratorTestCase(unittest.TestCase):
             ResourceType.MGMT_CONTAINERSERVICE,
         )
 
-        dec_agentpool_1 = dec_1.construct_default_agentpool_profile()
+        with patch(
+            "azure.cli.command_modules.acs.agentpool_decorator.cf_agent_pools",
+            return_value=Mock(),
+        ):
+            dec_agentpool_1 = dec_1.construct_default_agentpool_profile()
 
         upgrade_settings_1 = self.models.AgentPoolUpgradeSettings()
         agentpool_1 = self.models.AgentPool(upgrade_settings=upgrade_settings_1)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -50,18 +50,12 @@ class AKSAgentPoolModelsTestCase(unittest.TestCase):
         # load models directly (instead of through the `get_sdk` method provided by the cli component)
         from azure.cli.core.profiles._shared import AZURE_API_PROFILES
 
-        sdk_profile = AZURE_API_PROFILES["latest"][
-            ResourceType.MGMT_CONTAINERSERVICE
-        ]
+        sdk_profile = AZURE_API_PROFILES["latest"][ResourceType.MGMT_CONTAINERSERVICE]
         api_version = sdk_profile.default_api_version
-        module_name = "azure.mgmt.containerservice.v{}.models".format(
-            api_version.replace("-", "_")
-        )
+        module_name = "azure.mgmt.containerservice.v{}.models".format(api_version.replace("-", "_"))
         module = importlib.import_module(module_name)
 
-        self.assertEqual(
-            models.AgentPool, getattr(module, "AgentPool")
-        )
+        self.assertEqual(models.AgentPool, getattr(module, "AgentPool"))
         self.assertEqual(
             models.AgentPoolUpgradeSettings,
             getattr(module, "AgentPoolUpgradeSettings"),
@@ -77,23 +71,129 @@ class AKSAgentPoolContextTestCase(unittest.TestCase):
     def test__init__(self):
         # fail on not passing dictionary-like parameters
         with self.assertRaises(CLIInternalError):
-            AKSAgentPoolContext(
-                self.cmd, [], self.models, decorator_mode=DecoratorMode.CREATE
-            )
+            AKSAgentPoolContext(self.cmd, [], self.models, decorator_mode=DecoratorMode.CREATE)
         # fail on not passing decorator_mode with Enum type DecoratorMode
         with self.assertRaises(CLIInternalError):
             AKSAgentPoolContext(self.cmd, {}, self.models, decorator_mode=1)
 
     def test_attach_agentpool(self):
-        ctx_1 = AKSAgentPoolContext(
-            self.cmd, {}, self.models, decorator_mode=DecoratorMode.CREATE
-        )
+        ctx_1 = AKSAgentPoolContext(self.cmd, {}, self.models, decorator_mode=DecoratorMode.CREATE)
         agentpool = self.models.AgentPool()
         ctx_1.attach_agentpool(agentpool)
         self.assertEqual(ctx_1.agentpool, agentpool)
         # fail on attach again
         with self.assertRaises(CLIInternalError):
             ctx_1.attach_agentpool(agentpool)
+
+    def test_get_resource_group_name(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {"resource_group_name": "test_rg_name"},
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1.get_resource_group_name(), "test_rg_name")
+
+    def test_get_cluster_name(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {"cluster_name": "test_cluster_name"},
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1.get_cluster_name(), "test_cluster_name")
+
+    def test_get_nodepool_name(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {"nodepool_name": "test_nodepool_name"},
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        with patch(
+            "azure.cli.command_modules.acs.agentpool_decorator.cf_agent_pools",
+            return_value=Mock(),
+        ):
+            self.assertEqual(ctx_1.get_nodepool_name(), "test_nodepool_name")
+
+        agentpool_1 = self.models.AgentPool()
+        agentpool_1.name = "test_ap_name"
+        ctx_1.attach_agentpool(agentpool_1)
+        with patch(
+            "azure.cli.command_modules.acs.agentpool_decorator.cf_agent_pools",
+            return_value=Mock(),
+        ):
+            self.assertEqual(ctx_1.get_nodepool_name(), "test_ap_name")
+
+        # custom
+        ctx_2 = AKSAgentPoolContext(
+            self.cmd,
+            {"nodepool_name": "test_nodepool_name"},
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        mock_agentpool_instance_1 = Mock()
+        mock_agentpool_instance_1.name = "test_nodepool_name"
+        mock_agentpool_operations = Mock(list=Mock(return_value=[mock_agentpool_instance_1]))
+        # fail on existing nodepool name
+        with patch(
+            "azure.cli.command_modules.acs.agentpool_decorator.cf_agent_pools",
+            mock_agentpool_operations,
+        ), self.assertRaises(InvalidArgumentValueError):
+            ctx_2.get_nodepool_name()
+
+    def test_get_max_surge(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {
+                "max_surge": None,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1.get_max_surge(), None)
+
+        upgrade_settings_1 = self.models.AgentPoolUpgradeSettings(max_surge="test_max_surge")
+        agentpool_1 = self.models.AgentPool(upgrade_settings=upgrade_settings_1)
+        ctx_1.attach_agentpool(agentpool_1)
+        self.assertEqual(ctx_1.get_max_surge(), "test_max_surge")
+
+    def test_get_aks_custom_headers(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {
+                "aks_custom_headers": None,
+            },
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1.get_aks_custom_headers(), {})
+
+        # custom value
+        ctx_2 = AKSAgentPoolContext(
+            self.cmd,
+            {
+                "aks_custom_headers": "abc=def,xyz=123",
+            },
+            self.models,
+            decorator_mode=DecoratorMode.UPDATE,
+        )
+        self.assertEqual(ctx_2.get_aks_custom_headers(), {"abc": "def", "xyz": "123"})
+
+    def test_get_no_wait(self):
+        # default
+        ctx_1 = AKSAgentPoolContext(
+            self.cmd,
+            {"no_wait": False},
+            self.models,
+            decorator_mode=DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1.get_no_wait(), False)
 
 
 class AKSAgentPoolAddDecoratorTestCase(unittest.TestCase):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Refactor `aks nodepool add` - part 2.
  - Add  set_up_upgrade_settings.

Unit Test Coverage:

> "covered_lines": 97,
> "num_statements": 103,
> "percent_covered": 94.1747572815534,
> "percent_covered_display": "94",
> "missing_lines": 6,
> "excluded_lines": 0

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change.
[Component Name 2] `az command b`: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
