### PR TITLE
{Packaging} Unify `applicationinsights` versions and remove `wrapt`

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -136,5 +136,4 @@ urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==1.3.1
-wrapt==1.11.2
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -137,5 +137,4 @@ urllib3==1.26.7
 vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==1.3.1
-wrapt==1.11.2
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,5 +1,5 @@
 antlr4-python3-runtime==4.7.2
-applicationinsights==0.11.7
+applicationinsights==0.11.9
 argcomplete==1.11.1
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1


### PR DESCRIPTION
**Description**<!--Mandatory-->

Address concerns from https://github.com/microsoft/component-detection/issues/74#issuecomment-1061256973

### `applicationinsights`

`applicationinsights` dependency was introduced by https://github.com/Azure/azure-cli/pull/9785, but it has different versions on different platforms for unknown reason, possible simply due to a mistake:

https://github.com/Azure/azure-cli/blob/f29ea8ca7355095c5a964437bf37152dad305aa8/src/azure-cli/requirements.py3.windows.txt#L2

https://github.com/Azure/azure-cli/blob/f29ea8ca7355095c5a964437bf37152dad305aa8/src/azure-cli/requirements.py3.Linux.txt#L2

https://github.com/Azure/azure-cli/blob/f29ea8ca7355095c5a964437bf37152dad305aa8/src/azure-cli/requirements.py3.Darwin.txt#L2

This PR unifies `applicationinsights` versions.

### `wrapt`

`wrapt` is an indirect dependency:

```
> pipdeptree --reverse --packages wrapt
wrapt==1.13.3
  - astroid==2.8.6 [requires: wrapt>=1.11,<1.14]
    - pylint==2.11.1 [requires: astroid>=2.8.0,<2.9]
      - azdev==0.1.36 [requires: pylint==2.11.1]
  - Deprecated==1.2.13 [requires: wrapt>=1.10,<2]
    - PyGithub==1.55 [requires: deprecated]
      - azure-cli==2.32.0 [requires: PyGithub~=1.38]
  - vcrpy==4.1.1 [requires: wrapt]
    - azure-cli-testsdk==0.3.0 [requires: vcrpy>=1.10.3]
    - azure-devtools==1.2.0 [requires: vcrpy>=1.11.0]
```

So there is no need to pin its version.