### PR TITLE
{Core} Fix broken anchor in URI referring to quoting issues

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -551,7 +551,7 @@ def shell_safe_json_parse(json_or_dict_string, preserve_order=False, strict=True
             # Recommendation for all shells
             from azure.cli.core.azclierror import InvalidArgumentValueError
             recommendation = "The JSON may have been parsed by the shell. See " \
-                             "https://docs.microsoft.com/cli/azure/use-cli-effectively#quoting-issues"
+                             "https://docs.microsoft.com/cli/azure/use-cli-effectively#use-quotation-marks-in-arguments"
 
             # Recommendation especially for PowerShell
             parent_proc = get_parent_proc_name()


### PR DESCRIPTION
Commit https://github.com/MicrosoftDocs/azure-docs-cli/commit/f8bda76af6ad42ebbc6c8bf1395dde0931869813 removed the referred anchor.
