### PR TITLE
[Role] BREAKING CHANGE: `az ad sp create-for-rbac`: Change `validity_months` to `years * 12`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1615,7 +1615,7 @@ def _create_self_signed_cert_with_keyvault(cli_ctx, years, keyvault, keyvault_ce
                 'keyCertSign'
             ],
             'subject': 'CN=KeyVault Generated',
-            'validity_in_months': int((years * 12) + 1)
+            'validity_in_months': int(years * 12)
         }
     }
     vault_base_url = 'https://{}{}/'.format(keyvault, cli_ctx.cloud.suffixes.keyvault_dns)


### PR DESCRIPTION
- Fix IcM [294632821](https://portal.microsofticm.com/imp/v3/incidents/details/294632821/home), [294421779](https://portal.microsofticm.com/imp/v3/incidents/details/294421779/home)
- Fix #21609

## Symptom

When using `az ad sp create-for-rbac` to create a self-signed certificate in keyvault, Azure CLI by default creates the certificate with validity of `years * 12 + 1`, where `--years` is 1 by default. So the default validity is 13 month.

If a user also has a preview built-in [Azure Policy](https://docs.microsoft.com/en-us/azure/governance/policy/overview) [`Certificates_ValidityPeriod`](https://github.com/Azure/azure-policy/blob/d58633adb7f5c8764cb0541ff0b6cfbf6ba24ae0/built-in-policies/policyDefinitions/Key%20Vault/Certificates_ValidityPeriod.json#L43-L44) configured which enforces the certificate validity to be no longer than 12 months. `az ad sp create-for-rbac`'s certificate creation will fail:

> Forbidden: {"objectName":"TestPolicy","message":"Certificate 'TestPolicy' was disallowed by policy.","policyIdentifiers":{"policyAssignment":{"name":"[Preview]: Certificates should have the specified maximum validity period","id":"/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Authorization/policyAssignments/57278163f7ac4bb3a926c060"},"policyDefinition":{"name":"[Preview]: Certificates should have the specified maximum validity period","id":"/providers/Microsoft.Authorization/policyDefinitions/0a075868-4c26-42ef-914c-5bc007359560"}}}

## Cause

This `years * 12 + 1` behavior has been there since the dawn of Azure CLI (https://github.com/Azure/azure-cli/pull/3133).


## Solution

This PR changes the certificate validity to be `12 * years` by removing the extra 1 month, just like how `az keyvault certificate` commands behaves:

https://github.com/Azure/azure-cli/blob/28da7dc9b62d5093f214b1d1526a6b8efcdef217/src/azure-cli/azure/cli/command_modules/keyvault/custom.py#L121

## Also see

- https://github.com/Azure/azure-policy/issues/920
- https://github.com/MicrosoftDocs/azure-docs/issues/89766
- https://github.com/Azure/azure-cli/issues/10746

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Role] BREAKING CHANGE: `az ad sp create-for-rbac`: When creating a self-signed certificate in keyvault, `validity_months` is changed from `years * 12 + 1` to `years * 12`

