### PR TITLE
[ACR] Deprecate preview command group and implement same commands in parent command group

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -60,7 +60,7 @@ acr manifest metadata show:
       - no_positional_parameters
 acr manifest metadata update:
   parameters:
-    repo_id:
+    manifest_id:
       rule_exclusions:
       - no_positional_parameters
 acr manifest show:

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -43,22 +43,22 @@ acr manifest list-referrers:
     manifest_id:
       rule_exclusions:
       - no_positional_parameters
-acr manifest metadata list:
+acr manifest list-metadata:
   parameters:
     repo_id:
       rule_exclusions:
       - no_positional_parameters
-acr manifest metadata show:
-  parameters:
-    manifest_id:
-      rule_exclusions:
-      - no_positional_parameters
-acr manifest metadata update:
-  parameters:
-    manifest_id:
-      rule_exclusions:
-      - no_positional_parameters
 acr manifest show:
+  parameters:
+    manifest_id:
+      rule_exclusions:
+      - no_positional_parameters
+acr manifest show-metadata:
+  parameters:
+    manifest_id:
+      rule_exclusions:
+      - no_positional_parameters
+acr manifest update-metadata:
   parameters:
     manifest_id:
       rule_exclusions:

--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -48,6 +48,21 @@ acr manifest list-metadata:
     repo_id:
       rule_exclusions:
       - no_positional_parameters
+acr manifest metadata list:
+  parameters:
+    repo_id:
+      rule_exclusions:
+      - no_positional_parameters
+acr manifest metadata show:
+  parameters:
+    manifest_id:
+      rule_exclusions:
+      - no_positional_parameters
+acr manifest metadata update:
+  parameters:
+    repo_id:
+      rule_exclusions:
+      - no_positional_parameters
 acr manifest show:
   parameters:
     manifest_id:

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -550,38 +550,38 @@ type: group
 short-summary: Manage artifact manifest metadata in Azure Container Registries.
 """
 
-helps['acr manifest metadata show'] = """
+helps['acr manifest show-metadata'] = """
 type: command
 short-summary: Get the metadata of an artifact in an Azure Container Registry.
 examples:
   - name: Get the metadata of the tag 'hello-world:latest'.
-    text: az acr manifest metadata show -r MyRegistry -n hello-world:latest
+    text: az acr manifest show-metadata -r MyRegistry -n hello-world:latest
   - name: Get the metadata of the tag 'hello-world:latest'.
-    text: az acr manifest metadata show MyRegistry.azurecr.io/hello-world:latest
+    text: az acr manifest show-metadata MyRegistry.azurecr.io/hello-world:latest
   - name: Get the metadata of the manifest referenced by digest 'hello-world@sha256:abc123'.
-    text: az acr manifest metadata show -r MyRegistry -n hello-world@sha256:abc123
+    text: az acr manifest show-metadata -r MyRegistry -n hello-world@sha256:abc123
 """
 
-helps['acr manifest metadata list'] = """
+helps['acr manifest list-metadata'] = """
 type: command
 short-summary: List the metadata of the manifests in a repository in an Azure Container Registry.
 examples:
   - name: List the metadata of the manifests in the repository 'hello-world'.
-    text: az acr manifest metadata list -r MyRegistry -n hello-world
+    text: az acr manifest list-metadata -r MyRegistry -n hello-world
   - name: List the metadata of the manifests in the repository 'hello-world'.
-    text: az acr manifest metadata list MyRegistry.azurecr.io/hello-world
+    text: az acr manifest list-metadata MyRegistry.azurecr.io/hello-world
 """
 
-helps['acr manifest metadata update'] = """
+helps['acr manifest update-metadata'] = """
 type: command
 short-summary: Update the manifest metadata of an artifact in an Azure Container Registry.
 examples:
   - name: Update the metadata of the tag 'hello-world:latest'.
-    text: az acr manifest metadata update -r MyRegistry -n hello-world:latest --write-enabled false
+    text: az acr manifest update-metadata -r MyRegistry -n hello-world:latest --write-enabled false
   - name: Update the metadata of the tag 'hello-world:latest'.
-    text: az acr manifest metadata update MyRegistry.azurecr.io/hello-world:latest --write-enabled false
+    text: az acr manifest update-metadata MyRegistry.azurecr.io/hello-world:latest --write-enabled false
   - name: Update the metadata of the artifact referenced by digest 'hello-world@sha256:abc123'.
-    text: az acr manifest metadata update -r MyRegistry -n hello-world@sha256:abc123 --write-enabled false
+    text: az acr manifest update-metadata -r MyRegistry -n hello-world@sha256:abc123 --write-enabled false
 """
 
 helps['acr run'] = """

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -584,6 +584,21 @@ examples:
     text: az acr manifest update-metadata -r MyRegistry -n hello-world@sha256:abc123 --write-enabled false
 """
 
+helps['acr manifest metadata show'] = """
+type: command
+short-summary: Get the metadata of an artifact in an Azure Container Registry.
+"""
+
+helps['acr manifest metadata list'] = """
+type: command
+short-summary: List the metadata of the manifests in a repository in an Azure Container Registry.
+"""
+
+helps['acr manifest metadata update'] = """
+type: command
+short-summary: Update the manifest metadata of an artifact in an Azure Container Registry.
+"""
+
 helps['acr run'] = """
 type: command
 short-summary: Queues a quick run providing streamed logs for an Azure Container Registry.

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -188,6 +188,15 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('acr manifest update-metadata') as c:
         c.positional('manifest_id', arg_type=manifest_id_type)
 
+    with self.argument_context('acr manifest show-metadata') as c:
+        c.argument('manifest_id', arg_type=manifest_id_type)
+
+    with self.argument_context('acr manifest list-metadata') as c:
+        c.argument('repo_id', arg_type=repo_id_type)
+
+    with self.argument_context('acr manifest update-metadata') as c:
+        c.argument('manifest_id', arg_type=manifest_id_type)
+
     with self.argument_context('acr repository untag') as c:
         c.argument('image', options_list=['--image', '-t'], help="The name of the image. May include a tag in the format 'name:tag'.")
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -188,14 +188,14 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     with self.argument_context('acr manifest update-metadata') as c:
         c.positional('manifest_id', arg_type=manifest_id_type)
 
-    with self.argument_context('acr manifest show-metadata') as c:
-        c.argument('manifest_id', arg_type=manifest_id_type)
+    with self.argument_context('acr manifest metadata show') as c:
+        c.positional('manifest_id', arg_type=manifest_id_type)
 
-    with self.argument_context('acr manifest list-metadata') as c:
-        c.argument('repo_id', arg_type=repo_id_type)
+    with self.argument_context('acr manifest metadata list') as c:
+        c.positional('repo_id', arg_type=repo_id_type)
 
-    with self.argument_context('acr manifest update-metadata') as c:
-        c.argument('manifest_id', arg_type=manifest_id_type)
+    with self.argument_context('acr manifest metadata update') as c:
+        c.positional('manifest_id', arg_type=manifest_id_type)
 
     with self.argument_context('acr repository untag') as c:
         c.argument('image', options_list=['--image', '-t'], help="The name of the image. May include a tag in the format 'name:tag'.")

--- a/src/azure-cli/azure/cli/command_modules/acr/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_params.py
@@ -179,13 +179,13 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('artifact_type', help='Filter referrers based on artifact type.')
         c.argument('recursive', help='Recursively include referrer artifacts.', action='store_true')
 
-    with self.argument_context('acr manifest metadata show') as c:
+    with self.argument_context('acr manifest show-metadata') as c:
         c.positional('manifest_id', arg_type=manifest_id_type)
 
-    with self.argument_context('acr manifest metadata list') as c:
+    with self.argument_context('acr manifest list-metadata') as c:
         c.positional('repo_id', arg_type=repo_id_type)
 
-    with self.argument_context('acr manifest metadata update') as c:
+    with self.argument_context('acr manifest update-metadata') as c:
         c.positional('manifest_id', arg_type=manifest_id_type)
 
     with self.argument_context('acr repository untag') as c:

--- a/src/azure-cli/azure/cli/command_modules/acr/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/commands.py
@@ -206,7 +206,7 @@ def load_command_table(self, _):
         g.command('list', 'acr_repository_list')
         g.command('show-tags', 'acr_repository_show_tags')
         g.command('show-manifests', 'acr_repository_show_manifests',
-                  deprecate_info=self.deprecate(redirect='acr manifest metadata list', hide=True))
+                  deprecate_info=self.deprecate(redirect='acr manifest list-metadata', hide=True))
         g.show_command('show', 'acr_repository_show')
         g.command('update', 'acr_repository_update')
         g.command('delete', 'acr_repository_delete')
@@ -217,8 +217,19 @@ def load_command_table(self, _):
         g.command('list', 'acr_manifest_list', table_transformer=manifest_output_format)
         g.command('delete', 'acr_manifest_delete')
         g.command('list-referrers', 'acr_manifest_list_referrers', table_transformer=list_referrers_output_format)
+        g.show_command('show-metadata', 'acr_manifest_metadata_show')
+        g.command('list-metadata', 'acr_manifest_metadata_list')
+        g.command('update-metadata', 'acr_manifest_metadata_update')
 
-    with self.command_group('acr manifest metadata', acr_manifest_util, is_preview=True) as g:
+    def _metadata_deprecate_message(self):
+        msg = "This {} has been deprecated and will be removed in future release.".format(self.object_type)
+        msg += " Use '{}' instead.".format(self.redirect)
+        return msg
+
+    with self.command_group('acr manifest metadata', acr_manifest_util, is_preview=True,
+                            deprecate_info=self.deprecate(redirect="az acr manifest",
+                                                          message_func=_metadata_deprecate_message,
+                                                          hide=True)) as g:
         g.show_command('show', 'acr_manifest_metadata_show')
         g.command('list', 'acr_manifest_metadata_list')
         g.command('update', 'acr_manifest_metadata_update')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR deprecates the preview `az acr manifest metadata` command group and moves the 3 commands into the parent `az acr manifest` command group. This is essentially a renaming or reorganization of the commands after receiving customer feedback.  **There is no new functionality added**, just name changes.

 
**Testing Guide**
<!--Example commands with explanations.-->
helps['acr manifest show-metadata'] = """
type: command
short-summary: Get the metadata of an artifact in an Azure Container Registry.
examples:
  - name: Get the metadata of the tag 'hello-world:latest'.
    text: az acr manifest show-metadata -r MyRegistry -n hello-world:latest
  - name: Get the metadata of the tag 'hello-world:latest'.
    text: az acr manifest show-metadata MyRegistry.azurecr.io/hello-world:latest
  - name: Get the metadata of the manifest referenced by digest 'hello-world@sha256:abc123'.
    text: az acr manifest show-metadata -r MyRegistry -n hello-world@sha256:abc123
"""

helps['acr manifest list-metadata'] = """
type: command
short-summary: List the metadata of the manifests in a repository in an Azure Container Registry.
examples:
  - name: List the metadata of the manifests in the repository 'hello-world'.
    text: az acr manifest list-metadata -r MyRegistry -n hello-world
  - name: List the metadata of the manifests in the repository 'hello-world'.
    text: az acr manifest list-metadata MyRegistry.azurecr.io/hello-world
"""

helps['acr manifest update-metadata'] = """
type: command
short-summary: Update the manifest metadata of an artifact in an Azure Container Registry.
examples:
  - name: Update the metadata of the tag 'hello-world:latest'.
    text: az acr manifest update-metadata -r MyRegistry -n hello-world:latest --write-enabled false
  - name: Update the metadata of the tag 'hello-world:latest'.
    text: az acr manifest update-metadata MyRegistry.azurecr.io/hello-world:latest --write-enabled false
  - name: Update the metadata of the artifact referenced by digest 'hello-world@sha256:abc123'.
    text: az acr manifest update-metadata -r MyRegistry -n hello-world@sha256:abc123 --write-enabled false
"""
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] Deprecate `az acr manifest metadata` command group
[ACR] `az acr manifest`: Add `show-metadata`, `list-metadata`, and `update-metadata` commands

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
