### PR TITLE
{Packaging} Use Red Hat Universal Base Image 8 to build `el8` RPM package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -747,10 +747,11 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: rpm-centos7
 
-# rpmbuild on CentOS Stream 8 is slow, we use a separate job for CentOS Stream 8 instead of strategy.matrix so that
-# TestRpmPackage can start right after BuildRpmPackageCentOS7 finishes.
-- job: BuildRpmPackageCentOSStream8
-  displayName: Build Rpm Package CentOS Stream 8
+# TODO: rpmbuild on Red Hat UBI 8 is slow for unknown reason. Still working with Red Hat to investigate.
+# We use a separate job for Red Hat UBI 8 instead of strategy.matrix so that TestRpmPackage can start right after
+# BuildRpmPackageCentOS7 finishes.
+- job: BuildRpmPackageUbi8
+  displayName: Build Rpm Package Red Hat Universal Base Image 8
   # Do not run this job for Pull Requests due to the slowness
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
@@ -762,7 +763,7 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
     env:
-      IMAGE: centos_stream8
+      IMAGE: ubi8
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
     inputs:
@@ -771,7 +772,7 @@ jobs:
     displayName: 'Publish Artifact: rpm'
     inputs:
       TargetPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: rpm-centos_stream8
+      ArtifactName: rpm-ubi8
 
 
 - job: TestRpmPackage

--- a/scripts/release/rpm/Dockerfile.ubi8
+++ b/scripts/release/rpm/Dockerfile.ubi8
@@ -1,9 +1,8 @@
-# CentOS Stream 8 docker image is distributed as quay.io/centos/centos:stream8 at
-# https://quay.io/repository/centos/centos?tab=tags. See https://wiki.centos.org/FAQ/CentOSStream
+# Red Hat Universal Base Image 8: https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e
 
-ARG tag=stream8
+ARG tag=8.4
 
-FROM quay.io/centos/centos:${tag} AS build-env
+FROM registry.access.redhat.com/ubi8/ubi:${tag} AS build-env
 ARG cli_version=dev
 
 RUN yum update -y
@@ -17,7 +16,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 
-FROM quay.io/centos/centos:${tag} AS execution-env
+FROM registry.access.redhat.com/ubi8/ubi:${tag} AS execution-env
 
 RUN yum update -y
 RUN yum install -y python3 python3-virtualenv

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -6,7 +6,7 @@ set -exv
 
 : "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
 
-# IMAGE should be one of 'centos7', 'centos_stream8'
+# IMAGE should be one of 'centos7', 'ubi8'
 : "${IMAGE:?IMAGE environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`


### PR DESCRIPTION
**Description**<!--Mandatory-->

- Based on https://github.com/Azure/azure-cli/pull/20918
- Fix #https://github.com/Azure/azure-cli/issues/20719

Since we have get authorization to use [Red Hat Universal Base Image 8](https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e), we can now use it, instead of using CentOS Stream 8 which is an upstream of  Red Hat Enterprise Linux 8 and may not be stable.

