### PR TITLE
{Packaging} Use proper PEP 508 environment marker for dependencies

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -57,15 +57,12 @@ DEPENDENCIES = [
     'packaging>=20.9,<22.0',
     'paramiko>=2.0.8,<3.0.0',
     'pkginfo>=1.5.0.1',
+    # psutil can't install on cygwin: https://github.com/Azure/azure-cli/issues/9399
+    'psutil~=5.9; sys_platform != "cygwin"',
     'PyJWT>=2.1.0',
     'pyopenssl>=17.1.0',  # https://github.com/pyca/pyopenssl/pull/612
     'requests[socks]'
 ]
-
-# dependencies for specific OSes
-if not sys.platform.startswith('cygwin'):
-    DEPENDENCIES.append('psutil~=5.9')
-
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -139,6 +139,8 @@ DEPENDENCIES = [
     'azure-synapse-spark~=0.2.0',
     'chardet~=3.0.4',
     'colorama~=0.4.4',
+    # On Linux, the distribution (Ubuntu, Debian, etc) and version are checked for `az feedback`
+    'distro; sys_platform == "linux"',
     'fabric~=2.4',
     'javaproperties~=0.5.1',
     'jsondiff~=1.3.0',
@@ -153,10 +155,6 @@ DEPENDENCIES = [
     'websocket-client~=1.3.1',
     'xmltodict~=0.12'
 ]
-
-# On Linux, the distribution (Ubuntu, Debian, etc) and version are checked
-if sys.platform == 'linux':
-    DEPENDENCIES.append('distro')
 
 with open('README.rst', 'r', encoding='utf-8') as f:
     README = f.read()


### PR DESCRIPTION
**Description**<!--Mandatory-->

Similar to https://github.com/microsoft/knack/pull/257, use proper [PEP 508 environment marker](https://peps.python.org/pep-0508/#environment-markers) for dependencies.

Dependencies added by `DEPENDENCIES.append()` are only added to the list of requirements if the `setup.py` is executed. However, `azure-cli` and `azure-cli-core` are being distributed as a wheel packages and `setup.py` is not executed when installing a wheel package. Instead, dependencies are translated into `azure_cli-2.34.1-py3-none-any.whl/azure_cli-2.34.1.dist-info/METADATA` when building wheels:

```
Requires-Dist: argcomplete
Requires-Dist: jmespath
Requires-Dist: pygments
Requires-Dist: pyyaml
Requires-Dist: tabulate
```

What's in the wheel is determined by the packaging system, which is like taking a snapshot when packaging the wheel and the condition evaluation result is frozen into the wheel. Therefore, these conditional install won't work as expected.

```
conditional install in setup.py -----------> Requires-Dist in whl METADATA -----------> pip
                        frozen by packaging system
```

