### PR TITLE
[Packaging] Bump Python image to `3.10.3-alpine3.15`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.10.2"
+ARG PYTHON_VERSION="3.10.3"
 
 FROM python:${PYTHON_VERSION}-alpine3.15
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

CVE-2022-0778 was identified on OpenSSL library: https://nvd.nist.gov/vuln/detail/CVE-2022-0778

Alpine Linux 3.15 has this vulnerability and fixed it in 3.15.1:

https://alpinelinux.org/posts/Alpine-3.15.1-released.html

> This release includes a fix for openssl [CVE-2022-0778](https://security.alpinelinux.org/vuln/CVE-2022-0778).

See https://github.com/alpinelinux/docker-alpine/issues/243

Python 3.10.2 image is no longer updated and 3.10.3 updated its base Alpine Linux image to 3.15.1:

```
> docker run -it --rm python:3.10.3-alpine3.15 cat /etc/os-release
Unable to find image 'python:3.10.3-alpine3.15' locally
3.10.3-alpine3.15: Pulling from library/python
Digest: sha256:7099d74f22c2d7a597875c3084e840846ca294ad01da1e845b0154100a6ac15b
Status: Downloaded newer image for python:3.10.3-alpine3.15
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.15.1
PRETTY_NAME="Alpine Linux v3.15"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://bugs.alpinelinux.org/"
```

See https://hub.docker.com/_/python

This PR bumps the docker image's base image to `python:3.10.3-alpine3.15`.
