### PR TITLE
[App Service] Fix #20240: `az functionapp deployment source config-zip`: Fix the bug that the parameter `--slot` doesn't work

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -698,7 +698,7 @@ def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):
 
     blob_uri = block_blob_service.make_blob_url(container_name, blob_name, sas_token=blob_token)
     website_run_from_setting = "WEBSITE_RUN_FROM_PACKAGE={}".format(blob_uri)
-    update_app_settings(cmd, resource_group_name, name, settings=[website_run_from_setting])
+    update_app_settings(cmd, resource_group_name, name, settings=[website_run_from_setting], slot=slot)
     client = web_client_factory(cmd.cli_ctx)
 
     try:


### PR DESCRIPTION
**Description**
Correctly pass the slot name through to update app settings when the zip has been uploaded. 

**Testing Guide**

Run the following command with a function against a Linux Consumption plan function with a production and a staging slot.

`az functionapp deployment source config-zip -g "<resource group>" -n "<function app name>" --src "MyFunctionCode.Zip" --subscription "<subscription name>" --slot "staging"`

Before this fix, the deployment targets the production slot no matter what.  After this fix the function should be correctly deployed.
