### PR TITLE
{Role} Secure `_create_self_signed_cert`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1534,22 +1534,30 @@ def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-
     from OpenSSL import crypto
     from datetime import timedelta
 
-    _, cert_file = tempfile.mkstemp()
-    _, key_file = tempfile.mkstemp()
+    # Create a PEM file ~/tmpxxxxxxxx.pem with both PRIVATE KEY & CERTIFICATE so users can use to log in.
+    # The PEM file looks like
+    # -----BEGIN PRIVATE KEY-----
+    # MIIEv...
+    # -----END PRIVATE KEY-----
+    # -----BEGIN CERTIFICATE-----
+    # MIICo...
+    # -----END CERTIFICATE-----
 
-    # create a file with both cert & key so users can use to login
-    # leverage tempfile ot produce a random file name
-    _, temp_file = tempfile.mkstemp()
-    creds_file = path.join(path.expanduser("~"), path.basename(temp_file) + '.pem')
+    # Leverage tempfile to produce a random file name. The temp file itself is automatically deleted.
+    # There doesn't seem to be a good way to create a random file name without creating the file itself:
+    # https://stackoverflow.com/questions/26541416/generate-temporary-file-names-without-creating-actual-file-in-python
+    with tempfile.NamedTemporaryFile() as f:
+        temp_file_name = f.name
+    creds_file = path.join(path.expanduser("~"), path.basename(temp_file_name) + '.pem')
 
-    # create a key pair
+    # Create a key pair
     k = crypto.PKey()
     k.generate_key(crypto.TYPE_RSA, 2048)
 
-    # create a self-signed cert
+    # Create a self-signed cert
     cert = crypto.X509()
     subject = cert.get_subject()
-    # as long it works, we skip fileds C, ST, L, O, OU, which we have no reasonable defaults for
+    # As long as it works, we skip fields C, ST, L, O, OU, which we have no reasonable defaults for
     subject.CN = 'CLI-Login'
     cert.set_serial_number(1000)
     asn1_format = '%Y%m%d%H%M%SZ'
@@ -1561,23 +1569,16 @@ def _create_self_signed_cert(start_date, end_date):  # pylint: disable=too-many-
     cert.set_pubkey(k)
     cert.sign(k, 'sha1')
 
-    with open(cert_file, "wt") as f:
-        f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode())
-    with open(key_file, "wt") as f:
-        f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode())
+    cert_string = crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode()
+    key_string = crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode()
 
-    cert_string = None
-    with open(creds_file, 'wt') as cf:
-        with open(key_file, 'rt') as f:
-            cf.write(f.read())
-        with open(cert_file, "rt") as f:
-            cert_string = f.read()
-            cf.write(cert_string)
-    os.chmod(creds_file, 0o600)  # make the file readable/writable only for current user
+    with os.fdopen(_open(creds_file), 'w+') as cf:
+        cf.write(key_string)
+        cf.write(cert_string)
 
-    # get rid of the header and tails for upload to AAD: ----BEGIN CERT....----
-    cert_string = re.sub(r'\-+[A-z\s]+\-+', '', cert_string).strip()
-    return (cert_string, creds_file, cert_start_date, cert_end_date)
+    # Get rid of the header and tail for uploading to AAD: -----BEGIN CERTIFICATE-----, -----END CERTIFICATE-----
+    cert_string = re.sub(r'-+[A-z\s]+-+', '', cert_string).strip()
+    return cert_string, creds_file, cert_start_date, cert_end_date
 
 
 def _create_self_signed_cert_with_keyvault(cli_ctx, years, keyvault, keyvault_cert_name):  # pylint: disable=too-many-locals
@@ -1870,3 +1871,9 @@ def _random_password(length):
 
     password = first_character + ''.join(password_list)
     return password
+
+
+def _open(location):
+    """Open a file that only the current user can access."""
+    # The 600 seems no-op on Windows, and that is fine.
+    return os.open(location, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600)


### PR DESCRIPTION
## Context

When creating a self-signed certificate in commands such as `az ad sp create-for-rbac` or `az ad app credential reset`:

1. Create a `temp_file` and use its name for `creds_file`.
2. The certificate and private key are saved to `cert_file` and `key_file`.
3. The contents of `cert_file` and `key_file` are read back and combined into `creds_file`.
4. Change the mode of `creds_file` to `0o600` (`rw-------`).

This procedure exposes problems:

## Problem 1: `temp_file` is not deleted

According to https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp:

> Unlike `TemporaryFile()`, the user of `mkstemp()` is responsible for deleting the temporary file when done with it.

At least, the temp file made by `mkstemp` is empty with permission `0o600`, so it doesn't leak any credential. It's just it will be left as trash.

**Solution**: Use `NamedTemporaryFile` which automatically deletes the temp file.

## Problem 2: `cert_file` and `key_file` are not deleted

The "write to file and read it back" logic was introduced by https://github.com/Azure/azure-cli/pull/2457. The reason behind it is unknown. At least, they are secure with permission `0o600`, so no one else can read them:

```
$ ls -ld /tmp/tmp*
-rw------- 1 user1 user1    0 Mar 21 15:37 /tmp/tmp7v82yx_y
-rw------- 1 user1 user1 1704 Mar 21 18:57 /tmp/tmpavuictrh
-rw------- 1 user1 user1  973 Mar 21 18:57 /tmp/tmphv9npp_n
```

**Solution**: Only keep certificate and key values in memory as variables. Do not write them to files.

## Problem 3: Time gap between `creds_file`'s `open` and `chmod`

There is a time gap between `creds_file`'s `open` and `chmod`, during which its permission is `0o755` (`rwxr-xr-x`) meaning other users can read its content.

**Solution**: Create `creds_file` with the right mode, instead of changing it later. ADAL-based Azure CLI uses this approach for creating `accessTokens.json`:

https://github.com/Azure/azure-cli/blob/14cc787d0f58bc649d402b486fdecc5625eee9ac/src/azure-cli-core/azure/cli/core/_profile.py#L1100-L1101

`msal-extensions` made the same change in https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/107.

## References

- https://stackoverflow.com/questions/5624359/write-file-with-specific-permissions-in-python
- https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use
- MSRC 70882

