### PR TITLE
[App Service] Fix #21728: `az webapp deployment github-actions add`: Allow passing in runtime with colon delimiter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -4964,6 +4964,7 @@ def delete_function_key(cmd, resource_group_name, name, key_name, function_name=
 
 def add_github_actions(cmd, resource_group, name, repo, runtime=None, token=None, slot=None,  # pylint: disable=too-many-statements,too-many-branches
                        branch='master', login_with_github=False, force=False):
+    runtime = _StackRuntimeHelper(cmd).remove_delimiters(runtime)  # normalize "runtime:version"
     if not token and not login_with_github:
         raise_missing_token_suggestion()
     elif not token:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -48,15 +48,16 @@ class TestWebappMocked(unittest.TestCase):
     def setUp(self):
         self.client = WebSiteManagementClient(mock.MagicMock(), '123455678')
 
-    @mock.patch('azure.cli.command_modules.appservice.custom._update_site_source_control_properties_for_gh_action', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom._add_publish_profile_to_github', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom.prompt_y_n', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom._get_app_runtime_info', autospec=True)
-    @mock.patch('github.Github', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom.parse_resource_id', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
-    @mock.patch('azure.cli.command_modules.appservice.custom.get_app_details', autospec=True)
-    def test_webapp_github_actions_add(self, get_app_details_mock, web_client_factory_mock,  *args):
+    @mock.patch('azure.cli.command_modules.appservice.custom._update_site_source_control_properties_for_gh_action')
+    @mock.patch('azure.cli.command_modules.appservice.custom._add_publish_profile_to_github')
+    @mock.patch('azure.cli.command_modules.appservice.custom.prompt_y_n')
+    @mock.patch('azure.cli.command_modules.appservice.custom._get_app_runtime_info')
+    @mock.patch('github.Github')
+    @mock.patch('azure.cli.command_modules.appservice.custom.parse_resource_id')
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_site_availability')
+    @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory')
+    @mock.patch('azure.cli.command_modules.appservice.custom.get_app_details')
+    def test_webapp_github_actions_add(self, get_app_details_mock, web_client_factory_mock, site_availability_mock,  *args):
         runtime = "python:3.9"
         rg = "group"
         is_linux = True
@@ -64,6 +65,7 @@ class TestWebappMocked(unittest.TestCase):
         get_app_details_mock.return_value = mock.Mock()
         get_app_details_mock.return_value.resource_group = rg
         web_client_factory_mock.return_value.app_service_plans.get.return_value.reserved = is_linux
+        site_availability_mock.return_value.name_available = False
 
         with mock.patch('azure.cli.command_modules.appservice.custom._runtime_supports_github_actions', autospec=True) as m:
             add_github_actions(cmd, rg, "name", "repo", runtime, "token")


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #21728

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
