### PR TITLE
{CI} Explicitly fetch PR target branch

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -43,6 +43,8 @@ steps:
 
       if [[ "$(Build.Reason)" == "PullRequest" && "${{ parameters.fullTest }}" == 'False' ]]; then
         echo "Running incremental test"
+        # If CI is set to shallow fetch, target branch should be expilictly fetched.
+        git fetch origin --depth=1 $(System.PullRequest.TargetBranch)
         azdev test --no-exitfirst --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch) --cli-ci --profile ${{ parameters.profile }} --verbose --series
       else
         echo "Running full test"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1004,6 +1004,8 @@ jobs:
       . env/bin/activate
       python scripts/ci/service_name.py
       if [[ "$(System.PullRequest.TargetBranch)" != "" ]]; then
+        # If CI is set to shallow fetch, target branch should be expilictly fetched.
+        git fetch origin --depth=1 $(System.PullRequest.TargetBranch)
         azdev linter --ci-exclusions --min-severity medium --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch)
       else
         azdev linter --ci-exclusions --min-severity medium


### PR DESCRIPTION
**Description**<!--Mandatory-->

When shallow fetch is enabled in ADO

https://dev.azure.com/azure-sdk/public/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=246&view=Tab_Tasks

![image](https://user-images.githubusercontent.com/4003950/159846107-47c27aeb-ad2e-4f99-aa75-d5668d1a152b.png)

even though its help message says "each remote branch"

![image](https://user-images.githubusercontent.com/4003950/159846170-dd3ad256-98b5-45d7-9c53-31bdc5d2f961.png)

the actual commands is 

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1456114&view=logs&j=74095127-2a27-5370-37ed-15a4193f243f&t=3c34c09e-4c00-5f6e-f049-f62c206540eb

```
git init "/home/vsts/work/1/s"
git remote add origin https://github.com/Azure/azure-cli
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules origin --depth=1 +bf1b698fea11904607dfff3559b6feb2d5539b5f:refs/remotes/origin/bf1b698fea11904607dfff3559b6feb2d5539b5f
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules origin --depth=1 +bf1b698fea11904607dfff3559b6feb2d5539b5f
git checkout --progress --force refs/remotes/origin/bf1b698fea11904607dfff3559b6feb2d5539b5f
```

This will only fetch `bf1b698fea11904607dfff3559b6feb2d5539b5f`, but not `dev`.

Later, `azdev` fails with

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1456114&view=logs&j=74095127-2a27-5370-37ed-15a4193f243f&t=5cf5f89a-09fb-583c-72e4-4e4427c89fb1

```
ERROR: usage error, invalid branch: origin/dev
```

This PR explicitly fetches `origin/dev` branch so that it is available for the following `azdev` command.
