### PR TITLE
[Storage] Add `--service-endpoint` for storage data plane track2 commands to support customized account service endpoint

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -213,6 +213,7 @@ def cf_blob_service(cli_ctx, kwargs):
                              '_blob_service_client#BlobServiceClient')
     connection_string = kwargs.pop('connection_string', None)
     account_name = kwargs.pop('account_name', None)
+    account_url = kwargs.pop('account_url', None)
     account_key = kwargs.pop('account_key', None)
     token_credential = kwargs.pop('token_credential', None)
     sas_token = kwargs.pop('sas_token', None)
@@ -226,8 +227,8 @@ def cf_blob_service(cli_ctx, kwargs):
                                             .format(connection_string, str(err)),
                                             recommendation='Try `az storage account show-connection-string` '
                                                            'to get a valid connection string')
-
-    account_url = get_account_url(cli_ctx, account_name=account_name, service='blob')
+    if not account_url:
+        account_url = get_account_url(cli_ctx, account_name=account_name, service='blob')
     credential = account_key or sas_token or token_credential
 
     return t_blob_service(account_url=account_url, credential=credential, **client_kwargs)
@@ -249,6 +250,7 @@ def cf_blob_client(cli_ctx, kwargs):
         # del unused kwargs
         kwargs.pop('connection_string')
         kwargs.pop('account_name')
+        kwargs.pop('account_url')
         kwargs.pop('container_name')
         kwargs.pop('blob_name')
         return t_blob_client.from_blob_url(blob_url=kwargs.pop('blob_url'),
@@ -280,6 +282,7 @@ def cf_adls_service(cli_ctx, kwargs):
                              '_data_lake_service_client#DataLakeServiceClient')
     connection_string = kwargs.pop('connection_string', None)
     account_name = kwargs.pop('account_name', None)
+    account_url = kwargs.pop('account_url', None)
     account_key = kwargs.pop('account_key', None)
     token_credential = kwargs.pop('token_credential', None)
     sas_token = kwargs.pop('sas_token', None)
@@ -290,8 +293,8 @@ def cf_adls_service(cli_ctx, kwargs):
 
     if connection_string:
         return t_adls_service.from_connection_string(conn_str=connection_string, **client_kwargs)
-
-    account_url = get_account_url(cli_ctx, account_name=account_name, service='dfs')
+    if not account_url:
+        account_url = get_account_url(cli_ctx, account_name=account_name, service='dfs')
     credential = account_key or sas_token or token_credential
 
     return t_adls_service(account_url=account_url, credential=credential, **client_kwargs)
@@ -320,14 +323,15 @@ def cf_queue_service(cli_ctx, kwargs):
     t_queue_service = get_sdk(cli_ctx, ResourceType.DATA_STORAGE_QUEUE, '_queue_service_client#QueueServiceClient')
     connection_string = kwargs.pop('connection_string', None)
     account_name = kwargs.pop('account_name', None)
+    account_url = kwargs.pop('account_url', None)
     account_key = kwargs.pop('account_key', None)
     token_credential = kwargs.pop('token_credential', None)
     sas_token = kwargs.pop('sas_token', None)
 
     if connection_string:
         return t_queue_service.from_connection_string(conn_str=connection_string, **client_kwargs)
-
-    account_url = get_account_url(cli_ctx, account_name=account_name, service='queue')
+    if not account_url:
+        account_url = get_account_url(cli_ctx, account_name=account_name, service='queue')
     credential = account_key or sas_token or token_credential
 
     return t_queue_service(account_url=account_url, credential=credential, **client_kwargs)
@@ -343,14 +347,15 @@ def cf_table_service(cli_ctx, kwargs):
     client_kwargs = _config_location_mode(kwargs, client_kwargs)
     connection_string = kwargs.pop('connection_string', None)
     account_name = kwargs.pop('account_name', None)
+    account_url = kwargs.pop('account_url', None)
     account_key = kwargs.pop('account_key', None)
     token_credential = kwargs.pop('token_credential', None)
     sas_token = kwargs.pop('sas_token', None)
 
     if connection_string:
         return TableServiceClient.from_connection_string(conn_str=connection_string, **client_kwargs)
-
-    account_url = get_account_url(cli_ctx, account_name=account_name, service='table')
+    if not account_url:
+        account_url = get_account_url(cli_ctx, account_name=account_name, service='table')
     if account_key:
         from azure.core.credentials import AzureNamedKeyCredential
         credential = AzureNamedKeyCredential(name=account_name, key=account_key)


### PR DESCRIPTION
Support customized account service endpoint.

**Normal Case**
For normal usage:
customers can get service endpoint from `az storage account show`:
```
> az storage account show -n yssa
{
......
  "primaryEndpoints": {
    "blob": "https://yssa.blob.core.windows.net/",
    "dfs": "https://yssa.dfs.core.windows.net/",
    "file": "https://yssa.file.core.windows.net/",
    "internetEndpoints": null,
    "microsoftEndpoints": null,
    "queue": "https://yssa.queue.core.windows.net/",
    "table": "https://yssa.table.core.windows.net/",
    "web": "https://yssa.z13.web.core.windows.net/"
  },
  "primaryLocation": "eastus",
......
}
```
**Case 1**
For partitioned DNS account usage:
the service endpoint won't be like `https://myaccount.service.core.windows.net/`
Instead, it should be `https://myaccount.z123.service.core.windows.net/`.
There will be additional `z123` in endpoint for zone info

**Case 2**
For new service providing proxy ability:
the proxy endpoint could be `https://storage.contosoimagesproxy.net/` and it will help route to the real service endpoint `https://myaccount.service.core.windows.net/` like described in #21517 

**Case 3**
For Azure Clouds not defined in https://github.com/Azure/azure-cli/blob/7dad077cc5f9c9e55391b58a454072bbc8f70ec3/src/azure-cli-core/azure/cli/core/cloud.py#L422
They may have different endpoint other than
https://github.com/Azure/azure-cli/blob/7dad077cc5f9c9e55391b58a454072bbc8f70ec3/src/azure-cli-core/azure/cli/core/cloud.py#L320
https://github.com/Azure/azure-cli/blob/7dad077cc5f9c9e55391b58a454072bbc8f70ec3/src/azure-cli-core/azure/cli/core/cloud.py#L355
https://github.com/Azure/azure-cli/blob/7dad077cc5f9c9e55391b58a454072bbc8f70ec3/src/azure-cli-core/azure/cli/core/cloud.py#L386
https://github.com/Azure/azure-cli/blob/7dad077cc5f9c9e55391b58a454072bbc8f70ec3/src/azure-cli-core/azure/cli/core/cloud.py#L414

So this PR introduces a new parameter `--service-endpoint` for flexible usage.

_Note: Only added for data plane commands using track2 Python SDK. Those data plane commands using track1 Python SDK will be migrated to track2 step by step._

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
