### PR TITLE
{CI} Pin `Jinja2` to 3.0.3

### DIFF
--- a/scripts/ci/test_ref_doc.sh
+++ b/scripts/ci/test_ref_doc.sh
@@ -14,7 +14,7 @@ pip install -e ./tools
 [ -d privates ] && pip install -qqq privates/*.whl
 pip install $ALL_MODULES
 
-pip install "sphinx==1.6.7" -q
+pip install sphinx==1.6.7 Jinja2==3.0.3
 echo "Installed."
 
 cd doc/sphinx; python ./__main__.py
@@ -22,4 +22,3 @@ cd doc/sphinx; python ./__main__.py
 python $wd/test_help_doc_arguments.py "./_build/xml/ind.xml"
 
 echo "OK."
-


### PR DESCRIPTION
## Description

CI failed:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1459759&view=logs&j=715ff7e7-0433-5a80-bbc9-ca9609d2bc48&t=7f464a6b-d59f-566f-20bd-0d339d7433d8&l=831

```
2022-03-25T03:56:05.2026491Z Extension error:
2022-03-25T03:56:05.2028477Z Could not import extension sphinx.builders.latex (exception: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/jinja2/__init__.py))
```

This is because `Jinja2` released a new version yesterday which introduced breaking changes, but `sphinx` doesn't have version limits on `Jinja2`, causing the latest `Jinja2` being installed.

## TODO

This PR is only a workaround, the final solution would be to update `sphinx` to newer versions.

## References

- https://github.com/readthedocs/readthedocs.org/issues/9037
- https://github.com/pallets/jinja/issues/1631
