### PR TITLE
{Packaging} Not build Mariner RPM on PullRequest CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -702,6 +702,7 @@ jobs:
 
 - job: BuildRpmPackageMariner
   displayName: Build Rpm Package Mariner
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
     vmImage: 'ubuntu-20.04'
   steps:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Mariner 2.0 has `rpmbuild` 4.17.0 which is very slow while building the RPM (https://github.com/Azure/azure-cli/issues/21820).

This PR adds a `condition` to `BuildRpmPackageMariner` job so that Mariner RPM is not build on `PullRequest` CI.