### PR TITLE
[ARM] Fix #20842: `az bicep`: Fix to use requests environment variables for CA bundle

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -109,8 +109,8 @@ def ensure_bicep_installation(release_tag=None, target_platform=None, stdout=Tru
                 print(f"Installing Bicep CLI {release_tag}...")
             else:
                 print("Installing Bicep CLI...")
-        ca_file = certifi.where()
-        request = urlopen(_get_bicep_download_url(system, release_tag, target_platform=target_platform), cafile=ca_file)
+        os.environ.setdefault("CURL_CA_BUNDLE", certifi.where())
+        request = urlopen(_get_bicep_download_url(system, release_tag, target_platform=target_platform))
         with open(installation_path, "wb") as f:
             f.write(request.read())
 
@@ -143,8 +143,8 @@ def is_bicep_file(file_path):
 
 def get_bicep_available_release_tags():
     try:
-        ca_file = certifi.where()
-        response = requests.get("https://aka.ms/BicepReleases", verify=ca_file)
+        os.environ.setdefault("CURL_CA_BUNDLE", certifi.where())
+        response = requests.get("https://aka.ms/BicepReleases")
         return [release["tag_name"] for release in response.json()]
     except IOError as err:
         raise ClientRequestError(f"Error while attempting to retrieve available Bicep versions: {err}.")
@@ -152,8 +152,8 @@ def get_bicep_available_release_tags():
 
 def get_bicep_latest_release_tag():
     try:
-        ca_file = certifi.where()
-        response = requests.get("https://aka.ms/BicepLatestRelease", verify=ca_file)
+        os.environ.setdefault("CURL_CA_BUNDLE", certifi.where())
+        response = requests.get("https://aka.ms/BicepLatestRelease")
         response.raise_for_status()
         return response.json()["tag_name"]
     except IOError as err:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azure CLI relies on the requests python package, which allows users to set custom CA bundle paths through two environment variables: `CURL_CA_BUNDLE` and `REQUESTS_CA_BUNDLE`. https://2.python-requests.org/en/master/user/advanced/#ssl-cert-verification

This is useful for cases where the host is behind a MITM proxy that re-signs all SSL traffic for DPI, or due to a corporate policy that defines which CA roots are to be trusted.

Enforcing a hard-coded bundle, like the one provided by the certifi package, only leads users under similar use cases to modify the Python site packages files, which is meant to be controlled only by the package manager and thus it is not a good practice to configure any Python solution.

The proposed change here leverages Python `setdefault` mechanism available on dictionaries, which allows to set a default value for a key that is not set. This makes any lookups return the default value instead of their usual result (`KeyError` exception on an index lookup for a missing key, or `None` on a `get` method call). 

Setting the `CURL_CA_BUNDLE` environment variable default value to the certifi bundle path results in the following resolution order:

* `REQUESTS_CA_BUNDLE` environment variable is used if set
* `CURL_CA_BUNDLE` environment variable is used if set
* `certifi.where()` path is used otherwise

fixes #20842.

**Testing Guide**
<!--Example commands with explanations.-->

A clean environment should use the certifi CA bundle path:

```sh
env -i az bicep install
```

If either `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` is set, then it should be picked up:

```sh
env -i REQUESTS_CA_BUNDLE=/path/to/cacert1.pem az bicep install
env -i CURL_CA_BUNDLE=/path/to/cacert1.pem az bicep install
```

If both `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` are set, then it should use `REQUESTS_CA_BUNDLE` (this is by definition of the requests package).

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] Fix #20842: `az bicep`: Fix to use requests environment variables for CA bundle

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
