### PR TITLE
[App Service] `az staticwebapp`: Fix #21186: Show detailed error message instead of "bad request"

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -441,7 +441,7 @@ def load_command_table(self, _):
     with self.command_group('staticwebapp', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsites')
         g.custom_show_command('show', 'show_staticsite')
-        g.custom_command('create', 'create_staticsites', supports_no_wait=True)
+        g.custom_command('create', 'create_staticsites', supports_no_wait=True, exception_handler=ex_handler_factory())
         g.custom_command('delete', 'delete_staticsite', supports_no_wait=True, confirmation=True)
         g.custom_command('disconnect', 'disconnect_staticsite', supports_no_wait=True)
         g.custom_command('reconnect', 'reconnect_staticsite', supports_no_wait=True)
@@ -455,12 +455,12 @@ def load_command_table(self, _):
 
     with self.command_group('staticwebapp hostname', custom_command_type=staticsite_sdk) as g:
         g.custom_command('list', 'list_staticsite_domains')
-        g.custom_command('set', 'set_staticsite_domain', supports_no_wait=True)
+        g.custom_command('set', 'set_staticsite_domain', supports_no_wait=True, exception_handler=ex_handler_factory())
         g.custom_command('delete', 'delete_staticsite_domain', supports_no_wait=True, confirmation=True)
         g.custom_show_command('show', 'get_staticsite_domain')
 
     with self.command_group('staticwebapp identity', custom_command_type=staticsite_sdk) as g:
-        g.custom_command('assign', 'assign_identity')
+        g.custom_command('assign', 'assign_identity', exception_handler=ex_handler_factory())
         g.custom_command('remove', 'remove_identity', confirmation=True)
         g.custom_show_command('show', 'show_identity')
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -368,13 +368,13 @@ def create_staticsites(cmd, resource_group_name, name, location,  # pylint: disa
                        source, branch, token=None,
                        app_location="/", api_location=None, output_location=None,
                        tags=None, no_wait=False, sku='Free', login_with_github=False, format_output=True):
-    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core.exceptions import ResourceNotFoundError as _ResourceNotFoundError
 
     try:
         site = show_staticsite(cmd, name, resource_group_name)
         logger.warning("Static Web App %s already exists in resource group %s", name, resource_group_name)
         return site
-    except ResourceNotFoundError:
+    except _ResourceNotFoundError:
         pass
 
     if not token and not login_with_github:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -4,9 +4,10 @@
 # --------------------------------------------------------------------------------------------
 import unittest
 from unittest import mock
+from knack.util import CLIError
 
 from azure.cli.command_modules.appservice.static_sites import \
-    list_staticsites, show_staticsite, delete_staticsite, create_staticsites, CLIError, disconnect_staticsite, \
+    list_staticsites, show_staticsite, delete_staticsite, create_staticsites, disconnect_staticsite, \
     reconnect_staticsite, list_staticsite_environments, show_staticsite_environment, list_staticsite_domains, \
     set_staticsite_domain, delete_staticsite_domain, list_staticsite_functions, list_staticsite_app_settings, \
     set_staticsite_app_settings, delete_staticsite_app_settings, list_staticsite_users, \
@@ -159,7 +160,7 @@ class TestStaticAppCommands(unittest.TestCase):
         tags = {'key1': 'value1'}
         sku = 'Standard'
 
-        update_staticsite(self.mock_cmd, self.name1, self.source2, self.branch2, self.token2, tags=tags, sku=sku)
+        update_staticsite(cmd=self.mock_cmd, name=self.name1, source=self.source2, branch=self.branch2, token=self.token2, tags=tags, sku=sku)
 
         self.staticapp_client.update_static_site.assert_called_once()
         arg_list = self.staticapp_client.update_static_site.call_args[1]


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #21186.
Applies to the commands:
- `az staticwebapp identity assign`
- `az staticwebapp hostname set`
- `az staticwebapp create`

Also fixes #21465 for `az staticwebapp update`

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[App Service] `az staticwebapp identity assign`, `az staticwebapp hostname set`, `az staticwebapp create`: Fix #21186: Show detailed error message instead of "bad request"
[App Service] `az staticwebapp update`: Fix #21465: Allow specifying static web app resource group

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
