### PR TITLE
{AKS} Remove `from tkinter import FALSE` to unblock CI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import importlib
-from tkinter import FALSE
 import unittest
 from unittest.mock import Mock, call, patch
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/pull/21661 added this unused line for unknown reason and it breaks CI (https://github.com/Azure/azure-cli/pull/21661#discussion_r836079211).

Remove it to unblock CI.
