### PR TITLE
{APIM} Add `*.gql` to test packages

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -137,6 +137,7 @@ cat >>$testsrc_dir/setup.py <<EOL
     package_data={'': ['*.bat',
                        '*.byok',
                        '*.cer',
+                       '*.gql',  # graphql used by apim
                        '*.js',
                        '*.json',
                        '*.kql',
@@ -152,6 +153,7 @@ cat >>$testsrc_dir/setup.py <<EOL
                        '**/*.bat',
                        '**/*.byok',
                        '**/*.cer',
+                       '**/*.gql',
                        '**/*.ipynb',
                        '**/*.jar',
                        '**/*.js',


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix CI failure: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1464089&view=logs&j=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&t=9ebb608a-8a51-5834-bad0-46e2c03d2282

```
> api_file = open(schemapath, 'r')
E FileNotFoundError: [Errno 2] No such file or directory: '/opt/az/lib/python3.8/site-packages/azure/cli/command_modules/apim/tests/latest/gql_schema.gql'
```

Caused by https://github.com/Azure/azure-cli/pull/21585.
