### PR TITLE
{Service Connector} Disable `too-many-locals` for pylint

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -241,7 +241,7 @@ def connection_create(cmd, client,  # pylint: disable=too-many-locals
                          parameters=parameters)
 
 
-def connection_update(cmd, client,
+def connection_update(cmd, client,  # pylint: disable=too-many-locals
                       connection_name=None, client_type=None,
                       source_resource_group=None, source_id=None, indentifier=None,
                       secret_auth_info=None, secret_auth_info_auto=None,


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/pull/21766#discussion_r836293266

#21766 together with #21763 causes CI failure:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1464664&view=logs&j=36dd4138-4d53-5e46-00d9-e5cd9744be05&t=1cf3879c-0a42-5ccd-7693-7a4781d739d8&l=94

```
src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py:244:0: R0914: Too many local variables (26/25) (too-many-locals)
```

These PRs' CIs are run separately, but the final merged commit exceeds local variable limitation 25.
