### PR TITLE
[SQL] `az command sql db str-policy set`: Make `--diffbackup-hours` parameter optional

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -1097,7 +1097,6 @@ def load_arguments(self, _):
         c.argument(
             'diffbackup_hours',
             options_list=['--diffbackup-hours'],
-            required=True,
             help='New backup short term retention policy differential backup interval in hours.'
             'Valid differential backup interval for live database can be 12 or 24 hours.')
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -2736,7 +2736,7 @@ def update_short_term_retention(
         server_name,
         resource_group_name,
         retention_days,
-        diffbackup_hours,
+        diffbackup_hours=None,
         no_wait=False,
         **kwargs):
     '''

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_db_short_term_retention.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_db_short_term_retention.yaml
@@ -17,27 +17,27 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpdateLogicalDatabase","startTime":"2021-07-06T22:25:39.817Z"}'
+      string: '{"operation":"UpdateLogicalDatabase","startTime":"2022-03-29T22:13:36.47Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyAzureAsyncOperation/88d805f0-713e-4b1b-8741-1628e5cdc4ac?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '76'
+      - '75'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:25:39 GMT
+      - Tue, 29 Mar 2022 22:13:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyOperationResults/88d805f0-713e-4b1b-8741-1628e5cdc4ac?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -65,12 +65,12 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyAzureAsyncOperation/88d805f0-713e-4b1b-8741-1628e5cdc4ac?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"88d805f0-713e-4b1b-8741-1628e5cdc4ac","status":"Succeeded","startTime":"2021-07-06T22:25:39.817Z"}'
+      string: '{"name":"7f454ba4-c446-401e-a84b-8a2824e09960","status":"InProgress","startTime":"2022-03-29T22:13:36.47Z"}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +79,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:25:54 GMT
+      - Tue, 29 Mar 2022 22:13:50 GMT
       expires:
       - '-1'
       pragma:
@@ -111,21 +111,159 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"properties":{"retentionDays":7,"diffBackupIntervalInHours":24},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
+      string: '{"name":"7f454ba4-c446-401e-a84b-8a2824e09960","status":"InProgress","startTime":"2022-03-29T22:13:36.47Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '364'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:25:54 GMT
+      - Tue, 29 Mar 2022 22:14:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --retention-days --diffbackup-hours
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"7f454ba4-c446-401e-a84b-8a2824e09960","status":"InProgress","startTime":"2022-03-29T22:13:36.47Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:14:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --retention-days --diffbackup-hours
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/7f454ba4-c446-401e-a84b-8a2824e09960?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"7f454ba4-c446-401e-a84b-8a2824e09960","status":"Succeeded","startTime":"2022-03-29T22:13:36.47Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:14:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --retention-days --diffbackup-hours
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"properties":{"retentionDays":7,"diffBackupIntervalInHours":24},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '355'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:14:36 GMT
       expires:
       - '-1'
       pragma:
@@ -157,21 +295,21 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"properties":{"retentionDays":7,"diffBackupIntervalInHours":24},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
+      string: '{"properties":{"retentionDays":7,"diffBackupIntervalInHours":24},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '364'
+      - '355'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:25:55 GMT
+      - Tue, 29 Mar 2022 22:14:37 GMT
       expires:
       - '-1'
       pragma:
@@ -207,27 +345,27 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"operation":"UpdateLogicalDatabase","startTime":"2021-07-06T22:25:57.15Z"}'
+      string: '{"operation":"UpdateLogicalDatabase","startTime":"2022-03-29T22:14:38.957Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyAzureAsyncOperation/2db23907-676d-4c2a-8ac8-302e2f142b42?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/9c659033-fa9b-433a-adf0-0959655564c8?api-version=2021-02-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '75'
+      - '76'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:25:56 GMT
+      - Tue, 29 Mar 2022 22:14:38 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyOperationResults/2db23907-676d-4c2a-8ac8-302e2f142b42?api-version=2021-02-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/9c659033-fa9b-433a-adf0-0959655564c8?api-version=2021-02-01-preview
       pragma:
       - no-cache
       server:
@@ -255,21 +393,21 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/locations/westus2/shortTermRetentionPolicyAzureAsyncOperation/2db23907-676d-4c2a-8ac8-302e2f142b42?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/9c659033-fa9b-433a-adf0-0959655564c8?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"name":"2db23907-676d-4c2a-8ac8-302e2f142b42","status":"Succeeded","startTime":"2021-07-06T22:25:57.15Z"}'
+      string: '{"name":"9c659033-fa9b-433a-adf0-0959655564c8","status":"Succeeded","startTime":"2022-03-29T22:14:38.957Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:26:11 GMT
+      - Tue, 29 Mar 2022 22:14:53 GMT
       expires:
       - '-1'
       pragma:
@@ -301,21 +439,165 @@ interactions:
       ParameterSetName:
       - -g -s -n --retention-days --diffbackup-hours
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-sql/3.0.0 Python/3.8.10 (macOS-10.16-x86_64-i386-64bit)
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
   response:
     body:
-      string: '{"properties":{"retentionDays":6,"diffBackupIntervalInHours":12},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/WestUS2ResourceGroup/providers/Microsoft.Sql/servers/lillian-westus2-server/databases/ps5691/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
+      string: '{"properties":{"retentionDays":6,"diffBackupIntervalInHours":12},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '364'
+      - '355'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 06 Jul 2021 22:26:11 GMT
+      - Tue, 29 Mar 2022 22:14:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"retentionDays": 5}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n --retention-days
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateLogicalDatabase","startTime":"2022-03-29T22:14:56.447Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/96853727-0b1a-402a-8a17-5c167d243696?api-version=2021-02-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '76'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:14:55 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyOperationResults/96853727-0b1a-402a-8a17-5c167d243696?api-version=2021-02-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --retention-days
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/locations/eastus/shortTermRetentionPolicyAzureAsyncOperation/96853727-0b1a-402a-8a17-5c167d243696?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"name":"96853727-0b1a-402a-8a17-5c167d243696","status":"Succeeded","startTime":"2022-03-29T22:14:56.447Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:15:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql db str-policy set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --retention-days
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-sql/4.0.0b1 Python/3.8.10 (Windows-10-10.0.19044-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default?api-version=2021-02-01-preview
+  response:
+    body:
+      string: '{"properties":{"retentionDays":5,"diffBackupIntervalInHours":12},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/qiangdsrg/providers/Microsoft.Sql/servers/qiangdsmemberserver/databases/hubdatabase/backupShortTermRetentionPolicies/default","name":"default","type":"Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '355'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 29 Mar 2022 22:15:11 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -965,26 +965,25 @@ class SqlServerDbShortTermRetentionScenarioTest(ScenarioTest):
             'server_name': 'lillian-westus2-server',
             'database_name': 'ps5691',
             'retention_days_v1': 7,
-            'diffbackup_hours_v1': 24,
             'retention_days_v2': 6,
-            'diffbackup_hours_v2': 12
+            'diffbackup_hours_v2': 12,
+            'retention_days_v3': 5,
+            'diffbackup_hours_v3': 10
         })
 
-        # Test UPDATE short term retention policy on live database, value updated to v1.
+        # Test UPDATE short term retention policy (retention days only), value equals to v1.
         self.cmd(
-            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v1} --diffbackup-hours {diffbackup_hours_v1}',
+            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v1}',
             checks=[
                 self.check('resourceGroup', '{resource_group}'),
-                self.check('retentionDays', '{retention_days_v1}'),
-                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v1}')])
+                self.check('retentionDays', '{retention_days_v1}')])
 
-        # Test GET short term retention policy on live database, value equals to v1.
+        # Test GET short term retention policy (retention days only) on live database, value equals to v1.
         self.cmd(
             'sql db str-policy show -g {resource_group} -s {server_name} -n {database_name}',
             checks=[
                 self.check('resourceGroup', '{resource_group}'),
-                self.check('retentionDays', '{retention_days_v1}'),
-                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v1}')])
+                self.check('retentionDays', '{retention_days_v1}'),])
 
         # Test UPDATE short term retention policy on live database, value updated to v2.
         self.cmd(
@@ -993,6 +992,22 @@ class SqlServerDbShortTermRetentionScenarioTest(ScenarioTest):
                 self.check('resourceGroup', '{resource_group}'),
                 self.check('retentionDays', '{retention_days_v2}'),
                 self.check('diffBackupIntervalInHours', '{diffbackup_hours_v2}')])
+
+        # Test GET short term retention policy on live database, value equals to v2.
+        self.cmd(
+            'sql db str-policy show -g {resource_group} -s {server_name} -n {database_name}',
+            checks=[
+                self.check('resourceGroup', '{resource_group}'),
+                self.check('retentionDays', '{retention_days_v2}'),
+                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v2}')])
+
+        # Test UPDATE short term retention policy on live database, value updated to v3.
+        self.cmd(
+            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v3} --diffbackup-hours {diffbackup_hours_v3}',
+            checks=[
+                self.check('resourceGroup', '{resource_group}'),
+                self.check('retentionDays', '{retention_days_v3}'),
+                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v3}')])
 
 
 class SqlServerDbLongTermRetentionScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -961,29 +961,31 @@ class SqlServerDbShortTermRetentionScenarioTest(ScenarioTest):
     def test_sql_db_short_term_retention(self):
         # Initial parameters. default_diffbackup_hours will be changed to 24 soon.
         self.kwargs.update({
-            'resource_group': 'WestUS2ResourceGroup',
-            'server_name': 'lillian-westus2-server',
-            'database_name': 'ps5691',
+            'resource_group': 'qiangdsrg',
+            'server_name': 'qiangdsmemberserver',
+            'database_name': 'hubdatabase',
             'retention_days_v1': 7,
+            'diffbackup_hours_v1': 24,
             'retention_days_v2': 6,
             'diffbackup_hours_v2': 12,
-            'retention_days_v3': 5,
-            'diffbackup_hours_v3': 10
+            'retention_days_v3': 5
         })
 
-        # Test UPDATE short term retention policy (retention days only), value equals to v1.
+        # Test UPDATE short term retention policy on live database, value updated to v1.
         self.cmd(
-            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v1}',
+            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v1} --diffbackup-hours {diffbackup_hours_v1}',
             checks=[
                 self.check('resourceGroup', '{resource_group}'),
-                self.check('retentionDays', '{retention_days_v1}')])
+                self.check('retentionDays', '{retention_days_v1}'),
+                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v1}')])
 
-        # Test GET short term retention policy (retention days only) on live database, value equals to v1.
+        # Test GET short term retention policy on live database, value equals to v1.
         self.cmd(
             'sql db str-policy show -g {resource_group} -s {server_name} -n {database_name}',
             checks=[
                 self.check('resourceGroup', '{resource_group}'),
-                self.check('retentionDays', '{retention_days_v1}'),])
+                self.check('retentionDays', '{retention_days_v1}'),
+                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v1}')])
 
         # Test UPDATE short term retention policy on live database, value updated to v2.
         self.cmd(
@@ -993,21 +995,13 @@ class SqlServerDbShortTermRetentionScenarioTest(ScenarioTest):
                 self.check('retentionDays', '{retention_days_v2}'),
                 self.check('diffBackupIntervalInHours', '{diffbackup_hours_v2}')])
 
-        # Test GET short term retention policy on live database, value equals to v2.
+        # Test UPDATE short term retention policy on live database, only update retention days value to v3.
         self.cmd(
-            'sql db str-policy show -g {resource_group} -s {server_name} -n {database_name}',
-            checks=[
-                self.check('resourceGroup', '{resource_group}'),
-                self.check('retentionDays', '{retention_days_v2}'),
-                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v2}')])
-
-        # Test UPDATE short term retention policy on live database, value updated to v3.
-        self.cmd(
-            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v3} --diffbackup-hours {diffbackup_hours_v3}',
+            'sql db str-policy set -g {resource_group} -s {server_name} -n {database_name} --retention-days {retention_days_v3}',
             checks=[
                 self.check('resourceGroup', '{resource_group}'),
                 self.check('retentionDays', '{retention_days_v3}'),
-                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v3}')])
+                self.check('diffBackupIntervalInHours', '{diffbackup_hours_v2}')])
 
 
 class SqlServerDbLongTermRetentionScenarioTest(ScenarioTest):


### PR DESCRIPTION
**Description**
Make diffbackup_hours optional in sql db str-policy set.
We are releasing public preview feature short term retention parity for Very Large Database (VLDB) on May 1st .

We recently noticed a bug in Cli which requires differential backup interval as a required parameter. ([SQL] 'az sql db str-policy set/show': Add Set and Show ShortTermRetentionPolicy by lululilliancoding · Pull Request #14919 · Azure/azure-cli (github.com).
We are changing the parameter diffbackup_hours to be an optional parameter

**Testing Guide**
sql db str-policy set -g WestUS2ResourceGroup -s lillian-westus2-server -n ps5691 --retention-days 7

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[SQL] `az command sql db str-policy set`: Make `diffbackup_hours` parameter optional

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
