### PR TITLE
{pylint} Fix `collections.abc` import statement

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -7,13 +7,12 @@ import json
 import logging
 import os
 import time
-
-import collections.abc as collections
+from collections.abc import MutableMapping
 
 from knack.log import get_logger
 
 
-class Session(collections.MutableMapping):
+class Session(MutableMapping):
     """
     A simple dict-like class that is backed by a JSON file.
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix Pylint error:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1472599&view=logs&j=36dd4138-4d53-5e46-00d9-e5cd9744be05&t=1cf3879c-0a42-5ccd-7693-7a4781d739d8

```
ERROR: ************* Module azure.cli.core._session
src/azure-cli-core/azure/cli/core/_session.py:11:0: E0611: No name 'abc' in module 'collections.abc' (no-name-in-module)
```

By comparing this task with a previous successful one like https://dev.azure.com/azure-sdk/public/_build/results?buildId=1470973&view=logs&j=36dd4138-4d53-5e46-00d9-e5cd9744be05&t=1b5debc0-fc94-5266-47f5-73158590dd32, I found:

- There is no version update on `pylint`, `astroid`, etc
- The only difference is Python on the agent is upgraded from 3.10.2 to 3.10.4, but according to https://docs.python.org/release/3.10.4/whatsnew/changelog.html#python-3-10-4-final, no breaking changes are made for `collections.abc`

It looks like `pylint` somehow thinks `collections` is `collections.abc` _before_ redefining `collections` and think this statement is doing `import collections.abc.abc`.

Anyway, redefining built-in name is always a bad practice. This PRs fixes this bad statement.

