### PR TITLE
{Packaging} Revert `BuildRpmPackageCentOS7.ArtifactName` to `yum`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -746,7 +746,8 @@ jobs:
     displayName: 'Publish Artifact: rpm'
     inputs:
       TargetPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: rpm-centos7
+      # Should be 'rpm-centos7', but we keep 'yum' for backward compatibility
+      ArtifactName: yum
 
 # TODO: rpmbuild on Red Hat UBI 8 is slow for unknown reason. Still working with Red Hat to investigate.
 # We use a separate job for Red Hat UBI 8 instead of strategy.matrix so that TestRpmPackage can start right after


### PR DESCRIPTION
**Description**<!--Mandatory-->

#20918 changed the RPM artifact name from `yum` to `rpm-centos7` to better reflect its content (an RPM built by CentOS 7), but this requires lots of changes in the release pipeline, as well as the RPM archive path, such as https://azurecliprod.blob.core.windows.net/archive/20220301.49/yum/azure-cli-2.34.1-1.el7.x86_64.rpm

This PR reverts the change and keep the name `yum` for backward compatibility, even though it is a not good name.

