### PR TITLE
{CI} Increase `TestExtensionsLoading`'s timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -560,14 +560,14 @@ jobs:
 - job: TestExtensionsLoading
   displayName: Test Extensions Loading
   condition: succeeded()
-  timeoutInMinutes: 20
+  timeoutInMinutes: 40
 
   pool:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
+      Python310:
+        python.version: '3.10'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -19,7 +19,8 @@ output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
-ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s'
+# db-up: https://github.com/Azure/azure-cli-extensions/issues/4608
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s db-up'
 
 for ext in $output; do
     echo

--- a/scripts/ci/test_extensions.sh
+++ b/scripts/ci/test_extensions.sh
@@ -19,8 +19,7 @@ output=$(az extension list-available --query [].name -otsv)
 exit_code=0
 
 # azure-cli-ml: https://github.com/Azure/azure-cli-extensions/issues/826
-# db-up: https://github.com/Azure/azure-cli-extensions/issues/4608
-ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s db-up'
+ignore_list='azure-cli-ml fzf arcappliance arcdata connectedk8s'
 
 for ext in $output; do
     echo


### PR DESCRIPTION
**Description**<!--Mandatory-->

With the increasing number of Azure CLI extensions, `TestExtensionsLoading` now fails with 

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1475520&view=logs&j=dec4b9a0-9c0f-52f1-3e08-6456fce2bf62

```
##[error]The job running on agent [Azure Pipelines](https://dev.azure.com/azure-sdk/29ec6040-b234-4e31-b139-33dc4287b756/_settings/agentqueues?poolId=&queueId=57) 96 ran longer than the maximum time of 20 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134
Pool: Azure Pipelines
Image: ubuntu-20.04
Agent: Azure Pipelines 96
Started: Today at 1:13 PM
Duration: 20m 7s
```

This PR increases the timeout threshold.
