### PR TITLE
[ServiceConnector] `az webapp connection`: Add command `create sql/webpubsub` to support more target resources 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
@@ -617,6 +617,8 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.AppConfig: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.EventHub: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ServiceBus: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
+        RESOURCE.SignalR: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
+        RESOURCE.WebPubSub: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ConfluentKafka: [AUTH_TYPE.Secret],
     },
     RESOURCE.KubernetesCluster: {

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_resource_config.py
@@ -33,7 +33,7 @@ class RESOURCE(Enum):
     PostgresFlexible = 'postgres-flexible'
     Mysql = 'mysql'
     MysqlFlexible = 'mysql-flexible'
-    # Sql = 'sql'
+    Sql = 'sql'
     Redis = 'redis'
     RedisEnterprise = 'redis-enterprise'
     KeyVault = 'keyvault'
@@ -41,6 +41,7 @@ class RESOURCE(Enum):
     AppConfig = 'appconfig'
     ServiceBus = 'servicebus'
     SignalR = 'signalr'
+    WebPubSub = 'webpubsub'
     ConfluentKafka = 'confluent-cloud'
 
 
@@ -88,7 +89,7 @@ TARGET_RESOURCES = {
     RESOURCE.PostgresFlexible: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.DBforPostgreSQL/flexibleServers/{server}/databases/{database}',
     RESOURCE.MysqlFlexible: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.DBforMySQL/flexibleServers/{server}/databases/{database}',
     RESOURCE.Mysql: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.DBForMySQL/servers/{server}/databases/{database}',
-    # RESOURCE.Sql: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.Sql/servers/{server}/databases/{database}',
+    RESOURCE.Sql: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.Sql/servers/{server}/databases/{database}',
     RESOURCE.Redis: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.Cache/redis/{server}/databases/{database}',
     RESOURCE.RedisEnterprise: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.Cache/redisEnterprise/{server}/databases/{database}',
 
@@ -108,6 +109,7 @@ TARGET_RESOURCES = {
     RESOURCE.EventHub: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.EventHub/namespaces/{namespace}',
     RESOURCE.ServiceBus: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.ServiceBus/namespaces/{namespace}',
     RESOURCE.SignalR: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.SignalRService/SignalR/{signalr}',
+    RESOURCE.WebPubSub: '/subscriptions/{subscription}/resourceGroups/{target_resource_group}/providers/Microsoft.SignalRService/WebPubSub/{webpubsub}',
     RESOURCE.ConfluentKafka: '#',  # special target resource, no arm resource id
 }
 
@@ -237,23 +239,23 @@ TARGET_RESOURCES_PARAMS = {
             'placeholder': 'MyDB'
         }
     },
-    # RESOURCE.Sql: {
-    #     'target_resource_group': {
-    #         'options': ['--target-resource-group', '--tg'],
-    #         'help': 'The resource group which contains the sql server',
-    #         'placeholder': 'SqlRG'
-    #     },
-    #     'server': {
-    #         'options': ['--server'],
-    #         'help': 'Name of the sql server',
-    #         'placeholder': 'MyServer'
-    #     },
-    #     'database': {
-    #         'options': ['--database'],
-    #         'help': 'Name of the sql database',
-    #         'placeholder': 'MyDB'
-    #     }
-    # },
+    RESOURCE.Sql: {
+        'target_resource_group': {
+            'options': ['--target-resource-group', '--tg'],
+            'help': 'The resource group which contains the sql server',
+            'placeholder': 'SqlRG'
+        },
+        'server': {
+            'options': ['--server'],
+            'help': 'Name of the sql server',
+            'placeholder': 'MyServer'
+        },
+        'database': {
+            'options': ['--database'],
+            'help': 'Name of the sql database',
+            'placeholder': 'MyDB'
+        }
+    },
     RESOURCE.Redis: {
         'target_resource_group': {
             'options': ['--target-resource-group', '--tg'],
@@ -485,6 +487,18 @@ TARGET_RESOURCES_PARAMS = {
             'help': 'Name of the signalr service',
             'placeholder': 'MySignalR'
         }
+    },
+    RESOURCE.WebPubSub: {
+        'target_resource_group': {
+            'options': ['--target-resource-group', '--tg'],
+            'help': 'The resource group which contains the webpubsub',
+            'placeholder': 'WebpubsubRG'
+        },
+        'webpubsub': {
+            'options': ['--webpubsub'],
+            'help': 'Name of the webpubsub service',
+            'placeholder': 'MyWebPubSub'
+        }
     }
 }
 
@@ -493,6 +507,7 @@ TARGET_RESOURCES_PARAMS = {
 TARGET_SUPPORT_SERVICE_ENDPOINT = {
     RESOURCE.Postgres: True,
     RESOURCE.Mysql: True,
+    RESOURCE.Sql: True,
     RESOURCE.StorageBlob: True,
     RESOURCE.StorageQueue: True,
     RESOURCE.StorageFile: True,
@@ -505,7 +520,6 @@ TARGET_SUPPORT_SERVICE_ENDPOINT = {
     RESOURCE.CosmosTable: True,
     RESOURCE.ServiceBus: True,
     RESOURCE.EventHub: True,
-    # RESOURCE.Sql: True
 }
 
 # The dict defines the parameters used to provide auth info
@@ -556,7 +570,7 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.PostgresFlexible: [AUTH_TYPE.Secret],
         RESOURCE.Mysql: [AUTH_TYPE.Secret],
         RESOURCE.MysqlFlexible: [AUTH_TYPE.Secret],
-        # RESOURCE.Sql: [AUTH_TYPE.Secret],
+        RESOURCE.Sql: [AUTH_TYPE.Secret],
         RESOURCE.Redis: [AUTH_TYPE.SecretAuto],
         RESOURCE.RedisEnterprise: [AUTH_TYPE.SecretAuto],
 
@@ -576,6 +590,7 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.EventHub: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ServiceBus: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.SignalR: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
+        RESOURCE.WebPubSub: [AUTH_TYPE.SystemIdentity, AUTH_TYPE.SecretAuto, AUTH_TYPE.UserIdentity, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ConfluentKafka: [AUTH_TYPE.Secret],
     },
     RESOURCE.SpringCloud: {
@@ -583,7 +598,7 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.PostgresFlexible: [AUTH_TYPE.Secret],
         RESOURCE.Mysql: [AUTH_TYPE.Secret],
         RESOURCE.MysqlFlexible: [AUTH_TYPE.Secret],
-        # RESOURCE.Sql: [AUTH_TYPE.Secret],
+        RESOURCE.Sql: [AUTH_TYPE.Secret],
         RESOURCE.Redis: [AUTH_TYPE.SecretAuto],
         RESOURCE.RedisEnterprise: [AUTH_TYPE.SecretAuto],
 
@@ -609,7 +624,7 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.PostgresFlexible: [AUTH_TYPE.Secret],
         RESOURCE.Mysql: [AUTH_TYPE.Secret],
         RESOURCE.MysqlFlexible: [AUTH_TYPE.Secret],
-        # RESOURCE.Sql: [AUTH_TYPE.Secret],
+        RESOURCE.Sql: [AUTH_TYPE.Secret],
         RESOURCE.Redis: [AUTH_TYPE.SecretAuto],
         RESOURCE.RedisEnterprise: [AUTH_TYPE.SecretAuto],
 
@@ -629,6 +644,7 @@ SUPPORTED_AUTH_TYPE = {
         RESOURCE.EventHub: [AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ServiceBus: [AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.SignalR: [AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
+        RESOURCE.WebPubSub: [AUTH_TYPE.SecretAuto, AUTH_TYPE.ServicePrincipalSecret],
         RESOURCE.ConfluentKafka: [AUTH_TYPE.Secret],
     },
 }
@@ -686,18 +702,18 @@ SUPPORTED_CLIENT_TYPE = {
             CLIENT_TYPE.SpringBoot,
             CLIENT_TYPE.Blank
         ],
-        # RESOURCE.Sql: [
-        #     CLIENT_TYPE.Dotnet,
-        #     CLIENT_TYPE.Java,
-        #     CLIENT_TYPE.Python,
-        #     CLIENT_TYPE.Nodejs,
-        #     CLIENT_TYPE.Go,
-        #     CLIENT_TYPE.Php,
-        #     CLIENT_TYPE.Ruby,
-        #     CLIENT_TYPE.Django,
-        #     CLIENT_TYPE.SpringBoot,
-        #     CLIENT_TYPE.Blank
-        # ],
+        RESOURCE.Sql: [
+            CLIENT_TYPE.Dotnet,
+            CLIENT_TYPE.Java,
+            CLIENT_TYPE.Python,
+            CLIENT_TYPE.Nodejs,
+            CLIENT_TYPE.Go,
+            CLIENT_TYPE.Php,
+            CLIENT_TYPE.Ruby,
+            CLIENT_TYPE.Django,
+            CLIENT_TYPE.SpringBoot,
+            CLIENT_TYPE.Blank
+        ],
         RESOURCE.Redis: [
             CLIENT_TYPE.Dotnet,
             CLIENT_TYPE.Java,
@@ -826,6 +842,13 @@ SUPPORTED_CLIENT_TYPE = {
             CLIENT_TYPE.Dotnet,
             CLIENT_TYPE.Blank
         ],
+        RESOURCE.WebPubSub: [
+            CLIENT_TYPE.Dotnet,
+            CLIENT_TYPE.Java,
+            CLIENT_TYPE.Python,
+            CLIENT_TYPE.Nodejs,
+            CLIENT_TYPE.Blank
+        ],
         RESOURCE.ConfluentKafka: [
             CLIENT_TYPE.Dotnet,
             CLIENT_TYPE.Java,
@@ -860,12 +883,12 @@ SUPPORTED_CLIENT_TYPE = {
             CLIENT_TYPE.Dotnet,
             CLIENT_TYPE.Blank
         ],
-        # RESOURCE.Sql: [
-        #     CLIENT_TYPE.Java,
-        #     CLIENT_TYPE.SpringBoot,
-        #     CLIENT_TYPE.Dotnet
-        #     CLIENT_TYPE.Blank
-        # ],
+        RESOURCE.Sql: [
+            CLIENT_TYPE.Java,
+            CLIENT_TYPE.SpringBoot,
+            CLIENT_TYPE.Dotnet,
+            CLIENT_TYPE.Blank
+        ],
         RESOURCE.Redis: [
             CLIENT_TYPE.Java,
             CLIENT_TYPE.SpringBoot,

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/custom.py
@@ -168,6 +168,7 @@ def connection_create(cmd, client,  # pylint: disable=too-many-locals
                       key_space=None, graph=None, table=None,                # Resource.Cosmos*,
                       config_store=None,                                     # Resource.AppConfig
                       namespace=None,                                        # Resource.EventHub
+                      webpubsub=None,                                        # Resource.WebPubSub
                       signalr=None):                                         # Resource.SignalR
 
     if not source_id:

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/recordings/test_webapp_sql_e2e.yaml
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/recordings/test_webapp_sql_e2e.yaml
@@ -1,0 +1,709 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - 0
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31) msrest/0.6.21
+        msrest_azure/0.6.4 azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cupertino-kv-test.vault.azure.net/secrets/TestDbPassword/?api-version=7.0
+  response:
+    body:
+      string: '{"error": {"code": "Unauthorized", "message": "AKV10000: Request is
+        missing a Bearer or PoP token."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '101'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      www-authenticate:
+      - Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47",
+        resource="https://vault.azure.net"
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=40.119.237.139;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.9.331.5
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - 0
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31) msrest/0.6.21
+        msrest_azure/0.6.4 azure-keyvault/7.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+    method: GET
+    uri: https://cupertino-kv-test.vault.azure.net/secrets/TestDbPassword/?api-version=7.0
+  response:
+    body:
+      string: '{"value": "microsoft123!", "id": "https://cupertino-kv-test.vault.azure.net/secrets/TestDbPassword/e6c944984acc4f7dab51acf30b3d19cc",
+        "attributes": {"enabled": true, "created": 1607518360, "updated": 1607518360,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '254'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=40.119.237.139;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.9.331.5
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+      "authInfo": {"authType": "secret", "name": "servicelinker", "secret": "microsoft123!"},
+      "clientType": "python", "secretStore": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create sql
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '333'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --connection --source-id --target-id --secret --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T06:00:07.9327272Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T06:00:07.9327272Z"},
+        "properties": {"provisioningState": "Accepted", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+        "authInfo": {"name": "servicelinker", "authType": "secret"}, "vNetSolution":
+        null, "clientType": "python", "secretStore": {"keyVaultId": null}}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/7e01be32-3bde-40c2-968b-070ecf372f76*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '899'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:08 GMT
+      etag:
+      - '"3500dec8-0000-0400-0000-624694e90000"'
+      expires:
+      - '-1'
+      mise-correlation-id:
+      - 3f712133-cfa4-41e2-ac18-88f297be16dc
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create sql
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --secret --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/7e01be32-3bde-40c2-968b-070ecf372f76*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/7e01be32-3bde-40c2-968b-070ecf372f76*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "name": "7e01be32-3bde-40c2-968b-070ecf372f76*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T06:00:08.9000789Z", "endTime":
+        "2022-04-01T06:00:16.782836Z", "properties": {"message": "Deny public network
+        access is set to yes. Please confirm you are using private endpoint connection
+        to access target resource."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '829'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:39 GMT
+      etag:
+      - '"070068bf-0000-0400-0000-624694f00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create sql
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --secret --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T06:00:07.9327272Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T06:00:07.9327272Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+        "authInfo": {"name": "servicelinker", "authType": "secret"}, "clientType":
+        "python", "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '860'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:40 GMT
+      etag:
+      - '"3500eec8-0000-0400-0000-624694f00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"value": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T06:00:07.9327272Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T06:00:07.9327272Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+        "authInfo": {"name": "servicelinker", "authType": "secret"}, "clientType":
+        "python", "secretStore": {}}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '873'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection list-configuration
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn/listConfigurations?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"configurations": [{"name": "AZURE_SQL_SERVER", "value": "servicelinker-sql.database.windows.net"},
+        {"name": "AZURE_SQL_PORT", "value": "1433"}, {"name": "AZURE_SQL_DATABASE",
+        "value": "handler-test"}, {"name": "AZURE_SQL_USER", "value": "servicelinker"},
+        {"name": "AZURE_SQL_PASSWORD", "value": "microsoft123!"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '315'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:44 GMT
+      expires:
+      - '-1'
+      mise-correlation-id:
+      - cc29ad76-a2f9-4436-a6a3-fb6a56a70675
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T06:00:07.9327272Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T06:00:07.9327272Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+        "authInfo": {"name": "servicelinker", "authType": "secret"}, "clientType":
+        "python", "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '860'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:45 GMT
+      etag:
+      - '"3500eec8-0000-0400-0000-624694f00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn/validateLinker?api-version=2021-11-01-preview
+  response:
+    body:
+      string: 'null'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/5a3c7556-7633-4793-889d-948e64c9ff21*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:00:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/5a3c7556-7633-4793-889d-948e64c9ff21*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+      mise-correlation-id:
+      - be922802-d02b-4161-a7dd-9862dd992059
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/5a3c7556-7633-4793-889d-948e64c9ff21*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/5a3c7556-7633-4793-889d-948e64c9ff21*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "name": "5a3c7556-7633-4793-889d-948e64c9ff21*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T06:00:46.8331378Z", "endTime":
+        "2022-04-01T06:00:49.4288215Z", "properties": {"message": "{\"ConnectionName\":\"testconn\",\"IsConnectionAvailable\":true,\"ValidationDetail\":[{\"Name\":\"The
+        target existence is validated\",\"Description\":null,\"Result\":0},{\"Name\":\"The
+        target''s network access is validated\",\"Description\":\"Deny public network
+        access is set to yes. Please confirm you are using private endpoint connection
+        to access target resource.\",\"Result\":2},{\"Name\":\"The configured values
+        (except username/password) is validated\",\"Description\":null,\"Result\":0}],\"ReportStartTimeUtc\":\"2022-04-01T06:00:48.0864784Z\",\"ReportEndTimeUtc\":\"2022-04-01T06:00:49.31818Z\",\"SourceId\":null,\"TargetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test\",\"AuthType\":4}"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1530'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:01:17 GMT
+      etag:
+      - '"070011c0-0000-0400-0000-624695110000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T06:00:07.9327272Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T06:00:07.9327272Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Sql/servers/servicelinker-sql/databases/handler-test",
+        "authInfo": {"name": "servicelinker", "authType": "secret"}, "clientType":
+        "python", "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '860'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:01:18 GMT
+      etag:
+      - '"3500eec8-0000-0400-0000-624694f00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id --yes
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: 'null'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e8a288f6-5dc6-4830-b0e8-f8e471f2bd6a*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:01:22 GMT
+      etag:
+      - '"35007ec9-0000-0400-0000-624695320000"'
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e8a288f6-5dc6-4830-b0e8-f8e471f2bd6a*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+      mise-correlation-id:
+      - 5b56d030-095e-4cae-9209-9e2c02651438
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14998'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --yes
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e8a288f6-5dc6-4830-b0e8-f8e471f2bd6a*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e8a288f6-5dc6-4830-b0e8-f8e471f2bd6a*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "name": "e8a288f6-5dc6-4830-b0e8-f8e471f2bd6a*F712114A38F364B5CAB427C8E5BC23507E99B0D32E8EDFB0E4134B38ABF46FB0",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-sql-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T06:01:22.5145041Z", "endTime":
+        "2022-04-01T06:01:25.9380769Z", "properties": null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '694'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 06:01:53 GMT
+      etag:
+      - '"0700d3c0-0000-0400-0000-624695350000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/recordings/test_webapp_webpubsub_e2e.yaml
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/recordings/test_webapp_webpubsub_e2e.yaml
@@ -1,0 +1,698 @@
+interactions:
+- request:
+    body: '{"properties": {"targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+      "authInfo": {"authType": "systemAssignedIdentity"}, "clientType": "dotnet",
+      "secretStore": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create webpubsub
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '293'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --connection --source-id --target-id --system-identity --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T05:29:51.6361173Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T05:29:51.6361173Z"},
+        "properties": {"provisioningState": "Accepted", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+        "authInfo": {"authType": "systemAssignedIdentity"}, "vNetSolution": null,
+        "clientType": "dotnet", "secretStore": {"keyVaultId": null}}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '892'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:29:52 GMT
+      etag:
+      - '"02008e8f-0000-0100-0000-62468dd00000"'
+      expires:
+      - '-1'
+      mise-correlation-id:
+      - f8db5057-2862-429f-b992-1c0072373948
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create webpubsub
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --system-identity --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "name": "b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Accepted", "startTime": "2022-04-01T05:29:52.6203119Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '636'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:30:23 GMT
+      etag:
+      - '"ed07ea30-0000-0100-0000-62468dd00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create webpubsub
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --system-identity --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "name": "b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Accepted", "startTime": "2022-04-01T05:29:52.6203119Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '636'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:30:53 GMT
+      etag:
+      - '"ed07ea30-0000-0100-0000-62468dd00000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create webpubsub
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --system-identity --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "name": "b02568db-c288-4820-a20a-57d5f9869e26*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T05:29:52.6203119Z", "endTime":
+        "2022-04-01T05:31:11.6428883Z", "properties": {"message": "Deny public network
+        access is set to yes. Please confirm you are using private endpoint connection
+        to access target resource."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '836'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:23 GMT
+      etag:
+      - '"ed07ca68-0000-0100-0000-62468e1f0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection create webpubsub
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --connection --source-id --target-id --system-identity --client-type
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T05:29:51.6361173Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T05:29:51.6361173Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+        "authInfo": {"authType": "systemAssignedIdentity"}, "clientType": "dotnet",
+        "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:24 GMT
+      etag:
+      - '"0200a28f-0000-0100-0000-62468e1f0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --source-id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"value": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T05:29:51.6361173Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T05:29:51.6361173Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+        "authInfo": {"authType": "systemAssignedIdentity"}, "clientType": "dotnet",
+        "secretStore": {}}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '866'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection list-configuration
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn/listConfigurations?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"configurations": [{"name": "AZURE_WEBPUBSUB_HOST", "value": "servicelinker-webpubsub.webpubsub.azure.com"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '110'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:31 GMT
+      expires:
+      - '-1'
+      mise-correlation-id:
+      - 42528d76-4bcc-4d59-9424-558ce5f9dd94
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T05:29:51.6361173Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T05:29:51.6361173Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+        "authInfo": {"authType": "systemAssignedIdentity"}, "clientType": "dotnet",
+        "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:32 GMT
+      etag:
+      - '"0200a28f-0000-0100-0000-62468e1f0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn/validateLinker?api-version=2021-11-01-preview
+  response:
+    body:
+      string: 'null'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/a7512061-85d0-48e3-9407-0f02bf91d79f*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:31:32 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/a7512061-85d0-48e3-9407-0f02bf91d79f*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+      mise-correlation-id:
+      - 1168f247-321f-4ce3-80af-a75e65e209b3
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection validate
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/a7512061-85d0-48e3-9407-0f02bf91d79f*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/a7512061-85d0-48e3-9407-0f02bf91d79f*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "name": "a7512061-85d0-48e3-9407-0f02bf91d79f*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T05:31:32.6663585Z", "endTime":
+        "2022-04-01T05:31:35.5405Z", "properties": {"message": "{\"ConnectionName\":\"testconn\",\"IsConnectionAvailable\":true,\"ValidationDetail\":[{\"Name\":\"The
+        target existence is validated\",\"Description\":null,\"Result\":0},{\"Name\":\"The
+        target''s network access is validated\",\"Description\":\"Deny public network
+        access is set to yes. Please confirm you are using private endpoint connection
+        to access target resource.\",\"Result\":2},{\"Name\":\"The configured values
+        is validated\",\"Description\":null,\"Result\":0},{\"Name\":\"The identity
+        existence is validated\",\"Description\":null,\"Result\":0},{\"Name\":\"The
+        identity permission is validated\",\"Description\":null,\"Result\":0}],\"ReportStartTimeUtc\":\"2022-04-01T05:31:34.1505722Z\",\"ReportEndTimeUtc\":\"2022-04-01T05:31:35.3761582Z\",\"SourceId\":null,\"TargetId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub\",\"AuthType\":0}"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1675'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:32:03 GMT
+      etag:
+      - '"0700ec9a-0000-0400-0000-62468e370000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "name": "testconn", "type": "microsoft.servicelinker/linkers", "systemData":
+        {"createdBy": "tanchen@microsoft.com", "createdByType": "User", "createdAt":
+        "2022-04-01T05:29:51.6361173Z", "lastModifiedBy": "tanchen@microsoft.com",
+        "lastModifiedByType": "User", "lastModifiedAt": "2022-04-01T05:29:51.6361173Z"},
+        "properties": {"provisioningState": "Succeeded", "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.SignalRService/WebPubSub/servicelinker-webpubsub",
+        "authInfo": {"authType": "systemAssignedIdentity"}, "clientType": "dotnet",
+        "secretStore": {}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '853'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:32:03 GMT
+      etag:
+      - '"0200a28f-0000-0100-0000-62468e1f0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --id --yes
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn?api-version=2021-11-01-preview
+  response:
+    body:
+      string: 'null'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e29f6d6c-e510-4fa9-bb8d-60cec8ac3c4a*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:32:08 GMT
+      etag:
+      - '"350069b8-0000-0400-0000-62468e580000"'
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e29f6d6c-e510-4fa9-bb8d-60cec8ac3c4a*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+      mise-correlation-id:
+      - a79c6f03-9584-4aa8-a91d-5acd34467705
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-providerhub-traffic:
+      - 'True'
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - webapp connection delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --id --yes
+      User-Agent:
+      - AZURECLI/2.34.1 azsdk-python-mgmt-servicelinker/1.0.0b2 Python/3.10.4 (Linux-5.4.0-1062-azure-x86_64-with-glibc2.31)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e29f6d6c-e510-4fa9-bb8d-60cec8ac3c4a*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6?api-version=2021-11-01-preview
+  response:
+    body:
+      string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceLinker/locations/EASTUS/operationStatuses/e29f6d6c-e510-4fa9-bb8d-60cec8ac3c4a*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "name": "e29f6d6c-e510-4fa9-bb8d-60cec8ac3c4a*5DC6C9F01716022343AC8407589CB81F254417A2C57AB7236FF72D11D3DDD3B6",
+        "resourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/servicelinker-test-linux-group/providers/Microsoft.Web/sites/servicelinker-webpubsub-app/providers/Microsoft.ServiceLinker/linkers/testconn",
+        "status": "Succeeded", "startTime": "2022-04-01T05:32:08.1731347Z", "endTime":
+        "2022-04-01T05:32:11.6531126Z", "properties": null}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '700'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 01 Apr 2022 05:32:38 GMT
+      etag:
+      - '"0700b89b-0000-0400-0000-62468e5b0000"'
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_springcloud_connection_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_springcloud_connection_scenario.py
@@ -53,7 +53,7 @@ class CredentialReplacer(RecordingProcessor):
             request.headers['x-ms-cupertino-test-token'] = 'hidden'
         if 'x-ms-serviceconnector-user-token' in request.headers:
             request.headers['x-ms-serviceconnector-user-token'] = 'hidden'
-        
+
         return request
 
     def process_response(self, response):
@@ -145,7 +145,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create cosmos-cassandra --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -192,7 +192,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create cosmos-gremlin --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -238,7 +238,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create cosmos-mongo --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -284,7 +284,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create cosmos-sql --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -330,7 +330,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create cosmos-table --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -364,7 +364,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
             'spring': 'servicelinker-springcloud',
             'app': 'eventhub',
             'deployment': 'default',
-            'namespace': 'servicelinkertesteventhub' 
+            'namespace': 'servicelinkertesteventhub'
         })
 
         # prepare params
@@ -375,7 +375,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create eventhub --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -409,7 +409,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
             'spring': 'servicelinker-springcloud',
             'app': 'servicebus',
             'deployment': 'default',
-            'namespace': 'servicelinkertestservicebus' 
+            'namespace': 'servicelinkertestservicebus'
         })
 
         # prepare params
@@ -420,7 +420,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create servicebus --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -471,7 +471,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create postgres-flexible --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type java'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -516,7 +516,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create keyvault --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -540,7 +540,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # delete connection
         self.cmd('spring-cloud connection delete --id {} --yes'.format(connection_id))
 
-    
+
     # @record_only()
     def test_springcloud_redis_e2e(self):
         self.kwargs.update({
@@ -562,7 +562,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create redis --connection {} --source-id {} --target-id {} '
                  '--secret --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -608,7 +608,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create redis-enterprise --connection {} --source-id {} --target-id {} '
                  '--secret --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -659,7 +659,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create mysql --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type java'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -710,7 +710,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create mysql-flexible --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type java'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -761,7 +761,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create postgres --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type java'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -787,7 +787,6 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
 
 
     # @record_only
-    @unittest.skip('sql is removed from supported target resources')
     def test_springcloud_sql_e2e(self):
         self.kwargs.update({
             'subscription': get_subscription_id(self.cli_ctx),
@@ -813,7 +812,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create sql --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type java'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -858,7 +857,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create storage-blob --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),
@@ -953,7 +952,7 @@ class SpringCloudConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('spring-cloud connection create storage-queue --connection {} --source-id {} --target-id {} '
                  '--secret --client-type java'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'spring-cloud connection list --source-id {}'.format(source_id),

--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_webpp_connection_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/tests/latest/test_webpp_connection_scenario.py
@@ -53,7 +53,7 @@ class CredentialReplacer(RecordingProcessor):
             request.headers['x-ms-cupertino-test-token'] = 'hidden'
         if 'x-ms-serviceconnector-user-token' in request.headers:
             request.headers['x-ms-serviceconnector-user-token'] = 'hidden'
-        
+
         return request
 
     def process_response(self, response):
@@ -96,7 +96,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create appconfig --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -140,7 +140,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create cosmos-cassandra --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -185,7 +185,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create cosmos-gremlin --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -229,7 +229,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create cosmos-mongo --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type dotnet'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -273,7 +273,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create cosmos-sql --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -317,7 +317,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create cosmos-table --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -349,7 +349,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
             'source_resource_group': 'servicelinker-test-linux-group',
             'target_resource_group': 'servicelinker-test-linux-group',
             'site': 'servicelinker-eventhub-app2',
-            'namespace': 'servicelinkertesteventhub2' 
+            'namespace': 'servicelinkertesteventhub2'
         })
 
         # prepare params
@@ -360,7 +360,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create eventhub --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -392,7 +392,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
             'source_resource_group': 'servicelinker-test-linux-group',
             'target_resource_group': 'servicelinker-test-linux-group',
             'site': 'servicelinker-servicebus-app2',
-            'namespace': 'servicelinkertestservicebus2' 
+            'namespace': 'servicelinkertestservicebus2'
         })
 
         # prepare params
@@ -403,7 +403,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create servicebus --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -435,7 +435,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
             'source_resource_group': 'servicelinker-test-linux-group',
             'target_resource_group': 'servicelinker-test-linux-group',
             'site': 'servicelinker-signalr-app2',
-            'signalr': 'servicelinker-signalr2' 
+            'signalr': 'servicelinker-signalr2'
         })
 
         # prepare params
@@ -446,7 +446,50 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create signalr --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type dotnet'.format(name, source_id, target_id))
-        
+
+        # list connection
+        connections = self.cmd(
+            'webapp connection list --source-id {}'.format(source_id),
+            checks = [
+                self.check('length(@)', 1),
+                self.check('[0].authInfo.authType', 'systemAssignedIdentity'),
+                self.check('[0].clientType', 'dotnet')
+            ]
+        ).get_output_in_json()
+        connection_id = connections[0].get('id')
+
+        # list configuration
+        self.cmd('webapp connection list-configuration --id {}'.format(connection_id))
+
+        # validate connection
+        self.cmd('webapp connection validate --id {}'.format(connection_id))
+
+        # show connection
+        self.cmd('webapp connection show --id {}'.format(connection_id))
+
+        # delete connection
+        self.cmd('webapp connection delete --id {} --yes'.format(connection_id))
+
+
+    @record_only()
+    def test_webapp_webpubsub_e2e(self):
+        self.kwargs.update({
+            'subscription': get_subscription_id(self.cli_ctx),
+            'source_resource_group': 'servicelinker-test-linux-group',
+            'target_resource_group': 'servicelinker-test-linux-group',
+            'site': 'servicelinker-webpubsub-app',
+            'webpubsub': 'servicelinker-webpubsub'
+        })
+
+        # prepare params
+        name = 'testconn'
+        source_id = SOURCE_RESOURCES.get(RESOURCE.WebApp).format(**self.kwargs)
+        target_id = TARGET_RESOURCES.get(RESOURCE.WebPubSub).format(**self.kwargs)
+
+        # create connection
+        self.cmd('webapp connection create webpubsub --connection {} --source-id {} --target-id {} '
+                 '--system-identity --client-type dotnet'.format(name, source_id, target_id))
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -489,7 +532,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create keyvault --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -538,7 +581,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create postgres-flexible --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type python'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -582,7 +625,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create redis --connection {} --source-id {} --target-id {} '
                  '--secret --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -626,7 +669,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create redis-enterprise --connection {} --source-id {} --target-id {} '
                  '--secret --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -675,7 +718,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create mysql --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type python'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -724,7 +767,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create mysql-flexible --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type python'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -773,7 +816,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create postgres --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type python'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -799,7 +842,6 @@ class WebAppConnectionScenarioTest(ScenarioTest):
 
 
     @record_only()
-    @unittest.skip('Temporarily removed from supported target resources')
     def test_webapp_sql_e2e(self):
         self.kwargs.update({
             'subscription': get_subscription_id(self.cli_ctx),
@@ -823,7 +865,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create sql --connection {} --source-id {} --target-id {} '
                  '--secret name={} secret={} --client-type python'.format(name, source_id, target_id, user, password))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -866,7 +908,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create storage-blob --connection {} --source-id {} --target-id {} '
                  '--system-identity --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),
@@ -1024,7 +1066,7 @@ class WebAppConnectionScenarioTest(ScenarioTest):
         # create connection
         self.cmd('webapp connection create storage-queue --connection {} --source-id {} --target-id {} '
                  '--secret --client-type python'.format(name, source_id, target_id))
-        
+
         # list connection
         connections = self.cmd(
             'webapp connection list --source-id {}'.format(source_id),


### PR DESCRIPTION
**Description**<!--Mandatory-->

Adds supports for more target resources: sql and webpubsub.
* `az webapp connection create sql`
* `az webapp connection create webpubsub`

**Testing Guide**

add test: test_webapp_sql_e2e, test_webapp_webpubsub_e2e

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
