### PR TITLE
{Packaging} Bump Python version to 3.10.4 and 3.8.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 #---------------------------------------------------------------------------------------------
 
-ARG PYTHON_VERSION="3.10.3"
+ARG PYTHON_VERSION="3.10.4"
 
 FROM python:${PYTHON_VERSION}-alpine3.15
 

--- a/build_scripts/windows/scripts/build.cmd
+++ b/build_scripts/windows/scripts/build.cmd
@@ -13,10 +13,10 @@ if "%CLI_VERSION%"=="" (
     echo Please set the CLI_VERSION environment variable, e.g. 2.0.13
     goto ERROR
 )
-set PYTHON_VERSION=3.10.3
+set PYTHON_VERSION=3.10.4
 
 set WIX_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/msi/wix310-binaries-mirror.zip"
-set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/3.10.3/python-3.10.3-embed-win32.zip"
+set PYTHON_DOWNLOAD_URL="https://www.python.org/ftp/python/3.10.4/python-3.10.4-embed-win32.zip"
 set PROPAGATE_ENV_CHANGE_DOWNLOAD_URL="https://azurecliprod.blob.core.windows.net/util/propagate_env_change.zip"
 
 REM https://pip.pypa.io/en/stable/installation/#get-pip-py

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.8.12"
+PYTHON_VERSION="3.8.13"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages


### PR DESCRIPTION
**Description**

Use latest Python:

1. Docker image, Windows MSI: 3.10.4
2. Debian/Ubuntu: 3.8.13

