### PR TITLE
[AKS] Monitoring addon MSI auth - use existing tags on container insights extension dcr for PUT

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -389,20 +389,22 @@ def ensure_container_insights_for_monitoring(
                     raise ClientRequestError(
                         f"Data Collection Rule Associations are not supported for cluster region {location}"
                     )
-            dcr_url = cmd.cli_ctx.cloud.endpoints.resource_manager + f"{dcr_resource_id}?api-version=2019-11-01-preview"
+            dcr_url = cmd.cli_ctx.cloud.endpoints.resource_manager + \
+                f"{dcr_resource_id}?api-version=2019-11-01-preview"
             # get existing tags on the container insights extension DCR if the customer added any
-            existing_tags = get_existing_container_insights_extension_dcr_tags(cmd, dcr_url)
+            existing_tags = get_existing_container_insights_extension_dcr_tags(
+                cmd, dcr_url)
             # create the DCR
             dcr_creation_body = json.dumps(
                 {
                     "location": location,
-                    "tags":existing_tags,
+                    "tags": existing_tags,
                     "properties": {
                         "dataSources": {
                             "extensions": [
-                                    {
-                                        "name": "ContainerInsightsExtension",
-                                        "streams": [
+                                {
+                                    "name": "ContainerInsightsExtension",
+                                    "streams": [
                                             "Microsoft-Perf",
                                             "Microsoft-ContainerInventory",
                                             "Microsoft-ContainerLog",
@@ -415,37 +417,37 @@ def ensure_container_insights_for_monitoring(
                                             "Microsoft-KubePVInventory",
                                             "Microsoft-KubeServices",
                                             "Microsoft-InsightsMetrics",
-                                        ],
-                                        "extensionName": "ContainerInsights",
-                                    }
-                                ]
+                                    ],
+                                    "extensionName": "ContainerInsights",
+                                }
+                            ]
                         },
                         "dataFlows": [
-                                {
-                                    "streams": [
-                                        "Microsoft-Perf",
-                                        "Microsoft-ContainerInventory",
-                                        "Microsoft-ContainerLog",
-                                        "Microsoft-ContainerLogV2",
-                                        "Microsoft-ContainerNodeInventory",
-                                        "Microsoft-KubeEvents",
-                                        "Microsoft-KubeMonAgentEvents",
-                                        "Microsoft-KubeNodeInventory",
-                                        "Microsoft-KubePodInventory",
-                                        "Microsoft-KubePVInventory",
-                                        "Microsoft-KubeServices",
-                                        "Microsoft-InsightsMetrics",
-                                    ],
-                                    "destinations": ["la-workspace"],
-                                }
-                            ],
+                            {
+                                "streams": [
+                                    "Microsoft-Perf",
+                                    "Microsoft-ContainerInventory",
+                                    "Microsoft-ContainerLog",
+                                    "Microsoft-ContainerLogV2",
+                                    "Microsoft-ContainerNodeInventory",
+                                    "Microsoft-KubeEvents",
+                                    "Microsoft-KubeMonAgentEvents",
+                                    "Microsoft-KubeNodeInventory",
+                                    "Microsoft-KubePodInventory",
+                                    "Microsoft-KubePVInventory",
+                                    "Microsoft-KubeServices",
+                                    "Microsoft-InsightsMetrics",
+                                ],
+                                "destinations": ["la-workspace"],
+                            }
+                        ],
                         "destinations": {
-                                "logAnalytics": [
-                                    {
-                                        "workspaceResourceId": workspace_resource_id,
-                                        "name": "la-workspace",
-                                    }
-                                ]
+                            "logAnalytics": [
+                                {
+                                    "workspaceResourceId": workspace_resource_id,
+                                    "name": "la-workspace",
+                                }
+                            ]
                         },
                     },
                 }
@@ -556,7 +558,7 @@ def add_monitoring_role_assignment(result, cluster_resource_id, cmd):
         hasattr(result.addon_profiles[CONST_MONITORING_ADDON_NAME].config, "useAADAuth") and
         result.addon_profiles[CONST_MONITORING_ADDON_NAME].config.useAADAuth
     ):
-      is_useAADAuth = True
+        is_useAADAuth = True
     elif (
         hasattr(result, "service_principal_profile") and
         hasattr(result.service_principal_profile, "client_id") and
@@ -587,7 +589,8 @@ def add_monitoring_role_assignment(result, cluster_resource_id, cmd):
         is_service_principal = False
 
     if is_useAADAuth:
-        logger.info("Monitoring Metrics Publisher role assignment not required for monitoring addon with managed identity auth")
+        logger.info(
+            "Monitoring Metrics Publisher role assignment not required for monitoring addon with managed identity auth")
     elif service_principal_msi_id is not None:
         if not add_role_assignment(
             cmd,

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -251,7 +251,7 @@ def get_existing_container_insights_extension_dcr_tags(cmd, dcr_url):
             )
             json_response = json.loads(resp.text)
             if ("tags" in json_response) and (json_response["tags"] is not None):
-               tags = json_response["tags"]
+                tags = json_response["tags"]
             break
         except CLIError as e:
             if "ResourceNotFound" in str(e):
@@ -374,18 +374,17 @@ def ensure_container_insights_for_monitoring(
                 raise error
             json_response = json.loads(r.text)
             for resource in json_response["resourceTypes"]:
-                if (resource["resourceType"].lower() == "datacollectionrules"):
+                if resource["resourceType"].lower() == "datacollectionrules":
                     region_ids = map(
                         lambda x: region_names_to_id[x], resource["locations"])
-                    if (location not in region_ids):
+                    if location not in region_ids:
                         raise ClientRequestError(
                             f"Data Collection Rules are not supported for LA workspace region {location}")
-                if (resource["resourceType"].lower() == "datacollectionruleassociations"):
+                if resource["resourceType"].lower() == "datacollectionruleassociations":
                     region_ids = map(
                         lambda x: region_names_to_id[x], resource["locations"])
-                    if (cluster_region not in region_ids):
-                       raise ClientRequestError(
-                           f"Data Collection Rule Associations are not supported for cluster region {cluster_region}")
+                    if cluster_region not in region_ids:
+                        raise ClientRequestError(f"Data Collection Rule Associations are not supported for cluster region {cluster_region}")
             dcr_url = cmd.cli_ctx.cloud.endpoints.resource_manager + \
                 f"{dcr_resource_id}?api-version=2019-11-01-preview"
             # get existing tags on the container insights extension DCR if the customer added any
@@ -603,6 +602,7 @@ def _is_container_insights_solution_exists(cmd, workspace_resource_id):
             if retry_count >= (_MAX_RETRY_TIMES - 1):
                 raise ex
     return is_exists
+
 
 def _invoke_deployment(
     cmd,


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
For MSI auth of Monitoring addon, there will be DCR created  with format MSCI-<clusterName>-<clusterRegion>. If the customer tags and this resource exists, in case of customer try to re-onboard the monitoring addon with MSI auth, existing tags (if any) will be used for the PUT to retain the customer tags.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
