### PR TITLE
[IoT] BREAKING CHANGE: `iot dps access-policy`: Deprecate access-policy in favor of policy

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_help.py
@@ -18,56 +18,6 @@ type: group
 short-summary: Manage Azure IoT Hub Device Provisioning Service.
 """
 
-helps['iot dps access-policy'] = """
-type: group
-short-summary: Manage shared access policies for an Azure IoT Hub Device Provisioning Service instance.
-"""
-
-helps['iot dps access-policy create'] = """
-type: command
-short-summary: Create a new shared access policy in an Azure IoT Hub Device Provisioning Service instance.
-examples:
-  - name: Create a new shared access policy in an Azure IoT Hub Device Provisioning Service instance with EnrollmentRead right
-    text: >
-        az iot dps access-policy create --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentRead
-"""
-
-helps['iot dps access-policy delete'] = """
-type: command
-short-summary: Delete a shared access policies in an Azure IoT Hub Device Provisioning Service instance.
-examples:
-  - name: Delete shared access policy 'MyPolicy' in the Azure IoT Hub Device Provisioning Service instance 'MyDps'
-    text: >
-        az iot dps access-policy delete --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
-"""
-
-helps['iot dps access-policy list'] = """
-type: command
-short-summary: List all shared access policies in an Azure IoT Hub Device Provisioning Service instance.
-examples:
-  - name: List all shared access policies in the Azure IoT Hub Device Provisioning Service instance 'MyDps'
-    text: >
-        az iot dps access-policy list --dps-name MyDps --resource-group MyResourceGroup
-"""
-
-helps['iot dps access-policy show'] = """
-type: command
-short-summary: Show details of a shared access policies in an Azure IoT Hub Device Provisioning Service instance.
-examples:
-  - name: Show details of shared access policy 'MyPolicy' in the Azure IoT Hub Device Provisioning Service instance 'MyDps'
-    text: >
-        az iot dps access-policy show --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy
-"""
-
-helps['iot dps access-policy update'] = """
-type: command
-short-summary: Update a shared access policy in an Azure IoT Hub Device Provisioning Service instance.
-examples:
-  - name: Update shared access policy 'MyPolicy' in an Azure IoT Hub Device Provisioning Service instance with EnrollmentWrite right
-    text: >
-        az iot dps access-policy update --dps-name MyDps --resource-group MyResourceGroup --name MyPolicy --rights EnrollmentWrite
-"""
-
 helps['iot dps policy'] = """
 type: group
 short-summary: Manage shared access policies for an Azure IoT Hub Device Provisioning Service instance.

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -16,7 +16,6 @@ from azure.cli.core.commands.parameters import (get_location_type,
 from azure.mgmt.iotcentral.models import AppSku
 from azure.mgmt.iothub.models import IotHubSku
 from azure.mgmt.iothubprovisioningservices.models import (IotDpsSku,
-                                                          AllocationPolicy,
                                                           AccessRightsDescription)
 from azure.cli.command_modules.iot.shared import (EndpointType,
                                                   RouteSourceType,
@@ -78,12 +77,13 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    'cross geo-pair disaster recovery. This property is immutable once set on the resource. '
                    'Only available in select regions. Learn more at https://aka.ms/dpsdr')
 
-    for subgroup in ['policy', 'linked-hub', 'certificate']:
+    # plan to slowly align this with extension naming patterns - name should be aligned with dps_name
+    for subgroup in ['linked-hub', 'certificate']:
         with self.argument_context('iot dps {}'.format(subgroup)) as c:
             c.argument('dps_name', options_list=['--dps-name'], id_part=None)
 
     with self.argument_context('iot dps policy') as c:
-        c.argument('access_policy_name', options_list=['--policy-name', '--pn', '--name', '-n'],
+        c.argument('access_policy_name', options_list=['--policy-name', '--pn'],
                    help='A friendly name for DPS access policy.')
 
     for subgroup in ['create', 'update']:
@@ -124,10 +124,6 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    help='A boolean indicating whether to apply allocation policy to the Iot hub.',
                    arg_type=get_three_state_flag())
         c.argument('allocation_weight', help='Allocation weight of the IoT hub.')
-
-    with self.argument_context('iot dps allocation-policy update') as c:
-        c.argument('allocation_policy', options_list=['--policy', '-p'], arg_type=get_enum_type(AllocationPolicy),
-                   help='Allocation policy for the IoT Hub Device Provisioning Service.')
 
     with self.argument_context('iot dps certificate') as c:
         c.argument('certificate_path', options_list=['--path', '-p'], type=file_type,

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -61,7 +61,7 @@ system_assigned_type = CLIArgumentType(
 def load_arguments(self, _):  # pylint: disable=too-many-statements
     # Arguments for IoT DPS
     with self.argument_context('iot dps') as c:
-        c.argument('dps_name', dps_name_type, options_list=['--dps-name', '--name', '-n'], id_part='name')
+        c.argument('dps_name', dps_name_type, options_list=['--name', '-n'], id_part='name')
         c.argument('tags', tags_type)
 
     with self.argument_context('iot dps create') as c:
@@ -81,6 +81,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     for subgroup in ['linked-hub', 'certificate']:
         with self.argument_context('iot dps {}'.format(subgroup)) as c:
             c.argument('dps_name', options_list=['--dps-name'], id_part=None)
+
+    # To replace above
+    for subgroup in ['policy']:
+        with self.argument_context('iot dps {}'.format(subgroup)) as c:
+            c.argument('dps_name', options_list=['--dps-name', '-n'], id_part=None)
 
     with self.argument_context('iot dps policy') as c:
         c.argument('access_policy_name', options_list=['--policy-name', '--pn'],

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -78,8 +78,12 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    'cross geo-pair disaster recovery. This property is immutable once set on the resource. '
                    'Only available in select regions. Learn more at https://aka.ms/dpsdr')
 
+    for subgroup in ['policy', 'linked-hub', 'certificate']:
+        with self.argument_context('iot dps {}'.format(subgroup)) as c:
+            c.argument('dps_name', options_list=['--dps-name'], id_part=None)
+
     with self.argument_context('iot dps policy') as c:
-        c.argument('access_policy_name', options_list=['--policy-name', '--pn'],
+        c.argument('access_policy_name', options_list=['--policy-name', '--pn', '--name', '-n'],
                    help='A friendly name for DPS access policy.')
 
     for subgroup in ['create', 'update']:
@@ -98,7 +102,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('connection_string',
                    help='Connection string of the IoT hub. Required if hub name is not provided using --hub-name.',
                    arg_group='IoT Hub Identifier')
-        c.argument('hub_name', help='IoT Hub name.', arg_group='IoT Hub Identifier')
+        c.argument('hub_name',
+                   options_list=['--hub-name', '--hn'],
+                   help='IoT Hub name.',
+                   arg_group='IoT Hub Identifier')
         c.argument('hub_resource_group',
                    options_list=['--hub-resource-group', '--hrg'],
                    help='IoT Hub resource group name.',

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -78,55 +78,18 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    'cross geo-pair disaster recovery. This property is immutable once set on the resource. '
                    'Only available in select regions. Learn more at https://aka.ms/dpsdr')
 
-    # To deprecate
-    for subgroup in ['access-policy', 'linked-hub', 'certificate']:
-        with self.argument_context('iot dps {}'.format(subgroup)) as c:
-            c.argument('dps_name', options_list=['--dps-name'], id_part=None)
-
-    # To replace deprecated
-    for subgroup in ['policy']:
-        with self.argument_context('iot dps {}'.format(subgroup)) as c:
-            c.argument('dps_name', options_list=['--dps-name', '-n'], id_part=None)
-
-    with self.argument_context('iot dps access-policy') as c:
-        c.argument('access_policy_name', options_list=['--access-policy-name', '--name', '-n'],
-                   help='A friendly name for DPS shared access policy.')
-
-    with self.argument_context('iot dps access-policy create') as c:
-        c.argument('rights', options_list=['--rights', '-r'], nargs='+',
-                   arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT Hub Device Provisioning Service. '
-                        'Use space-separated list for multiple rights.')
-        c.argument('primary_key', help='Primary SAS key value.')
-        c.argument('secondary_key', help='Secondary SAS key value.')
-
-    with self.argument_context('iot dps access-policy update') as c:
-        c.argument('rights', options_list=['--rights', '-r'], nargs='+',
-                   arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT Hub Device Provisioning Service. '
-                        'Use space-separated list for multiple rights.')
-        c.argument('primary_key', help='Primary SAS key value.')
-        c.argument('secondary_key', help='Secondary SAS key value.')
-
     with self.argument_context('iot dps policy') as c:
         c.argument('access_policy_name', options_list=['--policy-name', '--pn'],
                    help='A friendly name for DPS access policy.')
 
-    with self.argument_context('iot dps policy create') as c:
-        c.argument('rights', options_list=['--rights', '-r'], nargs='+',
-                   arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT Hub Device Provisioning Service. '
-                        'Use space-separated list for multiple rights.')
-        c.argument('primary_key', help='Primary SAS key value.')
-        c.argument('secondary_key', help='Secondary SAS key value.')
-
-    with self.argument_context('iot dps policy update') as c:
-        c.argument('rights', options_list=['--rights', '-r'], nargs='+',
-                   arg_type=get_enum_type(AccessRightsDescription),
-                   help='Access rights for the IoT Hub Device Provisioning Service. '
-                        'Use space-separated list for multiple rights.')
-        c.argument('primary_key', help='Primary SAS key value.')
-        c.argument('secondary_key', help='Secondary SAS key value.')
+    for subgroup in ['create', 'update']:
+        with self.argument_context('iot dps policy {}'.format(subgroup)) as c:
+            c.argument('rights', options_list=['--rights', '-r'], nargs='+',
+                    arg_type=get_enum_type(AccessRightsDescription),
+                    help='Access rights for the IoT Hub Device Provisioning Service. '
+                            'Use space-separated list for multiple rights.')
+            c.argument('primary_key', help='Primary SAS key value.')
+            c.argument('secondary_key', help='Secondary SAS key value.')
 
     with self.argument_context('iot dps linked-hub') as c:
         c.argument('linked_hub', options_list=['--linked-hub'], help='Host name of linked IoT Hub.')

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -61,7 +61,7 @@ system_assigned_type = CLIArgumentType(
 def load_arguments(self, _):  # pylint: disable=too-many-statements
     # Arguments for IoT DPS
     with self.argument_context('iot dps') as c:
-        c.argument('dps_name', dps_name_type, options_list=['--name', '-n'], id_part='name')
+        c.argument('dps_name', dps_name_type, options_list=['--dps-name', '--name', '-n'], id_part='name')
         c.argument('tags', tags_type)
 
     with self.argument_context('iot dps create') as c:

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -77,7 +77,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
                    'cross geo-pair disaster recovery. This property is immutable once set on the resource. '
                    'Only available in select regions. Learn more at https://aka.ms/dpsdr')
 
-    # plan to slowly align this with extension naming patterns - name should be aligned with dps_name
+    # plan to slowly align this with extension naming patterns - n should be aligned with dps_name
     for subgroup in ['linked-hub', 'certificate']:
         with self.argument_context('iot dps {}'.format(subgroup)) as c:
             c.argument('dps_name', options_list=['--dps-name'], id_part=None)

--- a/src/azure-cli/azure/cli/command_modules/iot/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_params.py
@@ -89,8 +89,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
     for subgroup in ['create', 'update']:
         with self.argument_context('iot dps policy {}'.format(subgroup)) as c:
             c.argument('rights', options_list=['--rights', '-r'], nargs='+',
-                    arg_type=get_enum_type(AccessRightsDescription),
-                    help='Access rights for the IoT Hub Device Provisioning Service. '
+                       arg_type=get_enum_type(AccessRightsDescription),
+                       help='Access rights for the IoT Hub Device Provisioning Service. '
                             'Use space-separated list for multiple rights.')
             c.argument('primary_key', help='Primary SAS key value.')
             c.argument('secondary_key', help='Secondary SAS key value.')

--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -60,18 +60,6 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.generic_update_command('update', getter_name='iot_dps_get', setter_name='iot_dps_update',
                                  command_type=update_custom_util)
 
-    # iot dps access-policy commands (Deprecated)
-    with self.command_group('iot dps access-policy',
-                            client_factory=iot_service_provisioning_factory,
-                            deprecate_info=self.deprecate(redirect='iot dps policy',
-                                                          expiration='2.36.0')
-                            ) as g:
-        g.custom_command('list', 'iot_dps_policy_list')
-        g.custom_show_command('show', 'iot_dps_policy_get')
-        g.custom_command('create', 'iot_dps_policy_create', supports_no_wait=True)
-        g.custom_command('update', 'iot_dps_policy_update', supports_no_wait=True)
-        g.custom_command('delete', 'iot_dps_policy_delete', supports_no_wait=True)
-
     # iot dps linked-hub commands
     with self.command_group('iot dps linked-hub', client_factory=iot_service_provisioning_factory) as g:
         g.custom_command('list', 'iot_dps_linked_hub_list')

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_dps_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_dps_commands.py
@@ -58,7 +58,7 @@ class IoTDpsTest(ScenarioTest):
         new_right = 'EnrollmentWrite'
 
         # Create access policy
-        self.cmd('az iot dps policy create -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
+        self.cmd('az iot dps policy create -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
@@ -71,20 +71,20 @@ class IoTDpsTest(ScenarioTest):
         ])
 
         # Get access policy
-        self.cmd('az iot dps policy show -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name), checks=[
+        self.cmd('az iot dps policy show -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # Create update policy
-        self.cmd('az iot dps policy update -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, new_right),
+        self.cmd('az iot dps policy update -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, new_right),
                  checks=[
                      self.check('keyName', policy_name),
                      self.check('rights', new_right)
         ])
 
         # Delete policy
-        self.cmd('az iot dps policy delete -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name))
+        self.cmd('az iot dps policy delete -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name))
 
         # Test DPS Certificate Lifecycle
         cert_name = self.create_random_name('certificate', 20)

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_dps_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_dps_commands.py
@@ -58,33 +58,33 @@ class IoTDpsTest(ScenarioTest):
         new_right = 'EnrollmentWrite'
 
         # Create access policy
-        self.cmd('az iot dps access-policy create -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
+        self.cmd('az iot dps policy create -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # List access policy
-        self.cmd('az iot dps access-policy list -g {} --dps-name {}'.format(group_name, dps_name), checks=[
+        self.cmd('az iot dps policy list -g {} --dps-name {}'.format(group_name, dps_name), checks=[
             self.check('length([*])', 2),
             self.check('[1].keyName', policy_name),
             self.check('[1].rights', right)
         ])
 
         # Get access policy
-        self.cmd('az iot dps access-policy show -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name), checks=[
+        self.cmd('az iot dps policy show -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # Create update policy
-        self.cmd('az iot dps access-policy update -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, new_right),
+        self.cmd('az iot dps policy update -g {} --dps-name {} -n {} -r {}'.format(group_name, dps_name, policy_name, new_right),
                  checks=[
                      self.check('keyName', policy_name),
                      self.check('rights', new_right)
         ])
 
         # Delete policy
-        self.cmd('az iot dps access-policy delete -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name))
+        self.cmd('az iot dps policy delete -g {} --dps-name {} -n {}'.format(group_name, dps_name, policy_name))
 
         # Test DPS Certificate Lifecycle
         cert_name = self.create_random_name('certificate', 20)

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
@@ -66,33 +66,33 @@ class IoTDpsTest(ScenarioTest):
         new_right = 'EnrollmentWrite'
 
         # Create access policy
-        self.cmd('az iot dps policy create -g {} --name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
+        self.cmd('az iot dps policy create -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # List access policy
-        self.cmd('az iot dps policy list -g {} --name {}'.format(group_name, dps_name), checks=[
+        self.cmd('az iot dps policy list -g {} --dps-name {}'.format(group_name, dps_name), checks=[
             self.check('length([*])', 2),
             self.check('[1].keyName', policy_name),
             self.check('[1].rights', right)
         ])
 
         # Get access policy
-        self.cmd('az iot dps policy show -g {} --name {} --pn {}'.format(group_name, dps_name, policy_name), checks=[
+        self.cmd('az iot dps policy show -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # Create update policy
-        self.cmd('az iot dps policy update -g {} --name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, new_right),
+        self.cmd('az iot dps policy update -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, new_right),
                  checks=[
                      self.check('keyName', policy_name),
                      self.check('rights', new_right)
         ])
 
         # Delete policy
-        self.cmd('az iot dps policy delete -g {} --name {} --pn {}'.format(group_name, dps_name, policy_name))
+        self.cmd('az iot dps policy delete -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name))
 
         # Delete DPS
         self.cmd('az iot dps delete -g {} -n {}'.format(group_name, dps_name))

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
@@ -66,33 +66,33 @@ class IoTDpsTest(ScenarioTest):
         new_right = 'EnrollmentWrite'
 
         # Create access policy
-        self.cmd('az iot dps policy create -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
+        self.cmd('az iot dps policy create -g {} --name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, right), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # List access policy
-        self.cmd('az iot dps policy list -g {} --dps-name {}'.format(group_name, dps_name), checks=[
+        self.cmd('az iot dps policy list -g {} --name {}'.format(group_name, dps_name), checks=[
             self.check('length([*])', 2),
             self.check('[1].keyName', policy_name),
             self.check('[1].rights', right)
         ])
 
         # Get access policy
-        self.cmd('az iot dps policy show -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name), checks=[
+        self.cmd('az iot dps policy show -g {} --name {} --pn {}'.format(group_name, dps_name, policy_name), checks=[
             self.check('keyName', policy_name),
             self.check('rights', right)
         ])
 
         # Create update policy
-        self.cmd('az iot dps policy update -g {} --dps-name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, new_right),
+        self.cmd('az iot dps policy update -g {} --name {} --pn {} -r {}'.format(group_name, dps_name, policy_name, new_right),
                  checks=[
                      self.check('keyName', policy_name),
                      self.check('rights', new_right)
         ])
 
         # Delete policy
-        self.cmd('az iot dps policy delete -g {} --dps-name {} --pn {}'.format(group_name, dps_name, policy_name))
+        self.cmd('az iot dps policy delete -g {} --name {} --pn {}'.format(group_name, dps_name, policy_name))
 
         # Delete DPS
         self.cmd('az iot dps delete -g {} -n {}'.format(group_name, dps_name))


### PR DESCRIPTION
**Description**

Replace access-policy with policy in `az iot dps` to align better with other command groups.

**Testing Guide**
The following command was run to test:
`azdev test test_dps_lifecycle test_dps_certificate_lifecycle test_dps_linked_hub_lifecycle`

In addition, the entire iot module was tested:
`azdev test iot`

**History Notes**

The command group `az iot dps access-policy` has been deprecated and replaced with `az iot dps policy` .

Related prs:
https://github.com/Azure/azure-cli/pull/20682
https://github.com/Azure/azure-cli/pull/21892

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
