### PR TITLE
[App Config] Fix #14012055: Fix feature flag import for missing description when using 'appconfig/kvset' profile.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -36,6 +36,7 @@ from._featuremodels import (map_keyvalue_to_featureflag,
 logger = get_logger(__name__)
 FEATURE_MANAGEMENT_KEYWORDS = ["FeatureManagement", "featureManagement", "feature_management", "feature-management"]
 ENABLED_FOR_KEYWORDS = ["EnabledFor", "enabledFor", "enabled_for", "enabled-for"]
+FEATURE_FLAG_PROPERTIES = {'id', 'description', 'enabled', 'conditions'}
 
 
 class FeatureManagementReservedKeywords:
@@ -1127,7 +1128,7 @@ def __validate_import_feature_flag(kv):
     if kv and validate_import_feature(kv.key):
         try:
             ff = json.loads(kv.value)
-            if ff['id'] and ff['description'] and ff['enabled'] and ff['conditions']:
+            if FEATURE_FLAG_PROPERTIES.issubset(ff.keys()):
                 return True
             logger.warning("The feature flag with key '{%s}' is not a valid feature flag. It will not be imported.", kv.key)
         except JSONDecodeError as exception:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -1128,7 +1128,7 @@ def __validate_import_feature_flag(kv):
     if kv and validate_import_feature(kv.key):
         try:
             ff = json.loads(kv.value)
-            if FEATURE_FLAG_PROPERTIES.issubset(ff.keys()):
+            if FEATURE_FLAG_PROPERTIES == ff.keys():
                 return True
             logger.warning("The feature flag with key '{%s}' is not a valid feature flag. It will not be imported.", kv.key)
         except JSONDecodeError as exception:

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -149,8 +149,8 @@ def load_arguments(self, _):
     with self.argument_context('appconfig kv import', arg_group='AppConfig') as c:
         c.argument('src_name', help='The name of the source App Configuration.')
         c.argument('src_connection_string', validator=validate_connection_string, help="Combination of access key and endpoint of the source store.")
-        c.argument('src_key', help='If no key specified, import all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix. Key filtering not applicable for feature flags. By default, all feature flags with specified label will be imported. This argument is ignored when using `appconfig/kvset` profile.')
-        c.argument('src_label', help="Only keys with this label in source AppConfig will be imported. If no value specified, import keys with null label by default. Support star sign as filters, for instance * means all labels, abc* means labels with abc as prefix.  This argument is ignored when using `appconfig/kvset` profile.")
+        c.argument('src_key', help='If no key specified, import all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix. Key filtering not applicable for feature flags. By default, all feature flags with specified label will be imported.')
+        c.argument('src_label', help="Only keys with this label in source AppConfig will be imported. If no value specified, import keys with null label by default. Support star sign as filters, for instance * means all labels, abc* means labels with abc as prefix.")
         c.argument('preserve_labels', arg_type=get_three_state_flag(), help="Flag to preserve labels from source AppConfig. This argument should NOT be specified along with --label.")
         c.argument('src_endpoint', help='If --src-auth-mode is "login", provide endpoint URL of the source App Configuration.')
         c.argument('src_auth_mode', arg_type=get_enum_type(['login', 'key']),

--- a/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_params.py
@@ -149,8 +149,8 @@ def load_arguments(self, _):
     with self.argument_context('appconfig kv import', arg_group='AppConfig') as c:
         c.argument('src_name', help='The name of the source App Configuration.')
         c.argument('src_connection_string', validator=validate_connection_string, help="Combination of access key and endpoint of the source store.")
-        c.argument('src_key', help='If no key specified, import all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix. Key filtering not applicable for feature flags. By default, all feature flags with specified label will be imported.')
-        c.argument('src_label', help="Only keys with this label in source AppConfig will be imported. If no value specified, import keys with null label by default. Support star sign as filters, for instance * means all labels, abc* means labels with abc as prefix.")
+        c.argument('src_key', help='If no key specified, import all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix. Key filtering not applicable for feature flags. By default, all feature flags with specified label will be imported. This argument is ignored when using `appconfig/kvset` profile.')
+        c.argument('src_label', help="Only keys with this label in source AppConfig will be imported. If no value specified, import keys with null label by default. Support star sign as filters, for instance * means all labels, abc* means labels with abc as prefix.  This argument is ignored when using `appconfig/kvset` profile.")
         c.argument('preserve_labels', arg_type=get_three_state_flag(), help="Flag to preserve labels from source AppConfig. This argument should NOT be specified along with --label.")
         c.argument('src_endpoint', help='If --src-auth-mode is "login", provide endpoint URL of the source App Configuration.')
         c.argument('src_auth_mode', arg_type=get_enum_type(['login', 'key']),
@@ -160,7 +160,7 @@ def load_arguments(self, _):
         c.argument('appservice_account', validator=validate_appservice_name_or_id, help='ARM ID for AppService OR the name of the AppService, assuming it is in the same subscription and resource group as the App Configuration. Required for AppService arguments')
 
     with self.argument_context('appconfig kv export') as c:
-        c.argument('label', help="Only keys and feature flags with this label will be exported. If no label specified, export keys and feature flags with null label by default. Only when export destination is appconfig, we support star sign as filters, for instance * means all labels and abc* means labels with abc as prefix. Label filters are not supported when exporting to file or appservice.")
+        c.argument('label', help="Only keys and feature flags with this label will be exported. If no label specified, export keys and feature flags with null label by default. When export destination is appconfig, or when export destination is file with `appconfig/kvset` profile, this argument supports asterisk and comma signs for label filtering, for instance, * means all labels, abc* means labels with abc as prefix, and abc,xyz means labels with abc or xyz.")
         c.argument('prefix', help="Prefix to be trimmed from keys. Prefix will be ignored for feature flags.")
         c.argument('key', help='If no key specified, return all keys by default. Support star sign as filters, for instance abc* means keys with abc as prefix. Key filtering not applicable for feature flags. By default, all feature flags with specified label will be exported.')
         c.argument('destination', options_list=['--destination', '-d'], arg_type=get_enum_type(['file', 'appconfig', 'appservice']), validator=validate_export, help="The destination of exporting. Note that exporting feature flags to appservice is not supported.")


### PR DESCRIPTION
**Description**
- Fixes [#14012055](https://msazure.visualstudio.com/Azure%20AppConfig/_workitems/edit/14012055) Fix feature flag import for missing description when using 'appconfig/kvset' profile.
- Updates help text for a couple of arguments.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).