### PR TITLE
[Packaging] Add Ubuntu 22.04 Jammy Jellyfish support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -879,7 +879,6 @@ jobs:
 
 - job: TestDebPackages
   displayName: Test Deb Packages
-
   dependsOn:
    - BuildDebPackages
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
@@ -888,9 +887,15 @@ jobs:
       Focal:
         deb_system: ubuntu
         distro: focal
+      Jammy:
+        deb_system: ubuntu
+        distro: jammy
       Buster:
         deb_system: debian
         distro: buster
+      Bullseye:
+        deb_system: debian
+        distro: bullseye
   pool:
     vmImage: 'ubuntu-20.04'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -816,8 +816,6 @@ jobs:
 
 - job: BuildDebPackages
   displayName: Build Deb Packages
-
-  dependsOn: BuildPythonWheel
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
     vmImage: 'ubuntu-20.04'
@@ -859,12 +857,6 @@ jobs:
         deb_system: debian
         distro: bullseye
   steps:
-  - task: DownloadPipelineArtifact@1
-    displayName: 'Download Build Artifacts'
-    inputs:
-      TargetPath: '$(Build.ArtifactStagingDirectory)/pypi'
-      artifactName: pypi
-
   - task: Bash@3
     displayName: 'Build $(deb_system) $(distro) Package'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -840,6 +840,10 @@ jobs:
         # 21.10
         deb_system: ubuntu
         distro: impish
+      Jammy:
+        # 22.04
+        deb_system: ubuntu
+        distro: jammy
 
       # https://wiki.debian.org/DebianReleases
       Stretch:

--- a/scripts/release/debian/pipeline.sh
+++ b/scripts/release/debian/pipeline.sh
@@ -19,7 +19,3 @@ docker run --rm \
            -e DEBIAN_FRONTEND=noninteractive \
            $DISTRO_BASE_IMAGE \
            /mnt/repo/scripts/release/debian/build.sh
-
-if [ -d $BUILD_STAGINGDIRECTORY/pypi ]; then
-    rm -rf $BUILD_STAGINGDIRECTORY/pypi
-fi


### PR DESCRIPTION
**Description**

Close https://github.com/Azure/azure-cli/issues/21857

As the next LTS (Long-Term Support) version of Ubuntu - 22.04 Jammy Jellyfish will be released on April 21, 2022, we use the `devel` docker image to build the preview package.
