### PR TITLE
{Core} Ignore `FileNotFoundError` in `rmtree_with_retry`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1279,6 +1279,10 @@ def rmtree_with_retry(path):
             import shutil
             shutil.rmtree(path)
             return
+        except FileNotFoundError:
+            # The folder has already been deleted. No further retry is needed.
+            # errno: 2, winerror: 3, strerror: 'The system cannot find the path specified'
+            return
         except OSError as err:
             if retry_num > 0:
                 logger.warning("Failed to delete '%s': %s. Retrying ...", path, err)


### PR DESCRIPTION
**Description**<!--Mandatory-->

`rmtree_with_retry` now doesn't ignore `FileNotFoundError`. Then though the directory doesn't exist, `rmtree_with_retry` will retry several times (like in https://github.com/Azure/azure-cli/issues/21964), which is definitely not what we want.

This PR ignores `FileNotFoundError` in `rmtree_with_retry`.