### PR TITLE
[Storage] Fix #21914: `az storage blob upload`: Make block size larger (100MB) for large files (>200GB)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -510,12 +510,16 @@ def transform_blob_type(cmd, blob_type):
 
 # pylint: disable=protected-access
 def _adjust_block_blob_size(client, blob_type, length):
-    if not blob_type or blob_type != 'block':
+    if not blob_type or blob_type != 'block' or length is None:
         return
 
-    # increase the block size to 4000MB when the block list will contain more than
-    # 50,000 blocks(each block 100MB)
-    if length is not None and length > 50000 * 100 * 1024 * 1024:
+    # increase the block size to 100MB when the block list will contain more than 50,000 blocks(each block 4MB)
+    if length > 50000 * 4 * 1024 * 1024:
+        client.MAX_BLOCK_SIZE = 100 * 1024 * 1024
+        client.MAX_SINGLE_PUT_SIZE = 256 * 1024 * 1024
+
+    # increase the block size to 4000MB when the block list will contain more than 50,000 blocks(each block 100MB)
+    if length > 50000 * 100 * 1024 * 1024:
         client._config.max_block_size = 4000 * 1024 * 1024
         client._config.max_single_put_size = 5000 * 1024 * 1024
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -515,8 +515,8 @@ def _adjust_block_blob_size(client, blob_type, length):
 
     # increase the block size to 100MB when the block list will contain more than 50,000 blocks(each block 4MB)
     if length > 50000 * 4 * 1024 * 1024:
-        client.MAX_BLOCK_SIZE = 100 * 1024 * 1024
-        client.MAX_SINGLE_PUT_SIZE = 256 * 1024 * 1024
+        client._config.max_block_size = 100 * 1024 * 1024
+        client._config.max_single_put_size = 256 * 1024 * 1024
 
     # increase the block size to 4000MB when the block list will contain more than 50,000 blocks(each block 100MB)
     if length > 50000 * 100 * 1024 * 1024:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously would still use block size of 4MB for large files which results in more than 50,000 blocks.  (ErrorCode:BlockListTooLong)

**Testing Guide**
<!--Example commands with explanations.-->
Use a file larger than 200GB and `az storage blob upload -f {file_path} -c {container_name} -n {blob_name}
Should succeed

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] Fix #21914: `az storage blob upload`: Make block size larger (100MB) for large files (>200GB)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
