### PR TITLE
{netappfiles} Return the result of `SnapshotsOperations.begin_restore_files`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -417,7 +417,7 @@ def snapshot_restore_files(client, resource_group_name, account_name, pool_name,
         file_paths=file_paths,
         destination_path=destination_path
     )
-    client.begin_restore_files(resource_group_name, account_name, pool_name, volume_name, snapshot_name, body)
+    return client.begin_restore_files(resource_group_name, account_name, pool_name, volume_name, snapshot_name, body)
 
 
 # ---- SNAPSHOT POLICIES ----

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/tests/latest/test_snapshot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/tests/latest/test_snapshot_commands.py
@@ -2,6 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+
+import unittest
+
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer
 from azure.cli.testsdk.decorators import serial_test
 
@@ -176,6 +179,7 @@ class AzureNetAppFilesSnapshotServiceScenarioTest(ScenarioTest):
         snapshot_from_id = self.cmd("az netappfiles snapshot show --ids %s" % snapshot['id']).get_output_in_json()
         assert snapshot_from_id['name'] == account_name + '/' + pool_name + '/' + volume_name + '/' + snapshot_name
 
+    @unittest.skip('This test requires southcentralusstage and cannot be run with public cloud.')
     @ResourceGroupPreparer(name_prefix='cli_netappfiles_test_snapshot_', additional_tags={'owner': 'cli_test'})
     def test_restore_file(self):
         # create volume


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/issues/21954

`test_restore_file` added by https://github.com/Azure/azure-cli/pull/21712 randomly fails:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1485372&view=logs&j=c846b3e8-69b8-5dbd-1a39-4905d81e6a95&t=9ebb608a-8a51-5834-bad0-46e2c03d2282

```
2022-04-06T09:12:24.1762149Z =================================== FAILURES ===================================
2022-04-06T09:12:24.1762678Z ________ AzureNetAppFilesSnapshotServiceScenarioTest.test_restore_file _________
2022-04-06T09:12:24.1763782Z [gw0] linux -- Python 3.8.13 /opt/az/bin/python3
2022-04-06T09:12:24.1764428Z /opt/az/lib/python3.8/site-packages/azure/cli/testsdk/base.py:139: in tearDown
2022-04-06T09:12:24.1764907Z     super(ScenarioTest, self).tearDown()
2022-04-06T09:12:24.1765318Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2022-04-06T09:12:24.1765529Z 
2022-04-06T09:12:24.1766025Z self = <command_modules.netappfiles.tests.latest.test_snapshot_commands.AzureNetAppFilesSnapshotServiceScenarioTest testMethod=test_restore_file>
2022-04-06T09:12:24.1766574Z 
2022-04-06T09:12:24.1766877Z     def tearDown(self):
2022-04-06T09:12:24.1767226Z         os.environ = self.original_env
2022-04-06T09:12:24.1767596Z         # Autorest.Python 2.x
2022-04-06T09:12:24.1768058Z         assert not [t for t in threading.enumerate() if t.name.startswith("AzureOperationPoller")], \
2022-04-06T09:12:24.1768837Z             "You need to call 'result' or 'wait' on all AzureOperationPoller you have created"
2022-04-06T09:12:24.1769322Z         # Autorest.Python 3.x
2022-04-06T09:12:24.1769765Z >       assert not [t for t in threading.enumerate() if t.name.startswith("LROPoller")], \
2022-04-06T09:12:24.1770495Z             "You need to call 'result' or 'wait' on all LROPoller you have created"
2022-04-06T09:12:24.1771247Z E       AssertionError: You need to call 'result' or 'wait' on all LROPoller you have created
2022-04-06T09:12:24.1771563Z 
2022-04-06T09:12:24.1772203Z /opt/az/lib/python3.8/site-packages/azure/cli/testsdk/scenario_tests/base.py:156: AssertionError
2022-04-06T09:12:24.1772976Z ---------- generated xml file: /azure_cli_test_result/netappfiles.xml ----------
2022-04-06T09:12:24.1773527Z =========================== short test summary info ============================
2022-04-06T09:12:24.1774147Z FAILED tests/latest/test_snapshot_commands.py::AzureNetAppFilesSnapshotServiceScenarioTest::test_restore_file
```

**Change**

Return the result of `SnapshotsOperations.begin_restore_files` so that the returned `LROPoller` is polled by CLI core.
