### PR TITLE
[ACR] `acr task run`: Add missing --no-format option

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -856,6 +856,7 @@ def acr_task_run(cmd,  # pylint: disable=too-many-locals
                  secret_arg=None,
                  target=None,
                  update_trigger_token=None,
+                 no_format=False,
                  no_logs=False,
                  no_wait=False,
                  resource_group_name=None,
@@ -915,7 +916,7 @@ def acr_task_run(cmd,  # pylint: disable=too-many-locals
         from ._run_polling import get_run_with_polling
         return get_run_with_polling(cmd, client, run_id, registry_name, resource_group_name)
 
-    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, timeout, True)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, timeout, no_format, True)
 
 
 def acr_task_show_run(cmd,
@@ -984,6 +985,7 @@ def acr_task_logs(cmd,
                   run_id=None,
                   task_name=None,
                   image=None,
+                  no_format=False,
                   resource_group_name=None):
     _, resource_group_name = validate_managed_registry(
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
@@ -1007,7 +1009,7 @@ def acr_task_logs(cmd,
                                                   task_name=task_name,
                                                   image=image))
 
-    return stream_logs(cmd, client, run_id, registry_name, resource_group_name)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, None, no_format, False)
 
 
 def _get_list_runs_message(base_message, task_name=None, image=None):

--- a/src/azure-cli/azure/cli/command_modules/acr/taskrun.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/taskrun.py
@@ -48,6 +48,7 @@ def acr_taskrun_logs(cmd,
                      client,  # cf_acr_runs
                      registry_name,
                      taskrun_name,
+                     no_format=False,
                      resource_group_name=None):
     _, resource_group_name = validate_managed_registry(
         cmd, registry_name, resource_group_name, TASKRUN_NOT_SUPPORTED)
@@ -57,4 +58,4 @@ def acr_taskrun_logs(cmd,
     response = client_taskruns.get(resource_group_name, registry_name, taskrun_name)
     run_id = response.run_result.run_id
 
-    return stream_logs(cmd, client, run_id, registry_name, resource_group_name)
+    return stream_logs(cmd, client, run_id, registry_name, resource_group_name, None, no_format, False)


### PR DESCRIPTION
**Description**<!--Mandatory-->
The following command missed `--no-format` option. Other commands like `acr run` and `acr build` have already supported this option. 

* acr task run
* acr task logs
* acr taskrun logs

**Testing Guide**
az acr task run --no-format

**History Notes**
[ACR] `acr task run`: Add --no-format option
[ACR] `acr task logs`: Add --no-format option
[ACR] `acr taskrun logs`: Add --no-format option

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
