### PR TITLE
{Compute} `az vmss create --orchestration-mode flexible`: fix converting `--edge-zone` to template json 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -1571,7 +1571,7 @@ def process_vmss_create_namespace(cmd, namespace):
         if namespace.tags is not None:
             validate_tags(namespace)
         _validate_location(cmd, namespace, namespace.zones, namespace.vm_sku)
-        # validate_edge_zone(cmd, namespace)
+        validate_edge_zone(cmd, namespace)
         if namespace.application_security_groups is not None:
             validate_asg_names_or_ids(cmd, namespace)
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
Fix: https://github.com/Azure/azure-cli/issues/21793

There are two problems with this issue:
1. `--edge-zone` parameter is not converted through `validate_edge_zone`, resulting in the following `InvalidTemplate` error reports:
```
{"error":{"code":"InvalidTemplate","message":"Deployment template parse failed: 'Error converting value "microsoftrrdclab1" to type 'Azure.Deployments.Core.Definitions.Resources.ResourceExtendedLocation'. Path ''.'."}}
```
This PR is used to fix this problem

2. After fixing the first problem, an error will still occur because creating Flex VMSS still does not support edge zone
```
{"code":"BadRequest","message":"{ "error": { "code": "InvalidParameter", "message": "Parameter 'extendedLocation' is not allowed.", "target": "extendedLocation" }}}
```
We have confirmed with the Flex VMSS team @fitzgeraldsteele to keep this behavior and error message first, and wait for the subsequent support from service in Cu semester [comment link](https://github.com/Azure/azure-cli/issues/21793#issuecomment-1092398305)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
