### PR TITLE
{Packaging} Release edge builds for Ubuntu Focal, Impish, Jammy, el8

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,16 @@ If you want to get the latest build from the `dev` branch, you can use our "edge
 
 You can download the latest builds by following the links below:
 
-| Package  | Link                                       |
-| :-------: | :----------------------------------------- |
-| MSI   | https://aka.ms/InstallAzureCliWindowsEdge  |
-| Homebrew Formula | https://aka.ms/InstallAzureCliHomebrewEdge |
-| Ubuntu Xenial Deb | https://aka.ms/InstallAzureCliXenialEdge |
-| Ubuntu Bionic Deb | https://aka.ms/InstallAzureCliBionicEdge |
-| RPM | https://aka.ms/InstallAzureCliRpmEdge |
+|      Package      | Link                                       |
+|:-----------------:|:-------------------------------------------|
+|        MSI        | https://aka.ms/InstallAzureCliWindowsEdge  |
+| Homebrew Formula  | https://aka.ms/InstallAzureCliHomebrewEdge |
+| Ubuntu Xenial Deb | https://aka.ms/InstallAzureCliXenialEdge   |
+| Ubuntu Bionic Deb | https://aka.ms/InstallAzureCliBionicEdge   |
+| Ubuntu Focal Deb  | https://aka.ms/InstallAzureCliFocalEdge    |
+| Ubuntu Impish Deb | https://aka.ms/InstallAzureCliImpishEdge   |
+| Ubuntu Jammy Deb  | https://aka.ms/InstallAzureCliJammyEdge    |
+|        RPM        | https://aka.ms/InstallAzureCliRpmEdge      |
 
 You can easily install the latest Homebrew edge build with the following command:
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You can download the latest builds by following the links below:
 | Ubuntu Focal Deb  | https://aka.ms/InstallAzureCliFocalEdge    |
 | Ubuntu Impish Deb | https://aka.ms/InstallAzureCliImpishEdge   |
 | Ubuntu Jammy Deb  | https://aka.ms/InstallAzureCliJammyEdge    |
-|        RPM        | https://aka.ms/InstallAzureCliRpmEdge      |
+|      RPM el7      | https://aka.ms/InstallAzureCliRpmEdge      |
 |      RPM el8      | https://aka.ms/InstallAzureCliRpmEl8Edge   |
 
 You can easily install the latest Homebrew edge build with the following command:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You can download the latest builds by following the links below:
 | Ubuntu Impish Deb | https://aka.ms/InstallAzureCliImpishEdge   |
 | Ubuntu Jammy Deb  | https://aka.ms/InstallAzureCliJammyEdge    |
 |        RPM        | https://aka.ms/InstallAzureCliRpmEdge      |
+|      RPM el8      | https://aka.ms/InstallAzureCliRpmEl8Edge   |
 
 You can easily install the latest Homebrew edge build with the following command:
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

Ubuntu edge builds hasn't been updated since https://github.com/Azure/azure-cli/pull/13597. Now we release edge builds for Ubuntu Focal, Impish, Jammy, el8.
