### PR TITLE
{Auth} Provide GitHub issue links for DPAPI errors

### DIFF
--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -61,6 +61,7 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
     from azure.core.exceptions import AzureError
     from requests.exceptions import SSLError, HTTPError
     from azure.cli.core import azclierror
+    from msal_extensions.persistence import PersistenceError
     import traceback
 
     logger.debug("azure.cli.core.util.handle_exception is called with an exception:")
@@ -135,6 +136,19 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
     elif isinstance(ex, KeyboardInterrupt):
         error_msg = 'Keyboard interrupt is captured.'
         az_error = azclierror.ManualInterrupt(error_msg)
+
+    elif isinstance(ex, PersistenceError):
+        # errno is already in strerror. str(ex) gives duplicated errno.
+        az_error = azclierror.CLIInternalError(ex.strerror)
+        if ex.errno == 0:
+            az_error.set_recommendation(
+                "Please report to us via Github: https://github.com/Azure/azure-cli/issues/20278")
+        elif ex.errno == -2146893813:
+            az_error.set_recommendation(
+                "Please report to us via Github: https://github.com/Azure/azure-cli/issues/20231")
+        elif ex.errno == -2146892987:
+            az_error.set_recommendation(
+                "Please report to us via Github: https://github.com/Azure/azure-cli/issues/21010")
 
     else:
         error_msg = "The command failed with an unexpected error. Here is the traceback:"

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -51,7 +51,7 @@ DEPENDENCIES = [
     'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.9.0',
-    'msal-extensions>=0.3.1,<0.4',
+    'msal-extensions~=1.0.0',
     'msal>=1.17.0,<2.0.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9,<22.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.1
+msal-extensions==1.0.0
 msal==1.17.0
 msrest==0.6.21
 msrestazure==0.6.4

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.1
+msal-extensions==1.0.0
 msal==1.17.0
 msrest==0.6.21
 msrestazure==0.6.4

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ jmespath==0.9.5
 jsondiff==1.3.0
 knack==0.9.0
 MarkupSafe==1.1.1
-msal-extensions==0.3.1
+msal-extensions==1.0.0
 msal==1.17.0
 msrest==0.6.21
 msrestazure==0.6.4


### PR DESCRIPTION
**Description**<!--Mandatory-->

We see users constantly creating duplicated issues of 

- https://github.com/Azure/azure-cli/issues/20278
- https://github.com/Azure/azure-cli/issues/20231
- https://github.com/Azure/azure-cli/issues/21010

But the root cause for these issues remains unknown.

`msal-extensions` has made these errors catch-able in https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/108, but since `azure-identity` has pinned dependency `msal-extensions~=0.3.0`, ~~it is not possible for Azure CLI to use the latest `msal-extensions` which contains that improvement (https://github.com/Azure/azure-sdk-for-python/issues/23927).~~ the dependency on `azure-identity` is removed by https://github.com/Azure/azure-cli/pull/22124.


**Testing Guide**

Raise an `OSError` at https://github.com/AzureAD/microsoft-authentication-extensions-for-python/blob/0.3.1/msal_extensions/windows.py#L99

```py
        err_code = -2146893813
        raise OSError(None, _err_description.get(err_code, ''), None, err_code)
```

This will produce an error message like

```
Decryption failed: [WinError -2146893813] Key not valid for use in specified state.. App developer may consider this guidance: https://github.com/AzureAD/microsoft-authentication-extensions-for-python/wiki/PersistenceDecryptionError
Please report to us via Github: https://github.com/Azure/azure-cli/issues/20231
```