### PR TITLE
[Compute] `az vm create`: Fix the bug when creating Flex VMSS without SKU and VM profile

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -362,7 +362,7 @@ def _get_storage_profile_description(profile):
 def _validate_location(cmd, namespace, zone_info, size_info):
     if not namespace.location:
         get_default_location_from_resource_group(cmd, namespace)
-        if zone_info:
+        if zone_info and size_info:
             sku_infos = list_sku_info(cmd.cli_ctx, namespace.location)
             temp = next((x for x in sku_infos if x.name.lower() == size_info.lower()), None)
             # For Stack (compute - 2017-03-30), Resource_sku doesn't implement location_info property
@@ -1546,6 +1546,9 @@ def process_vmss_create_namespace(cmd, namespace):
         for param, value in banned_params.items():
             if value is not None:
                 raise ArgumentUsageError(f'usage error: {param} is not supported for Flex mode')
+
+        if namespace.vm_sku and not namespace.image:
+            raise ArgumentUsageError('usage error: please specify the --image when you want to specify the VM SKU')
 
         if namespace.image:
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_quick_create_flexible_vmss.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_quick_create_flexible_vmss.yaml
@@ -11,14 +11,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001","name":"cli_test_quick_create_flexible_vmss_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-03-17T11:27:36Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001","name":"cli_test_quick_create_flexible_vmss_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-04-11T06:53:44Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:27:40 GMT
+      - Mon, 11 Apr 2022 06:53:49 GMT
       expires:
       - '-1'
       pragma:
@@ -110,13 +110,13 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:27:40 GMT
+      - Mon, 11 Apr 2022 06:53:50 GMT
       etag:
       - W/"d5acead0b38a79d988c245a7a15ec01f999da9244c97bbdc1fa2ec70d9e433f5"
       expires:
-      - Thu, 17 Mar 2022 11:32:40 GMT
+      - Mon, 11 Apr 2022 06:58:50 GMT
       source-age:
-      - '159'
+      - '0'
       strict-transport-security:
       - max-age=31536000
       vary:
@@ -124,21 +124,21 @@ interactions:
       via:
       - 1.1 varnish
       x-cache:
-      - HIT
+      - MISS
       x-cache-hits:
-      - '2'
+      - '0'
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - 1401cf615604810455700888908c0a0342bcc312
+      - 04000c3620af0ce07ae2811d23554723a6be8311
       x-frame-options:
       - deny
       x-github-request-id:
-      - 2570:063C:1995B2:2734C1:62329D55
+      - 7644:7D02:100D92:2256BB:6253D07D
       x-served-by:
-      - cache-qpg1263-QPG
+      - cache-hkg17931-HKG
       x-timer:
-      - S1647516461.706641,VS0,VE0
+      - S1649660030.896259,VS0,VE333
       x-xss-protection:
       - 1; mode=block
     status:
@@ -156,15 +156,15 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus2euap/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions?$top=1&$orderby=name%20desc&api-version=2021-11-01
   response:
     body:
-      string: "[\r\n  {\r\n    \"location\": \"EastUS2EUAP\",\r\n    \"name\": \"18.04.202203080\",\r\n
-        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/EastUS2EUAP/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202203080\"\r\n
+      string: "[\r\n  {\r\n    \"location\": \"EastUS2EUAP\",\r\n    \"name\": \"18.04.202204010\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/EastUS2EUAP/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202204010\"\r\n
         \ }\r\n]"
     headers:
       cache-control:
@@ -174,7 +174,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:27:42 GMT
+      - Mon, 11 Apr 2022 06:53:53 GMT
       expires:
       - '-1'
       pragma:
@@ -191,7 +191,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43999
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43997
     status:
       code: 200
       message: OK
@@ -207,11 +207,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus2euap/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202203080?api-version=2021-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastus2euap/publishers/Canonical/artifacttypes/vmimage/offers/UbuntuServer/skus/18.04-LTS/versions/18.04.202204010?api-version=2021-11-01
   response:
     body:
       string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
@@ -223,7 +223,7 @@ interactions:
         \"True\"\r\n      }\r\n    ],\r\n    \"osDiskImage\": {\r\n      \"operatingSystem\":
         \"Linux\",\r\n      \"sizeInGb\": 31,\r\n      \"sizeInBytes\": 32213303808\r\n
         \   },\r\n    \"dataDiskImages\": []\r\n  },\r\n  \"location\": \"EastUS2EUAP\",\r\n
-        \ \"name\": \"18.04.202203080\",\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/EastUS2EUAP/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202203080\"\r\n}"
+        \ \"name\": \"18.04.202204010\",\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/EastUS2EUAP/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/18.04-LTS/Versions/18.04.202204010\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -232,7 +232,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:27:45 GMT
+      - Mon, 11 Apr 2022 06:53:57 GMT
       expires:
       - '-1'
       pragma:
@@ -249,7 +249,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73999
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73998
     status:
       code: 200
       message: OK
@@ -265,9 +265,9 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-network/19.3.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-network/19.3.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
   response:
@@ -281,7 +281,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:27:46 GMT
+      - Mon, 11 Apr 2022 06:53:58 GMT
       expires:
       - '-1'
       pragma:
@@ -331,11 +331,11 @@ interactions:
       "caching": "ReadWrite", "managedDisk": {"storageAccountType": null}}, "imageReference":
       {"publisher": "Canonical", "offer": "UbuntuServer", "sku": "18.04-LTS", "version":
       "latest"}}, "osProfile": {"computerNamePrefix": "vmsslong", "adminUsername":
-      "ruijun_hu", "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh":
-      {"publicKeys": [{"path": "/home/ruijun_hu/.ssh/authorized_keys", "keyData":
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-      cxznmhdcxz\n"}]}}}, "networkProfile": {"networkInterfaceConfigurations": [{"name":
-      "vmssl6447Nic", "properties": {"ipConfigurations": [{"name": "vmssl6447IPConfig",
+      "vmtest", "linuxConfiguration": {"disablePasswordAuthentication": true, "ssh":
+      {"publicKeys": [{"path": "/home/vmtest/.ssh/authorized_keys", "keyData": "ssh-rsa
+      AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+      Zhou.Xing@microsoft.com\n"}]}}}, "networkProfile": {"networkInterfaceConfigurations":
+      [{"name": "vmssl0626Nic", "properties": {"ipConfigurations": [{"name": "vmssl0626IPConfig",
       "properties": {"subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET/subnets/vmsslongnametestSubnet"},
       "loadBalancerBackendAddressPools": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB/backendAddressPools/vmsslongnametestLBBEPool"}]}}],
       "networkSecurityGroup": {"id": "[resourceId(''Microsoft.Network/networkSecurityGroups'',
@@ -354,29 +354,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '5070'
+      - '5077'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_jVHhoiWLatDWMwb2Tdrh5LozgAcejzjw","name":"vmss_deploy_jVHhoiWLatDWMwb2Tdrh5LozgAcejzjw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"4415628636625510129","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-03-17T11:28:00.603108Z","duration":"PT0.0001292S","correlationId":"2886e095-aee6-4eed-8122-f2154647f847","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]},{"resourceType":"networkSecurityGroups","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmsslongnametestLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vmsslongnametestNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmsslongnametest"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_oIcQiO1HO6UtzLmXefWZm70UqwaNRDaA","name":"vmss_deploy_oIcQiO1HO6UtzLmXefWZm70UqwaNRDaA","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5251721707389203823","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-04-11T06:54:14.2741233Z","duration":"PT0.0004382S","correlationId":"c1a41ed8-19a3-4398-b136-a12c3edc8d54","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]},{"resourceType":"networkSecurityGroups","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmsslongnametestLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vmsslongnametestNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmsslongnametest"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_jVHhoiWLatDWMwb2Tdrh5LozgAcejzjw/operationStatuses/08585540904079901144?api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_oIcQiO1HO6UtzLmXefWZm70UqwaNRDaA/operationStatuses/08585519468343009359?api-version=2021-04-01
       cache-control:
       - no-cache
       content-length:
-      - '2964'
+      - '2965'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:28:02 GMT
+      - Mon, 11 Apr 2022 06:54:17 GMT
       expires:
       - '-1'
       pragma:
@@ -386,7 +386,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -402,11 +402,11 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540904079901144?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519468343009359?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -418,7 +418,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:28:34 GMT
+      - Mon, 11 Apr 2022 06:54:48 GMT
       expires:
       - '-1'
       pragma:
@@ -444,11 +444,53 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540904079901144?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519468343009359?api-version=2021-04-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 11 Apr 2022 06:55:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vmss create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --orchestration-mode --admin-username
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519468343009359?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -460,7 +502,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:29:05 GMT
+      - Mon, 11 Apr 2022 06:55:50 GMT
       expires:
       - '-1'
       pragma:
@@ -486,25 +528,25 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -n -g --image --orchestration-mode
+      - -n -g --image --orchestration-mode --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_jVHhoiWLatDWMwb2Tdrh5LozgAcejzjw","name":"vmss_deploy_jVHhoiWLatDWMwb2Tdrh5LozgAcejzjw","type":"Microsoft.Resources/deployments","properties":{"templateHash":"4415628636625510129","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-03-17T11:29:00.1745676Z","duration":"PT59.5715888S","correlationId":"2886e095-aee6-4eed-8122-f2154647f847","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]},{"resourceType":"networkSecurityGroups","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmsslongnametestLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vmsslongnametestNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmsslongnametest"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":false,"orchestrationMode":"Flexible","virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmsslong","adminUsername":"ruijun_hu","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/ruijun_hu/.ssh/authorized_keys","keyData":"ssh-rsa
-        AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-        cxznmhdcxz\n"}]},"provisionVMAgent":true,"patchSettings":{"patchMode":"ImageDefault","assessmentMode":"ImageDefault"}},"secrets":[],"allowExtensionOperations":true,"requireGuestProvisionSignal":true},"storageProfile":{"osDisk":{"osType":"Linux","createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Premium_LRS"},"diskSizeGB":30},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"18.04-LTS","version":"latest"}},"networkProfile":{"networkApiVersion":"2020-11-01","networkInterfaceConfigurations":[{"name":"vmssl6447Nic","properties":{"primary":true,"enableIPForwarding":false,"deleteOption":"Delete","ipConfigurations":[{"name":"vmssl6447IPConfig","properties":{"privateIPAddressVersion":"IPv4","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET/subnets/vmsslongnametestSubnet"},"applicationSecurityGroups":[],"loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB/backendAddressPools/vmsslongnametestLBBEPool"}],"applicationGatewayBackendAddressPools":[]}}],"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG"},"dnsSettings":{"dnsServers":[]}}}]}},"provisioningState":"Succeeded","uniqueId":"12f38082-9208-4067-896e-ea04a9b03211","platformFaultDomainCount":1,"timeCreated":"2022-03-17T11:28:33.9545901+00:00"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Resources/deployments/vmss_deploy_oIcQiO1HO6UtzLmXefWZm70UqwaNRDaA","name":"vmss_deploy_oIcQiO1HO6UtzLmXefWZm70UqwaNRDaA","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5251721707389203823","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-04-11T06:55:20.1183963Z","duration":"PT1M5.8447112S","correlationId":"c1a41ed8-19a3-4398-b136-a12c3edc8d54","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus2euap"]},{"resourceType":"publicIPAddresses","locations":["eastus2euap"]},{"resourceType":"loadBalancers","locations":["eastus2euap"]},{"resourceType":"networkSecurityGroups","locations":["eastus2euap"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["eastus2euap"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vmsslongnametestLBPublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vmsslongnametestVNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB","resourceType":"Microsoft.Network/loadBalancers","resourceName":"vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vmsslongnametestNSG"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest","resourceType":"Microsoft.Compute/virtualMachineScaleSets","resourceName":"vmsslongnametest"}],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":false,"orchestrationMode":"Flexible","virtualMachineProfile":{"osProfile":{"computerNamePrefix":"vmsslong","adminUsername":"vmtest","linuxConfiguration":{"disablePasswordAuthentication":true,"ssh":{"publicKeys":[{"path":"/home/vmtest/.ssh/authorized_keys","keyData":"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+        Zhou.Xing@microsoft.com\n"}]},"provisionVMAgent":true,"patchSettings":{"patchMode":"ImageDefault","assessmentMode":"ImageDefault"},"enableVMAgentPlatformUpdates":false},"secrets":[],"allowExtensionOperations":true,"requireGuestProvisionSignal":true},"storageProfile":{"osDisk":{"osType":"Linux","createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Premium_LRS"},"deleteOption":"Delete","diskSizeGB":30},"imageReference":{"publisher":"Canonical","offer":"UbuntuServer","sku":"18.04-LTS","version":"latest"}},"networkProfile":{"networkApiVersion":"2020-11-01","networkInterfaceConfigurations":[{"name":"vmssl0626Nic","properties":{"primary":true,"enableIPForwarding":false,"deleteOption":"Delete","ipConfigurations":[{"name":"vmssl0626IPConfig","properties":{"privateIPAddressVersion":"IPv4","subnet":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET/subnets/vmsslongnametestSubnet"},"applicationSecurityGroups":[],"loadBalancerBackendAddressPools":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB/backendAddressPools/vmsslongnametestLBBEPool"}],"applicationGatewayBackendAddressPools":[]}}],"networkSecurityGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG"},"dnsSettings":{"dnsServers":[]}}}]}},"provisioningState":"Succeeded","uniqueId":"550caa6d-e1b3-421a-ace4-bb4cc199f1d2","platformFaultDomainCount":1,"timeCreated":"2022-04-11T06:54:48.0831338+00:00"}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/publicIPAddresses/vmsslongnametestLBPublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '6537'
+      - '6606'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:29:05 GMT
+      - Mon, 11 Apr 2022 06:55:50 GMT
       expires:
       - '-1'
       pragma:
@@ -532,7 +574,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmsslongnametest?api-version=2021-11-01
   response:
@@ -543,35 +585,36 @@ interactions:
         \   \"tier\": \"Standard\",\r\n    \"capacity\": 2\r\n  },\r\n  \"properties\":
         {\r\n    \"singlePlacementGroup\": false,\r\n    \"orchestrationMode\": \"Flexible\",\r\n
         \   \"virtualMachineProfile\": {\r\n      \"osProfile\": {\r\n        \"computerNamePrefix\":
-        \"vmsslong\",\r\n        \"adminUsername\": \"ruijun_hu\",\r\n        \"linuxConfiguration\":
+        \"vmsslong\",\r\n        \"adminUsername\": \"vmtest\",\r\n        \"linuxConfiguration\":
         {\r\n          \"disablePasswordAuthentication\": true,\r\n          \"ssh\":
         {\r\n            \"publicKeys\": [\r\n              {\r\n                \"path\":
-        \"/home/ruijun_hu/.ssh/authorized_keys\",\r\n                \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-        cxznmhdcxz\\n\"\r\n              }\r\n            ]\r\n          },\r\n          \"provisionVMAgent\":
-        true,\r\n          \"patchSettings\": {\r\n            \"patchMode\": \"ImageDefault\",\r\n
-        \           \"assessmentMode\": \"ImageDefault\"\r\n          }\r\n        },\r\n
-        \       \"secrets\": [],\r\n        \"allowExtensionOperations\": true,\r\n
-        \       \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
+        \"/home/vmtest/.ssh/authorized_keys\",\r\n                \"keyData\": \"ssh-rsa
+        AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+        Zhou.Xing@microsoft.com\\n\"\r\n              }\r\n            ]\r\n          },\r\n
+        \         \"provisionVMAgent\": true,\r\n          \"patchSettings\": {\r\n
+        \           \"patchMode\": \"ImageDefault\",\r\n            \"assessmentMode\":
+        \"ImageDefault\"\r\n          },\r\n          \"enableVMAgentPlatformUpdates\":
+        false\r\n        },\r\n        \"secrets\": [],\r\n        \"allowExtensionOperations\":
+        true,\r\n        \"requireGuestProvisionSignal\": true\r\n      },\r\n      \"storageProfile\":
         {\r\n        \"osDisk\": {\r\n          \"osType\": \"Linux\",\r\n          \"createOption\":
         \"FromImage\",\r\n          \"caching\": \"ReadWrite\",\r\n          \"managedDisk\":
         {\r\n            \"storageAccountType\": \"Premium_LRS\"\r\n          },\r\n
         \         \"diskSizeGB\": 30\r\n        },\r\n        \"imageReference\":
         {\r\n          \"publisher\": \"Canonical\",\r\n          \"offer\": \"UbuntuServer\",\r\n
         \         \"sku\": \"18.04-LTS\",\r\n          \"version\": \"latest\"\r\n
-        \       }\r\n      },\r\n      \"networkProfile\": {\"networkApiVersion\":\"2020-11-01\",\"networkInterfaceConfigurations\":[{\"name\":\"vmssl6447Nic\",\"properties\":{\"primary\":true,\"enableIPForwarding\":false,\"deleteOption\":\"Delete\",\"ipConfigurations\":[{\"name\":\"vmssl6447IPConfig\",\"properties\":{\"privateIPAddressVersion\":\"IPv4\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET/subnets/vmsslongnametestSubnet\"},\"applicationSecurityGroups\":[],\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB/backendAddressPools/vmsslongnametestLBBEPool\"}],\"applicationGatewayBackendAddressPools\":[]}}],\"networkSecurityGroup\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG\"},\"dnsSettings\":{\"dnsServers\":[]}}}]}\r\n
-        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"uniqueId\": \"12f38082-9208-4067-896e-ea04a9b03211\",\r\n
-        \   \"platformFaultDomainCount\": 1,\r\n    \"timeCreated\": \"2022-03-17T11:28:33.9545901+00:00\"\r\n
+        \       }\r\n      },\r\n      \"networkProfile\": {\"networkApiVersion\":\"2020-11-01\",\"networkInterfaceConfigurations\":[{\"name\":\"vmssl0626Nic\",\"properties\":{\"primary\":true,\"enableIPForwarding\":false,\"deleteOption\":\"Delete\",\"ipConfigurations\":[{\"name\":\"vmssl0626IPConfig\",\"properties\":{\"privateIPAddressVersion\":\"IPv4\",\"subnet\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/virtualNetworks/vmsslongnametestVNET/subnets/vmsslongnametestSubnet\"},\"applicationSecurityGroups\":[],\"loadBalancerBackendAddressPools\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/loadBalancers/vmsslongnametestLB/backendAddressPools/vmsslongnametestLBBEPool\"}],\"applicationGatewayBackendAddressPools\":[]}}],\"networkSecurityGroup\":{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_quick_create_flexible_vmss_000001/providers/Microsoft.Network/networkSecurityGroups/vmsslongnametestNSG\"},\"dnsSettings\":{\"dnsServers\":[]}}}]}\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"uniqueId\": \"550caa6d-e1b3-421a-ace4-bb4cc199f1d2\",\r\n
+        \   \"platformFaultDomainCount\": 1,\r\n    \"timeCreated\": \"2022-04-11T06:54:48.0831338+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3579'
+      - '3636'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:29:06 GMT
+      - Mon, 11 Apr 2022 06:55:52 GMT
       expires:
       - '-1'
       pragma:
@@ -588,7 +631,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;390,Microsoft.Compute/GetVMScaleSet30Min;2528
+      - Microsoft.Compute/GetVMScaleSet3Min;390,Microsoft.Compute/GetVMScaleSet30Min;2524
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_simple_orchestration_mode.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_vmss_simple_orchestration_mode.yaml
@@ -13,12 +13,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-03-17T11:29:58Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-04-11T08:11:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:01 GMT
+      - Mon, 11 Apr 2022 08:11:17 GMT
       expires:
       - '-1'
       pragma:
@@ -59,7 +59,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/proximityPlacementGroups/ppg1?api-version=2021-11-01
   response:
@@ -76,7 +76,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:07 GMT
+      - Mon, 11 Apr 2022 08:11:24 GMT
       expires:
       - '-1'
       pragma:
@@ -89,9 +89,9 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PutDeletePPG3Min;99,Microsoft.Compute/PutDeletePPG30Min;495
+      - Microsoft.Compute/PutDeletePPG3Min;97,Microsoft.Compute/PutDeletePPG30Min;494
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -109,12 +109,12 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-03-17T11:29:58Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-04-11T08:11:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -123,7 +123,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:07 GMT
+      - Mon, 11 Apr 2022 08:11:25 GMT
       expires:
       - '-1'
       pragma:
@@ -151,7 +151,7 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute?api-version=2021-04-01
   response:
@@ -164,7 +164,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -173,7 +173,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -203,7 +203,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -212,7 +212,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -242,7 +242,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2015-06-15","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2015-06-15","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -250,7 +250,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/extensions","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -258,7 +258,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -266,7 +266,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -274,7 +274,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -282,7 +282,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"locations/operations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -290,7 +290,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/vmSizes","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -298,7 +298,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/runCommands","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -306,7 +306,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -314,7 +314,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachines","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -322,7 +322,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachineScaleSets","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -330,7 +330,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/publishers","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -338,7 +338,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -346,7 +346,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"virtualMachines/runCommands","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"virtualMachines/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -354,8 +354,8 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/edgeZones","locations":[],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"locations/edgeZones/publishers","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/edgeZones","locations":[],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"locations/edgeZones/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -363,7 +363,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"restorePointCollections","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -371,7 +371,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
         SupportsLocation"},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
@@ -380,7 +380,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"capabilities":"None"},{"resourceType":"proximityPlacementGroups","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"capabilities":"None"},{"resourceType":"proximityPlacementGroups","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -388,21 +388,22 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
-        East","zones":[]},{"location":"Brazil South","zones":[]},{"location":"Canada
-        Central","zones":[]},{"location":"Central India","zones":[]},{"location":"Central
-        US","zones":[]},{"location":"Central US EUAP","zones":[]},{"location":"East
-        Asia","zones":[]},{"location":"East US","zones":[]},{"location":"East US 2","zones":[]},{"location":"East
-        US 2 EUAP","zones":[]},{"location":"France Central","zones":[]},{"location":"Germany
-        West Central","zones":[]},{"location":"Japan East","zones":[]},{"location":"Korea
-        Central","zones":[]},{"location":"North Central US","zones":[]},{"location":"North
-        Europe","zones":[]},{"location":"Norway East","zones":[]},{"location":"South
-        Africa North","zones":[]},{"location":"South Central US","zones":[]},{"location":"Southeast
-        Asia","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
-        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":[]},{"location":"West
-        Europe","zones":[]},{"location":"West US 2","zones":[]},{"location":"West
-        US 3","zones":[]}],"capabilities":"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove,
-        SupportsTags, SupportsLocation"},{"resourceType":"sshPublicKeys","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
+        Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
+        US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":[]},{"location":"East
+        Asia","zones":["2","3","1"]},{"location":"East US","zones":["2","3","1"]},{"location":"East
+        US 2","zones":["2","3","1"]},{"location":"East US 2 EUAP","zones":[]},{"location":"France
+        Central","zones":["2","3","1"]},{"location":"Germany West Central","zones":["2","3","1"]},{"location":"Japan
+        East","zones":["2","3","1"]},{"location":"Korea Central","zones":["2","3","1"]},{"location":"North
+        Central US","zones":[]},{"location":"North Europe","zones":["2","3","1"]},{"location":"Norway
+        East","zones":["2","3","1"]},{"location":"South Africa North","zones":["2","3","1"]},{"location":"South
+        Central US","zones":["2","3","1"]},{"location":"Southeast Asia","zones":["2","3","1"]},{"location":"Sweden
+        Central","zones":["2","3","1"]},{"location":"Switzerland North","zones":[]},{"location":"UAE
+        North","zones":[]},{"location":"UK South","zones":["2","3","1"]},{"location":"West
+        Europe","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"West
+        US 3","zones":["2","3","1"]}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"sshPublicKeys","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -410,7 +411,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
         SupportsLocation"},{"resourceType":"capacityReservationGroups","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -419,7 +420,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -441,7 +442,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -471,7 +472,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/spotPriceHistory","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/spotPriceHistory","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -479,7 +480,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/recommendations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/recommendations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -487,7 +488,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/sharedGalleries","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/sharedGalleries","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -495,7 +496,15 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMImages","locations":["West
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/communityGalleries","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Australia Central","Brazil South","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South","France Central","South
+        Africa North","UAE North","Switzerland North","Germany West Central","Norway
+        East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMImages","locations":["West
         Central US","South Central US","East US 2","Southeast Asia","West Europe","West
         US","East US","Canada Central","North Europe","North Central US","Brazil South","UK
         West","West India","East Asia","Australia East","Japan East","Korea South","West
@@ -584,7 +593,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -613,7 +622,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -629,7 +638,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"capabilities":"None"},{"resourceType":"diskEncryptionSets","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"capabilities":"None"},{"resourceType":"diskEncryptionSets","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -637,7 +646,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01"],"defaultApiVersion":"2021-08-01","capabilities":"SystemAssignedResourceIdentity,
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01"],"defaultApiVersion":"2021-08-01","capabilities":"SystemAssignedResourceIdentity,
         SupportsTags, SupportsLocation"},{"resourceType":"diskAccesses","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
@@ -646,7 +655,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01"],"defaultApiVersion":"2021-08-01","locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01"],"defaultApiVersion":"2021-08-01","locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -662,7 +671,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30"],"defaultApiVersion":"2021-08-01","capabilities":"None"},{"resourceType":"cloudServices","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30"],"defaultApiVersion":"2021-08-01","capabilities":"None"},{"resourceType":"cloudServices","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -756,7 +765,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -764,7 +773,23 @@ interactions:
         US","type":"EdgeZone","extendedLocations":["microsoftnewyork1","vzwindsor1","ezecustomerlabboston1"]},{"location":"Australia
         Southeast","type":"EdgeZone","extendedLocations":["microsoftperth1"]},{"location":"South
         Central US","type":"EdgeZone","extendedLocations":["attdallas1","ezecustomerlabhouston1"]}],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/logAnalytics","locations":["East
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/diagnostics","locations":["West
+        Central US","Southeast Asia","East US 2","East US","South Central US","West
+        Europe","North Europe","West US 2","UK South","Australia East","South India","Central
+        India","West India","Korea Central","Korea South","Jio India West","Japan
+        West","Japan East","East Asia","Canada Central","Canada East","South Africa
+        North","Central US","West US 3","West US","UK West","France Central","UAE
+        North","Australia Central","Australia Southeast","Switzerland North","Germany
+        West Central","Norway East","North Central US","Brazil South","Sweden Central","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2021-06-01-preview"],"defaultApiVersion":"2021-06-01-preview","capabilities":"None"},{"resourceType":"locations/diagnosticOperations","locations":["West
+        Central US","Southeast Asia","East US 2","East US","South Central US","West
+        Europe","North Europe","West US 2","UK South","Australia East","South India","Central
+        India","West India","Korea Central","Korea South","Jio India West","Japan
+        West","Japan East","East Asia","Canada Central","Canada East","South Africa
+        North","Central US","West US 3","West US","UK West","France Central","UAE
+        North","Australia Central","Australia Southeast","Switzerland North","Germany
+        West Central","Norway East","North Central US","Brazil South","Sweden Central","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2021-06-01-preview"],"defaultApiVersion":"2021-06-01-preview","capabilities":"None"},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -772,7 +797,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01"],"capabilities":"None"},{"resourceType":"hostGroups","locations":["Central
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01"],"capabilities":"None"},{"resourceType":"hostGroups","locations":["Central
         US","East US 2","West Europe","Southeast Asia","France Central","North Europe","West
         US 2","East US","UK South","Japan East","Japan West","East Asia","North Central
         US","South Central US","Canada East","Korea Central","Brazil South","UK West","Canada
@@ -780,7 +805,7 @@ interactions:
         Southeast","Korea South","West India","South Africa North","UAE North","Australia
         Central","Switzerland North","Germany West Central","Norway East","Australia
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -802,7 +827,7 @@ interactions:
         Southeast","Korea South","West India","South Africa North","UAE North","Australia
         Central","Switzerland North","Germany West Central","Norway East","Australia
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -816,15 +841,7 @@ interactions:
         Central","zones":["2","3","1"]},{"location":"Switzerland North","zones":[]},{"location":"UAE
         North","zones":[]},{"location":"UK South","zones":["2","3","1"]},{"location":"West
         Europe","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"West
-        US 3","zones":["2","3","1"]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"locations/communityGalleries","locations":["East
-        US","East US 2","West US","Central US","North Central US","South Central US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast","Australia Central","Brazil South","South India","Central
-        India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South","France Central","South
-        Africa North","UAE North","Switzerland North","Germany West Central","Norway
-        East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMExtensions","locations":["East
+        US 3","zones":["2","3","1"]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"sharedVMExtensions","locations":["East
         US 2 EUAP","Central US EUAP","Southeast Asia","East US 2","Central US","West
         Europe","East US","North Central US","South Central US","West US","North Europe","East
         Asia","Brazil South","West US 2","West Central US","UK West","UK South","Japan
@@ -847,11 +864,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '78225'
+      - '80513'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:08 GMT
+      - Mon, 11 Apr 2022 08:11:26 GMT
       expires:
       - '-1'
       pragma:
@@ -879,9 +896,9 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/proximityPlacementGroups/ppg1?api-version=2021-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/proximityPlacementGroups/ppg1?api-version=2022-03-01
   response:
     body:
       string: "{\r\n  \"name\": \"ppg1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/proximityPlacementGroups/ppg1\",\r\n
@@ -897,7 +914,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:09 GMT
+      - Mon, 11 Apr 2022 08:11:27 GMT
       expires:
       - '-1'
       pragma:
@@ -914,7 +931,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/HighCostGet3Min;133,Microsoft.Compute/HighCostGet30Min;634
+      - Microsoft.Compute/HighCostGet3Min;136,Microsoft.Compute/HighCostGet30Min;669
     status:
       code: 200
       message: OK
@@ -945,23 +962,23 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_8hLx0g2yDXJ5Q83YU20YkVUwcUd57Mg0","name":"vmss_deploy_8hLx0g2yDXJ5Q83YU20YkVUwcUd57Mg0","type":"Microsoft.Resources/deployments","properties":{"templateHash":"2634523410121960570","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-03-17T11:30:23.4717595Z","duration":"PT0.0005359S","correlationId":"f20ecf52-50ee-4442-9686-e5434f0ae88a","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_Sdw7yU1PpuisY3FcKYBKGtyFCc1mKdYt","name":"vmss_deploy_Sdw7yU1PpuisY3FcKYBKGtyFCc1mKdYt","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10956481804503365912","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-04-11T08:11:42.5494213Z","duration":"PT0.0003653S","correlationId":"ac2fd12b-7e2d-4c22-925b-68ca74f953dc","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_8hLx0g2yDXJ5Q83YU20YkVUwcUd57Mg0/operationStatuses/08585540902642969263?api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_Sdw7yU1PpuisY3FcKYBKGtyFCc1mKdYt/operationStatuses/08585519421852094234?api-version=2021-04-01
       cache-control:
       - no-cache
       content-length:
-      - '691'
+      - '692'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:25 GMT
+      - Mon, 11 Apr 2022 08:11:44 GMT
       expires:
       - '-1'
       pragma:
@@ -971,7 +988,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1198'
     status:
       code: 201
       message: Created
@@ -989,9 +1006,9 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540902642969263?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519421852094234?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1003,7 +1020,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:56 GMT
+      - Mon, 11 Apr 2022 08:12:16 GMT
       expires:
       - '-1'
       pragma:
@@ -1031,21 +1048,21 @@ interactions:
       ParameterSetName:
       - -g -n --orchestration-mode --single-placement-group --ppg --platform-fault-domain-count
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_8hLx0g2yDXJ5Q83YU20YkVUwcUd57Mg0","name":"vmss_deploy_8hLx0g2yDXJ5Q83YU20YkVUwcUd57Mg0","type":"Microsoft.Resources/deployments","properties":{"templateHash":"2634523410121960570","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-03-17T11:30:31.4913443Z","duration":"PT8.0201207S","correlationId":"f20ecf52-50ee-4442-9686-e5434f0ae88a","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":false,"orchestrationMode":"Flexible","proximityPlacementGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ORCHESTRATION_MODE_7YAJNOHJICSKLTGR2MWQHMZOEYQKHD27N2YBNPET77/providers/Microsoft.Compute/proximityPlacementGroups/ppg1"},"provisioningState":"Succeeded","uniqueId":"65786e7f-57ce-432a-9c51-ce713202da08","platformFaultDomainCount":3}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vmss_deploy_Sdw7yU1PpuisY3FcKYBKGtyFCc1mKdYt","name":"vmss_deploy_Sdw7yU1PpuisY3FcKYBKGtyFCc1mKdYt","type":"Microsoft.Resources/deployments","properties":{"templateHash":"10956481804503365912","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-04-11T08:11:51.3272157Z","duration":"PT8.7781597S","correlationId":"ac2fd12b-7e2d-4c22-925b-68ca74f953dc","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachineScaleSets","locations":["westus"]}]}],"dependencies":[],"outputs":{"vmss":{"type":"Object","value":{"singlePlacementGroup":false,"orchestrationMode":"Flexible","proximityPlacementGroup":{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ORCHESTRATION_MODE_COCEQZOQDZSZYHDNHZDOM5XTS3RWRE56UVZROQ3DIS/providers/Microsoft.Compute/proximityPlacementGroups/ppg1"},"provisioningState":"Succeeded","uniqueId":"f3e65c6b-8754-4e5a-99e9-17f81461cfb5","platformFaultDomainCount":3}}},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1340'
+      - '1341'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:57 GMT
+      - Mon, 11 Apr 2022 08:12:16 GMT
       expires:
       - '-1'
       pragma:
@@ -1072,13 +1089,14 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-03-17T11:29:58Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001","name":"cli_test_vmss_orchestration_mode_000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-04-11T08:11:10Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -1087,7 +1105,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:58 GMT
+      - Mon, 11 Apr 2022 08:12:17 GMT
       expires:
       - '-1'
       pragma:
@@ -1170,11 +1188,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:59 GMT
+      - Mon, 11 Apr 2022 08:12:18 GMT
       etag:
       - W/"d5acead0b38a79d988c245a7a15ec01f999da9244c97bbdc1fa2ec70d9e433f5"
       expires:
-      - Thu, 17 Mar 2022 11:35:59 GMT
+      - Mon, 11 Apr 2022 08:17:18 GMT
       source-age:
       - '0'
       strict-transport-security:
@@ -1184,21 +1202,21 @@ interactions:
       via:
       - 1.1 varnish
       x-cache:
-      - HIT
+      - MISS
       x-cache-hits:
-      - '1'
+      - '0'
       x-content-type-options:
       - nosniff
       x-fastly-request-id:
-      - ef1c63a16a4372d5ae2fe2e8ff1752b3edbd2f90
+      - 0f7bf2f14525f7c254cb97aed813e3616b257a18
       x-frame-options:
       - deny
       x-github-request-id:
-      - 2570:063C:1995B2:2734C1:62329D55
+      - 24BA:5BFC:92284:14819D:6253E2E2
       x-served-by:
-      - cache-qpg1246-QPG
+      - cache-hkg17931-HKG
       x-timer:
-      - S1647516659.059235,VS0,VE286
+      - S1649664738.250067,VS0,VE373
       x-xss-protection:
       - 1; mode=block
     status:
@@ -1217,8 +1235,9 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/publishers/OpenLogic/artifacttypes/vmimage/offers/CentOS/skus/7.5/versions?$top=1&$orderby=name%20desc&api-version=2021-11-01
   response:
@@ -1234,7 +1253,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:30:59 GMT
+      - Mon, 11 Apr 2022 08:12:19 GMT
       expires:
       - '-1'
       pragma:
@@ -1251,7 +1270,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43996
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43999
     status:
       code: 200
       message: OK
@@ -1268,8 +1287,9 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/westus/publishers/OpenLogic/artifacttypes/vmimage/offers/CentOS/skus/7.5/versions/7.5.201808150?api-version=2021-11-01
   response:
@@ -1290,7 +1310,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:01 GMT
+      - Mon, 11 Apr 2022 08:12:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1307,7 +1327,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73997
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73999
     status:
       code: 200
       message: OK
@@ -1324,8 +1344,9 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute?api-version=2021-04-01
   response:
@@ -1338,7 +1359,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -1347,7 +1368,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1377,7 +1398,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"CrossResourceGroupResourceMove,
         CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -1386,7 +1407,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1416,7 +1437,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2015-06-15","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2015-06-15","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1424,7 +1445,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/extensions","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1432,7 +1453,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1440,7 +1461,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1448,7 +1469,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1456,7 +1477,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"locations/operations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations","locations":[],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1464,7 +1485,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/vmSizes","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1472,7 +1493,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/runCommands","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1480,7 +1501,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1488,7 +1509,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachines","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1496,7 +1517,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachineScaleSets","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1504,7 +1525,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/publishers","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1512,7 +1533,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1520,7 +1541,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"virtualMachines/runCommands","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"],"capabilities":"None"},{"resourceType":"virtualMachines/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1528,8 +1549,8 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/edgeZones","locations":[],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"locations/edgeZones/publishers","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/edgeZones","locations":[],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"locations/edgeZones/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1537,7 +1558,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"restorePointCollections","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01"],"capabilities":"None"},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -1545,7 +1566,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
         SupportsLocation"},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
@@ -1554,7 +1575,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"capabilities":"None"},{"resourceType":"proximityPlacementGroups","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30"],"capabilities":"None"},{"resourceType":"proximityPlacementGroups","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1562,21 +1583,22 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
-        East","zones":[]},{"location":"Brazil South","zones":[]},{"location":"Canada
-        Central","zones":[]},{"location":"Central India","zones":[]},{"location":"Central
-        US","zones":[]},{"location":"Central US EUAP","zones":[]},{"location":"East
-        Asia","zones":[]},{"location":"East US","zones":[]},{"location":"East US 2","zones":[]},{"location":"East
-        US 2 EUAP","zones":[]},{"location":"France Central","zones":[]},{"location":"Germany
-        West Central","zones":[]},{"location":"Japan East","zones":[]},{"location":"Korea
-        Central","zones":[]},{"location":"North Central US","zones":[]},{"location":"North
-        Europe","zones":[]},{"location":"Norway East","zones":[]},{"location":"South
-        Africa North","zones":[]},{"location":"South Central US","zones":[]},{"location":"Southeast
-        Asia","zones":[]},{"location":"Sweden Central","zones":[]},{"location":"Switzerland
-        North","zones":[]},{"location":"UAE North","zones":[]},{"location":"UK South","zones":[]},{"location":"West
-        Europe","zones":[]},{"location":"West US 2","zones":[]},{"location":"West
-        US 3","zones":[]}],"capabilities":"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove,
-        SupportsTags, SupportsLocation"},{"resourceType":"sshPublicKeys","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
+        Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
+        US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":[]},{"location":"East
+        Asia","zones":["2","3","1"]},{"location":"East US","zones":["2","3","1"]},{"location":"East
+        US 2","zones":["2","3","1"]},{"location":"East US 2 EUAP","zones":[]},{"location":"France
+        Central","zones":["2","3","1"]},{"location":"Germany West Central","zones":["2","3","1"]},{"location":"Japan
+        East","zones":["2","3","1"]},{"location":"Korea Central","zones":["2","3","1"]},{"location":"North
+        Central US","zones":[]},{"location":"North Europe","zones":["2","3","1"]},{"location":"Norway
+        East","zones":["2","3","1"]},{"location":"South Africa North","zones":["2","3","1"]},{"location":"South
+        Central US","zones":["2","3","1"]},{"location":"Southeast Asia","zones":["2","3","1"]},{"location":"Sweden
+        Central","zones":["2","3","1"]},{"location":"Switzerland North","zones":[]},{"location":"UAE
+        North","zones":[]},{"location":"UK South","zones":["2","3","1"]},{"location":"West
+        Europe","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"West
+        US 3","zones":["2","3","1"]}],"capabilities":"CrossResourceGroupResourceMove,
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"sshPublicKeys","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1584,7 +1606,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01"],"defaultApiVersion":"2021-07-01","capabilities":"SupportsTags,
         SupportsLocation"},{"resourceType":"capacityReservationGroups","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
@@ -1593,7 +1615,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1615,7 +1637,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1645,7 +1667,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/spotPriceHistory","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/spotPriceHistory","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1653,7 +1675,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/recommendations","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/recommendations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1661,7 +1683,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/sharedGalleries","locations":["East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01"],"defaultApiVersion":"2021-07-01","capabilities":"None"},{"resourceType":"locations/sharedGalleries","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1669,7 +1691,15 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMImages","locations":["West
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"locations/communityGalleries","locations":["East
+        US","East US 2","West US","Central US","North Central US","South Central US","North
+        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
+        East","Australia Southeast","Australia Central","Brazil South","South India","Central
+        India","West India","Canada Central","Canada East","West US 2","West Central
+        US","UK South","UK West","Korea Central","Korea South","France Central","South
+        Africa North","UAE North","Switzerland North","Germany West Central","Norway
+        East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
+        US EUAP"],"apiVersions":["2022-03-01","2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMImages","locations":["West
         Central US","South Central US","East US 2","Southeast Asia","West Europe","West
         US","East US","Canada Central","North Europe","North Central US","Brazil South","UK
         West","West India","East Asia","Australia East","Japan East","Korea South","West
@@ -1758,7 +1788,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1787,7 +1817,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"defaultApiVersion":"2021-08-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -1803,7 +1833,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"capabilities":"None"},{"resourceType":"diskEncryptionSets","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01","2019-03-01","2018-09-30","2018-06-01","2018-04-01","2017-03-30","2016-04-30-preview"],"apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"capabilities":"None"},{"resourceType":"diskEncryptionSets","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -1811,7 +1841,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01"],"defaultApiVersion":"2021-08-01","capabilities":"SystemAssignedResourceIdentity,
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01","2019-11-01","2019-07-01"],"defaultApiVersion":"2021-08-01","capabilities":"SystemAssignedResourceIdentity,
         SupportsTags, SupportsLocation"},{"resourceType":"diskAccesses","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
@@ -1820,7 +1850,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01"],"defaultApiVersion":"2021-08-01","locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30","2020-06-30","2020-05-01"],"defaultApiVersion":"2021-08-01","locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -1836,7 +1866,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30"],"defaultApiVersion":"2021-08-01","capabilities":"None"},{"resourceType":"cloudServices","locations":["Southeast
+        US EUAP"],"apiVersions":["2022-03-02","2021-12-01","2021-08-01","2021-04-01","2020-12-01","2020-09-30"],"defaultApiVersion":"2021-08-01","capabilities":"None"},{"resourceType":"cloudServices","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
@@ -1930,7 +1960,7 @@ interactions:
         Central","Korea South","West India","France Central","South Africa North","UAE
         North","Australia Central","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"],"defaultApiVersion":"2021-07-01","apiProfiles":[{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2018-04-01"}],"locationMappings":[{"location":"East
         US 2 EUAP","type":"EdgeZone","extendedLocations":["eastus2euapmockedge","onefleetedge1mockedge","microsoftrrdclab1","microsoftrrdclab2","microsoftrrdclab3","microsoftrrdclab4","microsoftrrdclab5","microsoftrrdclab6","microsoftrrdclab7","microsoftrrdclab8","microsoftrrdclab9","microsoftdclabs1","microsoftb25lab1","ezerr10"]},{"location":"West
         US","type":"EdgeZone","extendedLocations":["microsoftlosangeles1","microsoftlasvegas1"]},{"location":"Canada
         Central","type":"EdgeZone","extendedLocations":["microsoftvancouver1"]},{"location":"East
@@ -1938,7 +1968,23 @@ interactions:
         US","type":"EdgeZone","extendedLocations":["microsoftnewyork1","vzwindsor1","ezecustomerlabboston1"]},{"location":"Australia
         Southeast","type":"EdgeZone","extendedLocations":["microsoftperth1"]},{"location":"South
         Central US","type":"EdgeZone","extendedLocations":["attdallas1","ezecustomerlabhouston1"]}],"capabilities":"CrossResourceGroupResourceMove,
-        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/logAnalytics","locations":["East
+        CrossSubscriptionResourceMove, SupportsTags, SupportsLocation"},{"resourceType":"locations/diagnostics","locations":["West
+        Central US","Southeast Asia","East US 2","East US","South Central US","West
+        Europe","North Europe","West US 2","UK South","Australia East","South India","Central
+        India","West India","Korea Central","Korea South","Jio India West","Japan
+        West","Japan East","East Asia","Canada Central","Canada East","South Africa
+        North","Central US","West US 3","West US","UK West","France Central","UAE
+        North","Australia Central","Australia Southeast","Switzerland North","Germany
+        West Central","Norway East","North Central US","Brazil South","Sweden Central","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2021-06-01-preview"],"defaultApiVersion":"2021-06-01-preview","capabilities":"None"},{"resourceType":"locations/diagnosticOperations","locations":["West
+        Central US","Southeast Asia","East US 2","East US","South Central US","West
+        Europe","North Europe","West US 2","UK South","Australia East","South India","Central
+        India","West India","Korea Central","Korea South","Jio India West","Japan
+        West","Japan East","East Asia","Canada Central","Canada East","South Africa
+        North","Central US","West US 3","West US","UK West","France Central","UAE
+        North","Australia Central","Australia Southeast","Switzerland North","Germany
+        West Central","Norway East","North Central US","Brazil South","Sweden Central","East
+        US 2 EUAP","Central US EUAP"],"apiVersions":["2021-06-01-preview"],"defaultApiVersion":"2021-06-01-preview","capabilities":"None"},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Australia Central","Brazil South","South India","Central
@@ -1946,7 +1992,7 @@ interactions:
         US","UK South","UK West","Korea Central","Korea South","France Central","South
         Africa North","UAE North","Switzerland North","Germany West Central","Norway
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01"],"capabilities":"None"},{"resourceType":"hostGroups","locations":["Central
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01"],"capabilities":"None"},{"resourceType":"hostGroups","locations":["Central
         US","East US 2","West Europe","Southeast Asia","France Central","North Europe","West
         US 2","East US","UK South","Japan East","Japan West","East Asia","North Central
         US","South Central US","Canada East","Korea Central","Brazil South","UK West","Canada
@@ -1954,7 +2000,7 @@ interactions:
         Southeast","Korea South","West India","South Africa North","UAE North","Australia
         Central","Switzerland North","Germany West Central","Norway East","Australia
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1976,7 +2022,7 @@ interactions:
         Southeast","Korea South","West India","South Africa North","UAE North","Australia
         Central","Switzerland North","Germany West Central","Norway East","Australia
         East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
+        US EUAP"],"apiVersions":["2022-03-01","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01"],"defaultApiVersion":"2021-07-01","zoneMappings":[{"location":"Australia
         East","zones":["2","3","1"]},{"location":"Brazil South","zones":["2","3","1"]},{"location":"Canada
         Central","zones":["2","3","1"]},{"location":"Central India","zones":["2","3","1"]},{"location":"Central
         US","zones":["2","3","1"]},{"location":"Central US EUAP","zones":["1","2"]},{"location":"East
@@ -1990,15 +2036,7 @@ interactions:
         Central","zones":["2","3","1"]},{"location":"Switzerland North","zones":[]},{"location":"UAE
         North","zones":[]},{"location":"UK South","zones":["2","3","1"]},{"location":"West
         Europe","zones":["2","3","1"]},{"location":"West US 2","zones":["2","3","1"]},{"location":"West
-        US 3","zones":["2","3","1"]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"locations/communityGalleries","locations":["East
-        US","East US 2","West US","Central US","North Central US","South Central US","North
-        Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
-        East","Australia Southeast","Australia Central","Brazil South","South India","Central
-        India","West India","Canada Central","Canada East","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South","France Central","South
-        Africa North","UAE North","Switzerland North","Germany West Central","Norway
-        East","Jio India West","West US 3","Sweden Central","East US 2 EUAP","Central
-        US EUAP"],"apiVersions":["2022-01-03","2021-11-01","2021-07-01","2021-04-01","2021-03-01","2020-12-01","2020-09-30","2020-06-01","2019-12-01","2019-07-01","2019-03-01","2018-10-01","2018-06-01","2018-04-01","2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"],"apiProfiles":[{"profileVersion":"2017-03-09-profile","apiVersion":"2016-03-30"},{"profileVersion":"2018-03-01-hybrid","apiVersion":"2017-03-30"},{"profileVersion":"2018-06-01-profile","apiVersion":"2017-12-01"}],"capabilities":"None"},{"resourceType":"sharedVMExtensions","locations":["East
+        US 3","zones":["2","3","1"]}],"capabilities":"SupportsTags, SupportsLocation"},{"resourceType":"sharedVMExtensions","locations":["East
         US 2 EUAP","Central US EUAP","Southeast Asia","East US 2","Central US","West
         Europe","East US","North Central US","South Central US","West US","North Europe","East
         Asia","Brazil South","West US 2","West Central US","UK West","UK South","Japan
@@ -2021,11 +2059,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '78225'
+      - '80513'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:01 GMT
+      - Mon, 11 Apr 2022 08:12:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2052,18 +2090,19 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2021-11-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1?api-version=2022-03-01
   response:
     body:
       string: "{\r\n  \"name\": \"vmss1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachineScaleSets\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"singlePlacementGroup\":
         false,\r\n    \"orchestrationMode\": \"Flexible\",\r\n    \"proximityPlacementGroup\":
-        {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ORCHESTRATION_MODE_7YAJNOHJICSKLTGR2MWQHMZOEYQKHD27N2YBNPET77/providers/Microsoft.Compute/proximityPlacementGroups/ppg1\"\r\n
-        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"uniqueId\": \"65786e7f-57ce-432a-9c51-ce713202da08\",\r\n
+        {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/CLI_TEST_VMSS_ORCHESTRATION_MODE_COCEQZOQDZSZYHDNHZDOM5XTS3RWRE56UVZROQ3DIS/providers/Microsoft.Compute/proximityPlacementGroups/ppg1\"\r\n
+        \   },\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"uniqueId\": \"f3e65c6b-8754-4e5a-99e9-17f81461cfb5\",\r\n
         \   \"platformFaultDomainCount\": 3\r\n  }\r\n}"
     headers:
       cache-control:
@@ -2073,7 +2112,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:02 GMT
+      - Mon, 11 Apr 2022 08:12:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2090,7 +2129,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetVMScaleSet3Min;307,Microsoft.Compute/GetVMScaleSet30Min;1593
+      - Microsoft.Compute/GetVMScaleSet3Min;395,Microsoft.Compute/GetVMScaleSet30Min;2574
     status:
       code: 200
       message: OK
@@ -2107,8 +2146,9 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-network/19.3.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-network/19.3.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
   response:
@@ -2122,7 +2162,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:02 GMT
+      - Mon, 11 Apr 2022 08:12:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2161,11 +2201,11 @@ interactions:
       "fromImage", "name": null, "caching": "ReadWrite", "managedDisk": {"storageAccountType":
       null}}, "imageReference": {"publisher": "OpenLogic", "offer": "CentOS", "sku":
       "7.5", "version": "latest"}}, "virtualMachineScaleSet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1"},
-      "osProfile": {"computerName": "vm1", "adminUsername": "ruijun_hu", "linuxConfiguration":
+      "osProfile": {"computerName": "vm1", "adminUsername": "vmtest", "linuxConfiguration":
       {"disablePasswordAuthentication": true, "ssh": {"publicKeys": [{"keyData": "ssh-rsa
-      AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-      cxznmhdcxz\n", "path": "/home/ruijun_hu/.ssh/authorized_keys"}]}}}, "platformFaultDomain":
-      "0"}}], "outputs": {}}, "parameters": {}, "mode": "incremental"}}'
+      AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+      Zhou.Xing@microsoft.com\n", "path": "/home/vmtest/.ssh/authorized_keys"}]}}},
+      "platformFaultDomain": "0"}}], "outputs": {}}, "parameters": {}, "mode": "incremental"}}'
     headers:
       Accept:
       - application/json
@@ -2176,29 +2216,30 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3679'
+      - '3686'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_DAPpcC48zMRBrL32HxRkEww3yws2zy9c","name":"vm_deploy_DAPpcC48zMRBrL32HxRkEww3yws2zy9c","type":"Microsoft.Resources/deployments","properties":{"templateHash":"11565536453011606042","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-03-17T11:31:07.3955689Z","duration":"PT0.0001409S","correlationId":"c6d36cd3-ee38-42ea-b53c-fbf77be225ec","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Ktw6mzO3ZiV7DAMGxNNufiFcbwmiuR","name":"vm_deploy_n8Ktw6mzO3ZiV7DAMGxNNufiFcbwmiuR","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5967166751667705922","parameters":{},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-04-11T08:12:30.2048139Z","duration":"PT0.0001772S","correlationId":"efd90a49-dae7-470d-8a20-077b5f18cbb4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}]}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_DAPpcC48zMRBrL32HxRkEww3yws2zy9c/operationStatuses/08585540902204707254?api-version=2021-04-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Ktw6mzO3ZiV7DAMGxNNufiFcbwmiuR/operationStatuses/08585519421378576763?api-version=2021-04-01
       cache-control:
       - no-cache
       content-length:
-      - '2491'
+      - '2490'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:08 GMT
+      - Mon, 11 Apr 2022 08:12:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2208,7 +2249,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -2225,10 +2266,11 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540902204707254?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519421378576763?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -2240,7 +2282,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:31:38 GMT
+      - Mon, 11 Apr 2022 08:13:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2267,10 +2309,11 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540902204707254?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519421378576763?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -2282,7 +2325,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:32:09 GMT
+      - Mon, 11 Apr 2022 08:13:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2309,10 +2352,11 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540902204707254?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519421378576763?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Running"}'
@@ -2324,7 +2368,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:32:40 GMT
+      - Mon, 11 Apr 2022 08:14:02 GMT
       expires:
       - '-1'
       pragma:
@@ -2351,10 +2395,11 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585540902204707254?api-version=2021-04-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585519421378576763?api-version=2021-04-01
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -2366,7 +2411,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:10 GMT
+      - Mon, 11 Apr 2022 08:14:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2393,22 +2438,23 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_DAPpcC48zMRBrL32HxRkEww3yws2zy9c","name":"vm_deploy_DAPpcC48zMRBrL32HxRkEww3yws2zy9c","type":"Microsoft.Resources/deployments","properties":{"templateHash":"11565536453011606042","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-03-17T11:32:54.8106714Z","duration":"PT1M47.4152434S","correlationId":"c6d36cd3-ee38-42ea-b53c-fbf77be225ec","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Resources/deployments/vm_deploy_n8Ktw6mzO3ZiV7DAMGxNNufiFcbwmiuR","name":"vm_deploy_n8Ktw6mzO3ZiV7DAMGxNNufiFcbwmiuR","type":"Microsoft.Resources/deployments","properties":{"templateHash":"5967166751667705922","parameters":{},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-04-11T08:14:22.3501307Z","duration":"PT1M52.145494S","correlationId":"efd90a49-dae7-470d-8a20-077b5f18cbb4","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["westus"]},{"resourceType":"networkSecurityGroups","locations":["westus"]},{"resourceType":"publicIPAddresses","locations":["westus"]},{"resourceType":"networkInterfaces","locations":["westus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["westus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"vm1VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"vm1PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"vm1VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"vm1"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/virtualNetworks/vm1VNET"}]}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3378'
+      - '3376'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:11 GMT
+      - Mon, 11 Apr 2022 08:14:34 GMT
       expires:
       - '-1'
       pragma:
@@ -2435,15 +2481,16 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1?$expand=instanceView&api-version=2021-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"c50080cc-d6a8-48be-8913-69a9296fa372\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"35943655-ca5f-4fb5-bb2b-f03f01b41fde\",\r\n
         \   \"virtualMachineScaleSet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\r\n
         \   },\r\n    \"platformFaultDomain\": 0,\r\n    \"hardwareProfile\": {\r\n
         \     \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n    \"storageProfile\":
@@ -2451,50 +2498,51 @@ interactions:
         \       \"offer\": \"CentOS\",\r\n        \"sku\": \"7.5\",\r\n        \"version\":
         \"latest\",\r\n        \"exactVersion\": \"7.5.201808150\"\r\n      },\r\n
         \     \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\":
-        \"vm1_OsDisk_1_df9cdbef3aee40358abf3b16c1d9bf0c\",\r\n        \"createOption\":
+        \"vm1_OsDisk_1_528859bd8aee4feea9f04daadad1c0bc\",\r\n        \"createOption\":
         \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\":
         {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_df9cdbef3aee40358abf3b16c1d9bf0c\"\r\n
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_528859bd8aee4feea9f04daadad1c0bc\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"vm1\",\r\n      \"adminUsername\": \"ruijun_hu\",\r\n
+        {\r\n      \"computerName\": \"vm1\",\r\n      \"adminUsername\": \"vmtest\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/ruijun_hu/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-        cxznmhdcxz\\n\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        }\r\n      },\r\n
-        \     \"secrets\": [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
-        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"}]},\r\n
+        \             \"path\": \"/home/vmtest/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+        Zhou.Xing@microsoft.com\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        }\r\n
+        \     },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"}]},\r\n
         \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"platformFaultDomain\":
         0,\r\n      \"computerName\": \"vm1\",\r\n      \"osName\": \"centos\",\r\n
         \     \"osVersion\": \"7.5.1804\",\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\":
-        \"2.7.0.6\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
+        \"2.7.1.0\",\r\n        \"statuses\": [\r\n          {\r\n            \"code\":
         \"ProvisioningState/succeeded\",\r\n            \"level\": \"Info\",\r\n            \"displayStatus\":
         \"Ready\",\r\n            \"message\": \"Guest Agent is running\",\r\n            \"time\":
-        \"2022-03-17T11:32:55+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
-        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_df9cdbef3aee40358abf3b16c1d9bf0c\",\r\n
+        \"2022-04-11T08:14:20+00:00\"\r\n          }\r\n        ],\r\n        \"extensionHandlers\":
+        []\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\": \"vm1_OsDisk_1_528859bd8aee4feea9f04daadad1c0bc\",\r\n
         \         \"statuses\": [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
         \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
-        succeeded\",\r\n              \"time\": \"2022-03-17T11:31:31.9088935+00:00\"\r\n
+        succeeded\",\r\n              \"time\": \"2022-04-11T08:12:55.8395569+00:00\"\r\n
         \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
         \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2022-03-17T11:32:51.440237+00:00\"\r\n
+        succeeded\",\r\n          \"time\": \"2022-04-11T08:14:18.5151247+00:00\"\r\n
         \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
         \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-03-17T11:31:28.3150838+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-04-11T08:12:52.8550716+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4319'
+      - '4327'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:11 GMT
+      - Mon, 11 Apr 2022 08:14:35 GMT
       expires:
       - '-1'
       pragma:
@@ -2511,7 +2559,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3888,Microsoft.Compute/LowCostGet30Min;30697
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31988
     status:
       code: 200
       message: OK
@@ -2528,19 +2576,20 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-network/19.3.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-network/19.3.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic?api-version=2018-01-01
   response:
     body:
       string: "{\r\n  \"name\": \"vm1VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\",\r\n
-        \ \"etag\": \"W/\\\"4b4abb6c-9eae-4829-b57a-c48567ec80c8\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"6feef8b2-b809-4f06-9e1f-349fe30b6953\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"d6b3c7fe-f48a-449c-abb6-e2e09262da7a\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"7fd442e0-940b-4cea-8dfe-42f4c6d822be\",\r\n
         \   \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigvm1\",\r\n
         \       \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\",\r\n
-        \       \"etag\": \"W/\\\"4b4abb6c-9eae-4829-b57a-c48567ec80c8\\\"\",\r\n
+        \       \"etag\": \"W/\\\"6feef8b2-b809-4f06-9e1f-349fe30b6953\\\"\",\r\n
         \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
@@ -2549,8 +2598,8 @@ interactions:
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
         [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"kos4uk33xibe5bk1muwnyb2tqg.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-22-48-09-45-66\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \"kbeeewsuw3gezl1tv4sxmu3w2h.dx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-3B-12-FD\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
         \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
         \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkSecurityGroups/vm1NSG\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
@@ -2564,9 +2613,9 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:12 GMT
+      - Mon, 11 Apr 2022 08:14:36 GMT
       etag:
-      - W/"4b4abb6c-9eae-4829-b57a-c48567ec80c8"
+      - W/"6feef8b2-b809-4f06-9e1f-349fe30b6953"
       expires:
       - '-1'
       pragma:
@@ -2583,7 +2632,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 56ac1685-2a0e-4cde-9eac-8f1cf573404e
+      - e7b8d8d6-70a8-47e5-9981-e3a1ed84cf11
     status:
       code: 200
       message: OK
@@ -2600,17 +2649,18 @@ interactions:
       - keep-alive
       ParameterSetName:
       - -g -n --image --platform-fault-domain --vmss --generate-ssh-keys --nsg-rule
+        --admin-username
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-network/19.3.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-network/19.3.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP?api-version=2018-01-01
   response:
     body:
       string: "{\r\n  \"name\": \"vm1PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/publicIPAddresses/vm1PublicIP\",\r\n
-        \ \"etag\": \"W/\\\"1b448c55-1c14-4d66-8ca5-ba912cdbe8e4\\\"\",\r\n  \"location\":
+        \ \"etag\": \"W/\\\"10579425-6a9c-4846-96b6-5a1d6d618e31\\\"\",\r\n  \"location\":
         \"westus\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\":
-        \"Succeeded\",\r\n    \"resourceGuid\": \"85525114-fe76-4361-b7c7-3d4c207d46b1\",\r\n
-        \   \"ipAddress\": \"13.64.16.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \"Succeeded\",\r\n    \"resourceGuid\": \"509b367a-c208-4582-bfb9-9eef326c7ef0\",\r\n
+        \   \"ipAddress\": \"137.135.7.91\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
         \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
         4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic/ipConfigurations/ipconfigvm1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
@@ -2619,13 +2669,13 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '923'
+      - '924'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:13 GMT
+      - Mon, 11 Apr 2022 08:14:37 GMT
       etag:
-      - W/"1b448c55-1c14-4d66-8ca5-ba912cdbe8e4"
+      - W/"10579425-6a9c-4846-96b6-5a1d6d618e31"
       expires:
       - '-1'
       pragma:
@@ -2642,7 +2692,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 35bfff58-2823-4cf2-b74c-cd436ab70905
+      - 49adf6b9-e9bc-458c-b375-d2d8064c0371
     status:
       code: 200
       message: OK
@@ -2660,14 +2710,14 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.34.1 azsdk-python-azure-mgmt-compute/25.0.0 Python/3.10.0 (Windows-10-10.0.19043-SP0)
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-compute/26.1.0 Python/3.8.1 (Windows-10-10.0.19041-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2021-11-01
   response:
     body:
       string: "{\r\n  \"name\": \"vm1\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachines/vm1\",\r\n
         \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"westus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"c50080cc-d6a8-48be-8913-69a9296fa372\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"vmId\": \"35943655-ca5f-4fb5-bb2b-f03f01b41fde\",\r\n
         \   \"virtualMachineScaleSet\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1\"\r\n
         \   },\r\n    \"platformFaultDomain\": 0,\r\n    \"hardwareProfile\": {\r\n
         \     \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n    \"storageProfile\":
@@ -2675,33 +2725,34 @@ interactions:
         \       \"offer\": \"CentOS\",\r\n        \"sku\": \"7.5\",\r\n        \"version\":
         \"latest\",\r\n        \"exactVersion\": \"7.5.201808150\"\r\n      },\r\n
         \     \"osDisk\": {\r\n        \"osType\": \"Linux\",\r\n        \"name\":
-        \"vm1_OsDisk_1_df9cdbef3aee40358abf3b16c1d9bf0c\",\r\n        \"createOption\":
+        \"vm1_OsDisk_1_528859bd8aee4feea9f04daadad1c0bc\",\r\n        \"createOption\":
         \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n        \"managedDisk\":
         {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n          \"id\":
-        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_df9cdbef3aee40358abf3b16c1d9bf0c\"\r\n
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Compute/disks/vm1_OsDisk_1_528859bd8aee4feea9f04daadad1c0bc\"\r\n
         \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
         30\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
-        {\r\n      \"computerName\": \"vm1\",\r\n      \"adminUsername\": \"ruijun_hu\",\r\n
+        {\r\n      \"computerName\": \"vm1\",\r\n      \"adminUsername\": \"vmtest\",\r\n
         \     \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
         true,\r\n        \"ssh\": {\r\n          \"publicKeys\": [\r\n            {\r\n
-        \             \"path\": \"/home/ruijun_hu/.ssh/authorized_keys\",\r\n              \"keyData\":
-        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyHIxtehmSa4iZExLrQ4pc7bklBKwAR865F9LEWNd8SIgFCYy2s+vA5Sofj2cMD06HqCAPeM+VJvjwImCmGhO3GQU816Zo7AOX21dKGUZLbGQ35lxXPMsd0aCx8J8Ncq1sReBPlZs9BT2X0pR2jkalCJQKFWXXkwXyj8l05PunQm2lnggijrnLAMjdI7+6S6rNUs4oA54egfrKIXSQiqjfSNMySytJzJkGYdbQzUrGrL47qNEy0keAPi1VGlijs/m3khFQAd2Bdb1Nhp1k8QC0OQ5BccKPVfFRyz/EoRMFvjzfNQrR75D6f2q+XZIrlee1Z7MX/KpYx1IOI2ATlfRqUoIlM7O1hWsQr9rGek+D10BtBJ4uZsrUOHs+llQo5fQXzVunZEzaYUBulRwPO1kBHjSkD0NNCO5490EnaCIFot41Wh/bDTWFNDZkZHxXhbrXRaA/d0vzrlAiLDUkUEtOKP0jc9o9vz/vSbEth6u8df06cq9yYVbn+1j93lX5vJ0=
-        cxznmhdcxz\\n\"\r\n            }\r\n          ]\r\n        },\r\n        \"provisionVMAgent\":
-        true,\r\n        \"patchSettings\": {\r\n          \"patchMode\": \"ImageDefault\",\r\n
-        \         \"assessmentMode\": \"ImageDefault\"\r\n        }\r\n      },\r\n
-        \     \"secrets\": [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\":
-        true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\": \"2022-03-17T11:31:28.3150838+00:00\"\r\n
+        \             \"path\": \"/home/vmtest/.ssh/authorized_keys\",\r\n              \"keyData\":
+        \"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDdfdN+YWbkBS84r36yJbgfTI+Gx1W/ErinzCGvXBeO0S8F8JBc45BGTSaNmgOiqVMef3L9Dne7xUv6CwK+NaPRF23B2Sfv1VT1RWjKzgsgLAGiMvMuXA8/BfnKyQU43P6ImgXW/89E8OE9tS2TYLWiSSOjSTiCDnH+bJOw0Gqb25CLhZiahL1lS8MPuZHQaLa71GGUJS93GeBBF6eM2aFKitdFif38RsHxwY/aLlKhjwuy0XPI/4HcIHJR9uyEiFsPQXZMbFPwfvTWyRQDqS0KfxgFXtoVQgaNq74zJv94JdqDykoXYrempJU33jCC06vi39u+xZHAdAagp6e8z/WQc7fIPEOoKqNBKO3UhjXfLfHsxM9QvEiE2kL1xBekS9XrzqSvYZBi4tiSiLAYajOdI5dlv9HgvRTdCtnfF6v8iVGpwql/B1OTOn/A9uCmRIu3o9aMjsQoegqGX6e+h7omfVaExdClXOrW1Qi5l9mUSDLJgsGm1sT9nLaVJlPotFM=
+        Zhou.Xing@microsoft.com\\n\"\r\n            }\r\n          ]\r\n        },\r\n
+        \       \"provisionVMAgent\": true,\r\n        \"patchSettings\": {\r\n          \"patchMode\":
+        \"ImageDefault\",\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        }\r\n
+        \     },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_vmss_orchestration_mode_000001/providers/Microsoft.Network/networkInterfaces/vm1VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\": \"2022-04-11T08:12:52.8550716+00:00\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2991'
+      - '2998'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 17 Mar 2022 11:33:13 GMT
+      - Mon, 11 Apr 2022 08:14:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2718,7 +2769,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/LowCostGet3Min;3885,Microsoft.Compute/LowCostGet30Min;30694
+      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31987
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -6491,7 +6491,7 @@ class VMSSOrchestrationModeScenarioTest(ScenarioTest):
 
         self.cmd('ppg create -g {rg} -n {ppg}')
         self.cmd('vmss create -g {rg} -n {vmss} --orchestration-mode Flexible --single-placement-group false '
-                 '--ppg {ppg} --platform-fault-domain-count 3 --admin-username vmtest',
+                 '--ppg {ppg} --platform-fault-domain-count 3',
                  checks=[
                      self.check('vmss.singlePlacementGroup', False),
                      self.check('vmss.platformFaultDomainCount', 3)
@@ -6643,6 +6643,10 @@ class VMSSOrchestrationModeScenarioTest(ScenarioTest):
         self.kwargs.update({
             'vmss': 'vmsslongnametest',
         })
+
+        from azure.cli.core.azclierror import ArgumentUsageError
+        with self.assertRaisesRegex(ArgumentUsageError, 'please specify the --image when you want to specify the VM SKU'):
+            self.cmd('vmss create -n {vmss} -g {rg} --orchestration-mode Flexible --platform-fault-domain-count 1 --zones 1 --instance-count 3 --vm-sku Standard_D1_v2')
 
         self.cmd('vmss create -n {vmss} -g {rg} --image ubuntults --orchestration-mode flexible --admin-username vmtest')
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This problem comes from ICM. Just as communicating with @fitzgeraldsteele on Teams, CLI needs to fix the following problems:
1. Error handling issue: `'NoneType' object has no attribute 'lower'` when creating Flex VMSS without `--vm-sku` parameter
2. When creating VM/VMSS, if the user does not pass in `--location`, the location from resource group can be used by default *(there is already this logic, but it is not triggered due to this bug)*
3. For creating VMSS, the information of VM profile and SKU should be either passed in or not passed in. Therefore, if users pass in the `--vm-sku` parameter, CLI needs to verify that users must also pass in the `--image` parameter



**Testing Guide**
<!--Example commands with explanations.-->
Because if the `--zone` parameter is added in the test, the recorded file will be very large. Therefore, instead of adding the corresponding test case, upload the screenshot of this case
![Screenshot 2022-04-11 113529](https://user-images.githubusercontent.com/16612065/162697724-ba08044d-40d8-4936-a3d1-31f3c62d3ca7.png)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] `az vm create`: Fix the bug of "NoneType object has no attribute lower" when creating Flex VMSS without `--vm-sku` parameter

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
