### PR TITLE
{packaging} Update jsondiff to 2.0.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -107,7 +107,7 @@ isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==2.11.3
 jmespath==0.9.5
-jsondiff==1.3.0
+jsondiff==2.0.0
 knack==0.9.0
 MarkupSafe==1.1.1
 msal-extensions==0.3.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -108,7 +108,7 @@ isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==2.11.3
 jmespath==0.9.5
-jsondiff==1.3.0
+jsondiff==2.0.0
 knack==0.9.0
 MarkupSafe==1.1.1
 msal-extensions==0.3.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -107,7 +107,7 @@ isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==2.11.3
 jmespath==0.9.5
-jsondiff==1.3.0
+jsondiff==2.0.0
 knack==0.9.0
 MarkupSafe==1.1.1
 msal-extensions==0.3.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -143,7 +143,7 @@ DEPENDENCIES = [
     'distro; sys_platform == "linux"',
     'fabric~=2.4',
     'javaproperties~=0.5.1',
-    'jsondiff~=1.3.0',
+    'jsondiff~=2.0.0',
     'packaging>=20.9,<22.0',
     'PyGithub~=1.38',
     'PyNaCl~=1.4.0',


### PR DESCRIPTION
**Description**<!--Mandatory-->

The `jsondiff` package was recently updated and a 2.0.0 version was released. I'd like to update my `python3-jsondiff` Fedora package to 2.0.0, but `azure-cli` demands a version `>= 1.3` and `<= 1.4`.

For completeness, the bug on the Fedora side is [BZ 2073817](https://bugzilla.redhat.com/show_bug.cgi?id=2073817).

**Testing Guide**

All testing processes should remain the same.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
