### PR TITLE
[RDBMS] `az postgres server create`: Fix error message for invalid server names

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/custom.py
@@ -782,8 +782,7 @@ def create_postgresql_connection_string(server_name, host, user, password):
 def check_server_name_availability(check_name_client, parameters):
     server_availability = check_name_client.execute(parameters)
     if not server_availability.name_available:
-        raise CLIError("The server name '{}' already exists.Please re-run command with some "
-                       "other server name.".format(parameters.name))
+        raise CLIError(server_availability.message)
     return True
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
The error message from `az postgres server create` is the same when validating the server name for both when the server name is already taken and when the server name is invalid.

This PR addresses the change by passing through the message from the response directly.

resolves #21999

**Testing Guide**
<!--Example commands with explanations.-->

Try running the command with either an existing server name or an invalid name like one with underscores in it.