### PR TITLE
{Packaging} Build RPMs with Mariner 2.0 and 1.0 images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -705,12 +705,23 @@ jobs:
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   pool:
     vmImage: 'ubuntu-20.04'
+  strategy:
+    matrix:
+      1.0:
+        acr: cblmariner
+        tag: 1.0
+      2.0:
+        acr: cblmariner2preview
+        tag: 2.0
   steps:
   - task: Bash@3
     displayName: 'Build Rpm Package: Mariner'
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
+    env:
+      ACR: $(acr)
+      TAG: $(tag)
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
@@ -721,7 +732,7 @@ jobs:
     displayName: 'Publish Artifact: rpm-mariner'
     inputs:
       TargetPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: rpm-mariner
+      ArtifactName: rpm-mariner$(tag)
 
 
 - job: BuildRpmPackageCentOS7

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -1,6 +1,7 @@
 ARG tag=2.0
+ARG acr=cblmariner2preview
 
-FROM cblmariner2preview.azurecr.io/base/core:${tag} AS build-env
+FROM ${acr}.azurecr.io/base/core:${tag} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
@@ -14,7 +15,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
 
-FROM cblmariner2preview.azurecr.io/base/core:${tag} AS execution-env
+FROM ${acr}.azurecr.io/base/core:${tag} AS execution-env
 
 RUN tdnf update -y
 RUN tdnf install -y python3 python3-virtualenv

--- a/scripts/release/rpm/pipeline_mariner.sh
+++ b/scripts/release/rpm/pipeline_mariner.sh
@@ -5,12 +5,16 @@
 set -exv
 
 : "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
+: "${ACR:?ACR environment variable not set.}"
+: "${TAG:?TAG environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 
 # Create a container image that includes the source code and a built RPM using this file.
 docker build \
     --target build-env \
+    --build-arg acr=${ACR} \
+    --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/mariner.dockerfile \
     -t azure/azure-cli:mariner-builder \
@@ -18,22 +22,25 @@ docker build \
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
+    --build-arg acr=${ACR} \
+    --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/mariner.dockerfile \
     -t azure/azure-cli:mariner \
     .
 
 # Extract the built RPM so that it can be distributed independently.
-docker run \
-    azure/azure-cli:mariner-builder \
-    cat /usr/src/mariner/RPMS/x86_64/azure-cli-${CLI_VERSION}-1.x86_64.rpm \
-    > ${BUILD_STAGINGDIRECTORY}/azure-cli-${CLI_VERSION}-1.x86_64.rpm
+# The RPM file looks like azure-cli-2.32.0-1.x86_64.rpm
+id=$(docker create azure/azure-cli:mariner-builder bash)
+# https://docs.docker.com/engine/reference/commandline/cp/
+# Append /. so that the x86_64 folder's content is copied, instead of x86_64 folder itself.
+docker cp $id:/usr/src/mariner/RPMS/x86_64/. ${BUILD_STAGINGDIRECTORY}
 
 # Save these too a staging directory so that later build phases can choose to save them as Artifacts or publish them to
 # a registry.
 #
 # The products of `docker save` can be rehydrated using `docker load`.
-mkdir -p ${BUILD_STAGINGDIRECTORY}/docker
-docker save azure/azure-cli:mariner-builder | gzip > ${BUILD_STAGINGDIRECTORY}/docker/azure_azure-cli_mariner-builder.tar.gz &
-docker save azure/azure-cli:mariner | gzip > ${BUILD_STAGINGDIRECTORY}/docker/azure_azure-cli_mariner.tar.gz &
-wait
+# mkdir -p ${BUILD_STAGINGDIRECTORY}/docker
+# docker save azure/azure-cli:mariner-builder | gzip > ${BUILD_STAGINGDIRECTORY}/docker/azure_azure-cli_mariner-builder.tar.gz &
+# docker save azure/azure-cli:mariner | gzip > ${BUILD_STAGINGDIRECTORY}/docker/azure_azure-cli_mariner.tar.gz &
+# wait


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/pull/21245 changed the Mariner image from 1.0 to 2.0.

According to the discussion we had today, Mariner 1.0 is still supported, so we should build images for both 1.0 and 2.0.
