### PR TITLE
{CI} Drop Python 3.9 tests

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -24,8 +24,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -46,8 +44,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -68,8 +64,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -90,8 +84,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -391,11 +391,6 @@ jobs:
          --rm -v $PYPI_FILES:/mnt/pypi python:3.8 \
          /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
 
-       # echo "== Testing pip install on Python 3.9 =="
-       # docker run \
-       #   --rm -v $PYPI_FILES:/mnt/pypi python:3.9 \
-       #   /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
-
        echo "== Testing pip install on Python 3.10 =="
        docker run \
          --rm -v $PYPI_FILES:/mnt/pypi python:3.10 \
@@ -414,8 +409,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -435,8 +428,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -459,8 +450,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -484,8 +473,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -505,8 +492,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -526,8 +511,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -547,8 +530,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -967,8 +948,6 @@ jobs:
         python.version: '3.6'
       Python38:
         python.version: '3.8'
-      Python39:
-        python.version: '3.9'
       Python310:
         python.version: '3.10'
   pool:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Python versions used by Azure CLI packages:

1. Docker image, Windows MSI, Homebrew, PyPI: 3.10
2. Debian/Ubuntu DEB: 3.8
3. RPM: 3.6 (We can't drop it now as explained in https://github.com/Azure/azure-cli/pull/20865)

Since Azure CLI has fully supported Python 3.10, we can drop Python 3.9 to save some computation resource in Azure DevOps.
