### PR TITLE
{CI} enable pytest group worker in module test and full test

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -32,12 +32,20 @@ steps:
       echo fullTest: ${{ parameters.fullTest }}
       echo module: ${{ parameters.module }}
       echo Build.Reason: $(Build.Reason)
+      series_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
 
       # Test specific module
       module="${{ parameters.module }}"
       if [[ -n $module ]]; then
         echo "Running test for module '$module'"
-        azdev test --no-exitfirst --verbose --series $module
+        # Determine whether the module belongs to series_modules
+        if [[ "$series_modules" =~ "$module" ]]; then
+          echo "Running in series"
+          azdev test --no-exitfirst --verbose --series $module --pytest-args "--durations=0"
+        else
+          echo "Running in parallels"
+          azdev test --no-exitfirst --verbose $module --pytest-args "--durations=0"
+        fi
         exit 0
       fi
 
@@ -45,10 +53,10 @@ steps:
         echo "Running incremental test"
         # If CI is set to shallow fetch, target branch should be expilictly fetched.
         git fetch origin --depth=1 $(System.PullRequest.TargetBranch)
-        azdev test --no-exitfirst --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch) --cli-ci --profile ${{ parameters.profile }} --verbose --series
+        azdev test --no-exitfirst --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch) --cli-ci --profile ${{ parameters.profile }} --verbose --series --pytest-args "--durations=0"
       else
         echo "Running full test"
-        azdev test --no-exitfirst --profile ${{ parameters.profile }} --verbose --series
+        python scripts/ci/automation_full_test.py "${{ parameters.profile }}"
       fi
     displayName: "azdev test"
     env:

--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -32,14 +32,14 @@ steps:
       echo fullTest: ${{ parameters.fullTest }}
       echo module: ${{ parameters.module }}
       echo Build.Reason: $(Build.Reason)
-      series_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
+      serial_modules="appservice botservice cloud network azure-cli-core azure-cli-telemetry"
 
       # Test specific module
       module="${{ parameters.module }}"
       if [[ -n $module ]]; then
         echo "Running test for module '$module'"
-        # Determine whether the module belongs to series_modules
-        if [[ "$series_modules" =~ "$module" ]]; then
+        # Determine whether the module belongs to serial_modules
+        if [[ "$serial_modules" =~ "$module" ]]; then
           echo "Running in series"
           azdev test --no-exitfirst --verbose --series $module --pytest-args "--durations=0"
         else
@@ -56,7 +56,7 @@ steps:
         azdev test --no-exitfirst --repo=./ --src=HEAD --tgt=origin/$(System.PullRequest.TargetBranch) --cli-ci --profile ${{ parameters.profile }} --verbose --series --pytest-args "--durations=0"
       else
         echo "Running full test"
-        python scripts/ci/automation_full_test.py "${{ parameters.profile }}"
+        python scripts/ci/automation_full_test.py "${{ parameters.profile }}" "$serial_modules"
       fi
     displayName: "azdev test"
     env:

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -16,13 +16,14 @@ ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
 logger.addHandler(ch)
 profile = sys.argv[1]
+serial_modules = sys.argv[2].split()
 
 
 class AutomaticScheduling(object):
 
     def __init__(self):
         self.modules = {}
-        self.series_modules = ['appservice', 'botservice', 'cloud', 'network', 'azure-cli-core', 'azure-cli-telemetry']
+        self.serial_modules = serial_modules
         self.profile = profile
 
     def get_all_modules(self):
@@ -33,24 +34,24 @@ class AutomaticScheduling(object):
     def run_modules(self):
         # divide all modules into parallel or serial execution
         error_flag = False
-        series = []
-        parallers = []
+        serial_tests = []
+        parallel_tests = []
         for k, v in self.modules.items():
-            if k in self.series_modules:
-                series.append(k)
+            if k in self.serial_modules:
+                serial_tests.append(k)
             else:
-                parallers.append(k)
-        if series:
+                parallel_tests.append(k)
+        if serial_tests:
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + \
-                  series + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+                  serial_tests + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
                 subprocess.run(cmd)
             except subprocess.CalledProcessError:
                 error_flag = True
-        if parallers:
+        if parallel_tests:
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + \
-                  parallers + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+                  parallel_tests + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
                 subprocess.run(cmd)

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -17,7 +17,7 @@ profile = sys.argv[1]
 class AutomaticScheduling(object):
 
     def __init__(self):
-        self.modules = []
+        self.modules = {}
         self.series_modules = ['appservice', 'botservice', 'cloud', 'network', 'azure-cli-core', 'azure-cli-telemetry']
         self.profile = profile
 
@@ -25,7 +25,7 @@ class AutomaticScheduling(object):
         result = get_path_table()
         self.modules = {**result['mod'], **result['core']}
 
-    def run_modules(self, modules):
+    def run_modules(self):
         # divide all modules into parallel or serial execution
         error_flag = False
         series = []
@@ -36,14 +36,16 @@ class AutomaticScheduling(object):
             else:
                 parallers.append(k)
         if series:
-            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + series + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + \
+                  series + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
                 subprocess.run(cmd)
             except subprocess.CalledProcessError:
                 error_flag = True
         if parallers:
-            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallers + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + \
+                  parallers + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
                 subprocess.run(cmd)
@@ -54,9 +56,9 @@ class AutomaticScheduling(object):
 
 def main():
     logger.info("Start check pull request ...\n")
-    AS = AutomaticScheduling()
-    AS.get_all_modules()
-    sys.exit(1) if AS.run_modules() else sys.exit(0)
+    autoschduling = AutomaticScheduling()
+    autoschduling.get_all_modules()
+    sys.exit(1) if autoschduling.run_modules() else sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -11,6 +11,10 @@ import sys
 from azdev.utilities import get_path_table
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+logger.addHandler(ch)
 profile = sys.argv[1]
 
 

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -51,8 +51,13 @@ class AutomaticScheduling(object):
                 error_flag = True
         return error_flag
 
+
 def main():
     logger.info("Start check pull request ...\n")
     AS = AutomaticScheduling()
     AS.get_all_modules()
     sys.exit(1) if AS.run_modules() else sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -23,6 +23,7 @@ class AutomaticScheduling(object):
 
     def get_all_modules(self):
         result = get_path_table()
+        # only get modules and core, ignore extensions
         self.modules = {**result['mod'], **result['core']}
 
     def run_modules(self):
@@ -55,7 +56,7 @@ class AutomaticScheduling(object):
 
 
 def main():
-    logger.info("Start check pull request ...\n")
+    logger.info("Start automation full test ...\n")
     autoschduling = AutomaticScheduling()
     autoschduling.get_all_modules()
     sys.exit(1) if autoschduling.run_modules() else sys.exit(0)

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import logging
+import subprocess
+import sys
+from azdev.utilities import get_path_table
+
+logger = logging.getLogger(__name__)
+profile = sys.argv[1]
+
+
+class AutomaticScheduling(object):
+
+    def __init__(self):
+        self.modules = []
+        self.series_modules = ['appservice', 'botservice', 'cloud', 'network', 'azure-cli-core', 'azure-cli-telemetry']
+        self.profile = profile
+
+    def get_all_modules(self):
+        result = get_path_table()
+        self.modules = {**result['mod'], **result['core']}
+
+    def run_modules(self, modules):
+        # divide all modules into parallel or serial execution
+        error_flag = False
+        series = []
+        parallers = []
+        for k, v in self.modules.items():
+            if k in self.series_modules:
+                series.append(k)
+            else:
+                parallers.append(k)
+        if series:
+            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + series + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+            logger.info(cmd)
+            try:
+                subprocess.run(cmd)
+            except subprocess.CalledProcessError:
+                error_flag = True
+        if parallers:
+            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallers + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
+            logger.info(cmd)
+            try:
+                subprocess.run(cmd)
+            except subprocess.CalledProcessError:
+                error_flag = True
+        return error_flag
+
+def main():
+    logger.info("Start check pull request ...\n")
+    AS = AutomaticScheduling()
+    AS.get_all_modules()
+    sys.exit(1) if AS.run_modules() else sys.exit(0)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

- Add --pytest-args "--durations=0" to record the time spent on each test.
- For module test and full test:
  Every module not in serial_modules, enable group worker in pytest, pytest will spawn a number of workers processes equal to the number of available CPUs, and distribute the tests randomly across them.
- For incremental test:
  Remain the same
- serial_modules: ['appservice', 'botservice', 'cloud', 'network', 'azure-cli-core', 'azure-cli-telemetry']

![image](https://user-images.githubusercontent.com/18628534/163130926-fb64f66c-9b4f-428c-a2d1-55d7fb89a15b.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
