### PR TITLE
{CI} Add `/azure-cli` as `safe.directory` in docker container

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -8,6 +8,11 @@ set -ev
 ##############################################
 # clean up and dir search
 mkdir -p ./artifacts
+
+# Current folder (/azure-cli) is mounted from host which has different owner than docker container's
+# current user 0(root).
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/
+git config --global --add safe.directory $(pwd)
 echo `git rev-parse --verify HEAD` > ./artifacts/build.sha
 
 mkdir -p ./artifacts/build


### PR DESCRIPTION
**Description**<!--Mandatory-->

Git released a fix for CVE-2022-24765 today, making it impossible to run `git` commands in a directory that is not owned by the current user:

- https://github.blog/2022-04-12-git-security-vulnerability-announced/
- https://lore.kernel.org/git/xmqqv8veb5i6.fsf@gitster.g/
- https://nvd.nist.gov/vuln/detail/CVE-2022-24765

This fix was backported to `2.25.1-1ubuntu3.3` on Ubuntu Focal (https://launchpad.net/ubuntu/+source/git/1:2.25.1-1ubuntu3.3), causing CI failure:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1501323&view=logs&j=6a6a2ac0-ff7f-5678-6bf3-3c1acb42be6f&t=9fdc6347-bbbe-562a-7659-31ca5019fc37

```
git checkout src
fatal: unsafe repository ('/azure-cli' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /azure-cli
```

As it is expected for mounted `/azure-cli` to have different owner than the current docker container's user, this PR adds `/azure-cli` as[ `safe.directory`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory).

Other Microsoft developers are taking the same approach: https://github.com/microsoft/openocd/commit/16d4838818c5a67cb7739d948582c5e63095ceed (found by https://github.com/search?q=org%3Amicrosoft+safe.directory+git+config&type=code)
