### PR TITLE
[Storage] Fix #21966: `az storage blob download-batch`: Fix failure when `--pattern` is blob name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/util.py
@@ -28,8 +28,11 @@ def collect_blob_objects(blob_service, container, pattern=None):
         raise ValueError('missing parameter container')
 
     if not _pattern_has_wildcards(pattern):
-        if blob_service.exists(container, pattern):
-            yield pattern, blob_service.get_blob_properties(container, pattern)
+        from azure.core.exceptions import ResourceNotFoundError
+        try:
+            yield pattern, blob_service.get_blob_client(container, pattern).get_blob_properties()
+        except ResourceNotFoundError:
+            return
     else:
         if hasattr(blob_service, 'list_blobs'):
             blobs = blob_service.list_blobs(container)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #21966 

**Testing Guide**
<!--Example commands with explanations.-->
Blob exist:
`az storage blob download-batch -d D:\tmp --pattern policy.json -s yscontainer --account-name yssa --auth-mode login`
Blob not eixst:
`az storage blob download-batch -d D:\tmp --pattern notexist.json -s yscontainer --account-name yssa --auth-mode login`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
