### PR TITLE
{Network}`az network lb create`  and `az network lb frontend ip create`: Add hint to use standard sku

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -3670,6 +3670,14 @@ def create_load_balancer(cmd, load_balancer_name, resource_group_name, location=
     from azure.cli.command_modules.network._template_builder import (
         build_load_balancer_resource, build_public_ip_resource, build_vnet_resource)
 
+    # In the latest profile, the default public IP will be expected to be changed from Basic to Standard.
+    # In order to avoid breaking change which has a big impact to users,
+    # we use the hint to guide users to use Standard sku to create lb.
+    if cmd.cli_ctx.cloud.profile == 'latest':
+        logger.warning(
+            'Please note that the default public IP used for lb creation will be changed from Basic to Standard '
+            'in the future.')
+
     DeploymentProperties = cmd.get_models('DeploymentProperties', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
     IPAllocationMethod = cmd.get_models('IPAllocationMethod')
 
@@ -3884,6 +3892,15 @@ def create_lb_frontend_ip_configuration(
         cmd, resource_group_name, load_balancer_name, item_name, public_ip_address=None,
         public_ip_prefix=None, subnet=None, virtual_network_name=None, private_ip_address=None,
         private_ip_address_version=None, private_ip_address_allocation=None, zone=None):
+
+    # In the latest profile, the default public IP will be expected to be changed from Basic to Standard.
+    # In order to avoid breaking change which has a big impact to users,
+    # we use the hint to guide users to use Standard sku to create lb frontend ip.
+    if cmd.cli_ctx.cloud.profile == 'latest':
+        logger.warning(
+            'Please note that the default public IP used for lb frontend ip creation will be changed from Basic to Standard '
+            'in the future.')
+
     FrontendIPConfiguration, SubResource, Subnet = cmd.get_models(
         'FrontendIPConfiguration', 'SubResource', 'Subnet')
     ncf = network_client_factory(cmd.cli_ctx)


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-cli/issues/21831

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

{network}'az network lb create': and 'az network lb frontend ip create':Add hint to use standard sku
In the latest profile and the profiles that use the same api-version as latest profile, the default public IP used for creation for an LB frontend with "az network lb create" and/or "az network lb frontend-ip create" will be changed from Basic to Standard. In advance of eventual breaking change, would like to add warning for users.
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
