### PR TITLE
[Network] Fix #22085: `az network nsg rule create` has no attribute "is_default"

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4983,8 +4983,7 @@ def _handle_asg_property(kwargs, key, asgs):
     if asgs:
         kwargs[key] = asgs
         if kwargs[prefix + 'address_prefix']:
-           kwargs[prefix + 'address_prefix'] = ''
-
+            kwargs[prefix + 'address_prefix'] = ''
 
 
 def create_nsg_rule_2017_06_01(cmd, resource_group_name, network_security_group_name, security_rule_name,

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -4982,8 +4982,9 @@ def _handle_asg_property(kwargs, key, asgs):
     prefix = key.split('_', 1)[0] + '_'
     if asgs:
         kwargs[key] = asgs
-        if kwargs[prefix + 'address_prefix'].is_default:
-            kwargs[prefix + 'address_prefix'] = ''
+        if kwargs[prefix + 'address_prefix']:
+           kwargs[prefix + 'address_prefix'] = ''
+
 
 
 def create_nsg_rule_2017_06_01(cmd, resource_group_name, network_security_group_name, security_rule_name,


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-cli/issues/22085

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix 'str' object has no attribute 'is_default' issue
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
