### PR TITLE
{RDBMS} Use `ServicePrincipalCredential` with environment credential

### DIFF
--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -14,7 +14,6 @@ from azure.cli.core._profile import (Profile, SubscriptionFinder, _attach_token_
                                      _transform_subscription_for_multiapi)
 from azure.cli.core.auth.util import AccessToken
 from azure.cli.core.mock import DummyCli
-from azure.identity import AuthenticationRecord
 from azure.mgmt.resource.subscriptions.models import \
     (Subscription, SubscriptionPolicies, SpendingLimit, ManagedByTenant)
 
@@ -94,9 +93,6 @@ class TestProfile(unittest.TestCase):
         cls.display_name1 = 'foo account'
         cls.home_account_id = "00000003-0000-0000-0000-000000000000.00000003-0000-0000-0000-000000000000"
         cls.client_id = "00000003-0000-0000-0000-000000000000"
-        cls.authentication_record = AuthenticationRecord(cls.tenant_id, cls.client_id,
-                                                         "https://login.microsoftonline.com", cls.home_account_id,
-                                                         cls.user1)
         cls.state1 = 'Enabled'
         cls.managed_by_tenants = [ManagedByTenantStub('00000003-0000-0000-0000-000000000000'),
                                   ManagedByTenantStub('00000004-0000-0000-0000-000000000000')]

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_client_factory.py
@@ -5,14 +5,12 @@
 
 from azure.cli.core.commands.client_factory import get_mgmt_service_client
 from azure.cli.core.profiles import ResourceType
+from azure.cli.core.auth.identity import get_environment_credential, AZURE_CLIENT_ID
 
 # pylint: disable=import-outside-toplevel
 
 RM_URI_OVERRIDE = 'AZURE_CLI_RDBMS_RM_URI'
 SUB_ID_OVERRIDE = 'AZURE_CLI_RDBMS_SUB_ID'
-CLIENT_ID = 'AZURE_CLIENT_ID'
-TENANT_ID = 'AZURE_TENANT_ID'
-CLIENT_SECRET = 'AZURE_CLIENT_SECRET'
 
 
 def get_mariadb_management_client(cli_ctx, **_):
@@ -24,13 +22,9 @@ def get_mariadb_management_client(cli_ctx, **_):
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
     if rm_uri_override:
-        client_id = getenv(CLIENT_ID)
+        client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
-            from azure.identity import ClientSecretCredential
-            credentials = ClientSecretCredential(
-                client_id=client_id,
-                client_secret=getenv(CLIENT_SECRET),
-                tenant_id=getenv(TENANT_ID))
+            credentials = get_environment_credential()
         else:
             from msrest.authentication import Authentication  # pylint: disable=import-error
             credentials = Authentication()
@@ -52,13 +46,9 @@ def get_mysql_management_client(cli_ctx, **_):
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
     if rm_uri_override:
-        client_id = getenv(CLIENT_ID)
+        client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
-            from azure.identity import ClientSecretCredential
-            credentials = ClientSecretCredential(
-                client_id=client_id,
-                client_secret=getenv(CLIENT_SECRET),
-                tenant_id=getenv(TENANT_ID))
+            credentials = get_environment_credential()
         else:
             from msrest.authentication import Authentication  # pylint: disable=import-error
             credentials = Authentication()
@@ -80,13 +70,9 @@ def get_mysql_flexible_management_client(cli_ctx, **_):
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
     if rm_uri_override:
-        client_id = getenv(CLIENT_ID)
+        client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
-            from azure.identity import ClientSecretCredential
-            credentials = ClientSecretCredential(
-                client_id=client_id,
-                client_secret=getenv(CLIENT_SECRET),
-                tenant_id=getenv(TENANT_ID))
+            credentials = get_environment_credential()
         else:
             from msrest.authentication import Authentication  # pylint: disable=import-error
             credentials = Authentication()
@@ -108,13 +94,9 @@ def get_postgresql_management_client(cli_ctx, **_):
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
     if rm_uri_override:
-        client_id = getenv(CLIENT_ID)
+        client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
-            from azure.identity import ClientSecretCredential
-            credentials = ClientSecretCredential(
-                client_id=client_id,
-                client_secret=getenv(CLIENT_SECRET),
-                tenant_id=getenv(TENANT_ID))
+            credentials = get_environment_credential()
         else:
             from msrest.authentication import Authentication  # pylint: disable=import-error
             credentials = Authentication()
@@ -135,13 +117,9 @@ def get_postgresql_flexible_management_client(cli_ctx, **_):
     # variable.
     rm_uri_override = getenv(RM_URI_OVERRIDE)
     if rm_uri_override:
-        client_id = getenv(CLIENT_ID)
+        client_id = getenv(AZURE_CLIENT_ID)
         if client_id:
-            from azure.identity import ClientSecretCredential
-            credentials = ClientSecretCredential(
-                client_id=client_id,
-                client_secret=getenv(CLIENT_SECRET),
-                tenant_id=getenv(TENANT_ID))
+            credentials = get_environment_credential()
         else:
             from msrest.authentication import Authentication  # pylint: disable=import-error
             credentials = Authentication()

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -13,7 +13,6 @@ azure-cosmos==3.2.0
 azure-data-tables==12.2.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
-azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
 azure-keyvault-keys==4.5.0
 azure-keyvault==1.1.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -13,7 +13,6 @@ azure-cosmos==3.2.0
 azure-data-tables==12.2.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
-azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
 azure-keyvault-keys==4.5.0
 azure-keyvault==1.1.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -13,7 +13,6 @@ azure-cosmos==3.2.0
 azure-data-tables==12.2.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
-azure-identity==1.6.1
 azure-keyvault-administration==4.0.0b3
 azure-keyvault-keys==4.5.0
 azure-keyvault==1.1.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -59,7 +59,6 @@ DEPENDENCIES = [
     'azure-data-tables==12.2.0',
     'azure-datalake-store~=0.0.49',
     'azure-graphrbac~=0.60.0',
-    'azure-identity',
     'azure-keyvault-administration==4.0.0b3',
     'azure-keyvault-keys==4.5.0',
     'azure-keyvault~=1.1.0',


### PR DESCRIPTION
## Description

https://github.com/Azure/azure-cli/pull/22009 relies on the latest `msal-extensions` 1.0.0, but `azure-identity` will release a new version (https://github.com/Azure/azure-sdk-for-python/pull/24083) as early as 2020-04-22. This will miss our 2022-04-20 code freeze deadline and 2022-04-22 release schedule for [Apr 2022 sprint](https://github.com/Azure/azure-cli/milestone/117).

`rdbms` is the only module using `azure-identity`. https://github.com/Azure/azure-cli/pull/4908 first uses env vars to create `azure.common.credentials.ServicePrincipalCredentials` and passes the credential to client constructor. https://github.com/Azure/azure-cli/pull/17191 migrated to using `azure.identity.ClientSecretCredential`.

Since Azure CLI has migrated to MSAL (https://github.com/Azure/azure-cli/pull/19853), `rdbms` can now use `ServicePrincipalCredential` provided by `azure.cli.core` with environment credential.

We will fully support environment credential in the future (https://github.com/Azure/azure-cli/issues/10241).

## Testing Guide

Set env vars:

```
AZURE_CLIENT_ID=...
AZURE_TENANT_ID=54826b22-38d6-4fb2-bad9-b7b93a3e9c5a
AZURE_CLIENT_SECRET=...
AZURE_CLI_RDBMS_RM_URI=https://management.azure.com/
AZURE_CLI_RDBMS_SUB_ID=0b1f6471-1bf0-4dda-aec3-cb9272f09590
```

Run

```
az mysql server list
```
