### PR TITLE
{CI} Include all files under `data` as `package_data`

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -171,9 +171,7 @@ cat >>$testsrc_dir/setup.py <<EOL
                        '**/*.txt',
                        '**/*.txt',
                        '**/*.xml',
-                       'data/*.whl',
-                       'data/*.yaml',
-                       'data/*.zip',
+                       'data/*',
                        'recordings/*.yaml']},
     install_requires=DEPENDENCIES
 )


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/pull/22056 added some file types that are not included while building the test package:

- `data/assetTrack.ttml`
- `data/sampleIsmFile.ism`

causing CI to fail:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1523127&view=logs&jobId=47870e38-5a53-5929-70f9-c65c4a436be8&j=47870e38-5a53-5929-70f9-c65c4a436be8&t=4b4323e2-b1dc-59ac-6bbb-9f51b3f2dde3

```
ex = FileNotFoundError(2, 'No such file or directory')

    def file_related_exception_handler(ex):
        from azure.cli.core.azclierror import FileOperationError
        if isinstance(ex, FileNotFoundError):
>           raise FileOperationError(ex, recommendation='Please check the file path.')
E           azure.cli.core.azclierror.FileOperationError: [Errno 2] No such file or directory: '/opt/az/lib/python3.8/site-packages/azure/cli/command_modules/ams/tests/latest/data/assetTrack.ttml'
```

This mistake has happened several times:

- #8370
- #19802
- #21825
- #20599

Now we include all files under `data` as `package_data`.

See

- https://docs.python.org/3/distutils/setupscript.html#installing-package-data
- https://setuptools.pypa.io/en/latest/userguide/datafiles.html