### PR TITLE
[Storage] Fix #21819: `az storage fs directory`: Add new command `generate-sas`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -2209,6 +2209,16 @@ helps['storage fs directory download'] = """
           text: az storage fs directory download -f myfilesystem --account-name mystorageaccount -s "path/to/subdirectory" -d "<local-path>" --recursive
 """
 
+helps['storage fs directory generate-sas'] = """
+type: command
+short-summary: Generate a SAS token for directory in ADLS Gen2 account.
+examples:
+  - name: Generate a sas token for directory and use it to upload files.
+    text: |
+        end=`date -u -d "30 minutes" '+%Y-%m-%dT%H:%MZ'`
+        az storage fs directory generate-sas --name dir/ --file-system myfilesystem --https-only --permissions dlrw --expiry $end -o tsv
+"""
+
 helps['storage fs file'] = """
 type: group
 short-summary: Manage files in Azure Data Lake Storage Gen2 account.

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -2126,6 +2126,36 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                                                      'including the files in subdirectories will be downloaded.')
         c.ignore('source')
 
+    with self.argument_context('storage fs directory generate-sas') as c:
+        t_file_system_permissions = self.get_sdk('_models#FileSystemSasPermissions',
+                                                 resource_type=ResourceType.DATA_STORAGE_FILEDATALAKE)
+        c.register_sas_arguments()
+        c.argument('file_system_name', options_list=['--file-system', '-f'],
+                   help="File system name (i.e. container name).", required=True)
+        c.argument('directory_name', options_list=['--name', '-n'], help="The name of directory.", required=True)
+        c.argument('id', options_list='--policy-name',
+                   help='The name of a stored access policy.')
+        c.argument('permission', options_list='--permissions',
+                   help=sas_help.format(get_permission_help_string(t_file_system_permissions)),
+                   validator=get_permission_validator(t_file_system_permissions))
+        c.argument('cache_control', help='Response header value for Cache-Control when resource is accessed'
+                                         'using this shared access signature.')
+        c.argument('content_disposition', help='Response header value for Content-Disposition when resource is accessed'
+                                               'using this shared access signature.')
+        c.argument('content_encoding', help='Response header value for Content-Encoding when resource is accessed'
+                                            'using this shared access signature.')
+        c.argument('content_language', help='Response header value for Content-Language when resource is accessed'
+                                            'using this shared access signature.')
+        c.argument('content_type', help='Response header value for Content-Type when resource is accessed'
+                                        'using this shared access signature.')
+        c.argument('as_user', action='store_true',
+                   validator=as_user_validator,
+                   help="Indicates that this command return the SAS signed with the user delegation key. "
+                        "The expiry parameter and '--auth-mode login' are required if this argument is specified. ")
+        c.ignore('sas_token')
+        c.argument('full_uri', action='store_true',
+                   help='Indicate that this command return the full blob URI and the shared access signature token.')
+
     with self.argument_context('storage fs file list') as c:
         c.extra('file_system_name', options_list=['-f', '--file-system'],
                 help="File system name (i.e. container name).", required=True)

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -869,6 +869,10 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.storage_command_oauth('metadata update', 'set_metadata')
         g.storage_command_oauth('metadata show', 'get_directory_properties', exception_handler=show_exception_handler,
                                 transform=transform_metadata)
+        g.storage_custom_command_oauth('generate-sas', 'generate_sas_directory_uri',
+                                       custom_command_type=get_custom_sdk('fs_directory',
+                                                                          client_factory=cf_adls_service),
+                                       min_api='2020-02-10')
 
     with self.command_group('storage fs directory', custom_command_type=get_custom_sdk('azcopy', None))as g:
         g.storage_custom_command('upload', 'storage_fs_directory_copy', is_preview=True)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -775,7 +775,7 @@ def generate_sas_blob_uri(cmd, client, permission=None, expiry=None, start=None,
 
     if full_uri:
         blob_client = t_blob_client(account_url=client.url, container_name=container_name, blob_name=blob_name,
-                                    snapshot=snapshot, credential=sas_token)
+                                    snapshot=snapshot, credential=quote(sas_token, safe='&%()$=\',~'))
         return encode_url_path(blob_client.url)
     return quote(sas_token, safe='&%()$=\',~')
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/fs_directory.py
@@ -5,9 +5,12 @@
 
 """Custom operations for storage file datalake"""
 
+from datetime import datetime
 from azure.cli.core.profiles import ResourceType
 
 from knack.util import todict
+
+from ..util import get_datetime_from_string
 
 
 def exists(cmd, client, timeout=None):
@@ -80,3 +83,43 @@ def update_access_control_recursive(client, acl, **kwargs):
     result = todict(result)
     result['failedEntries'] = failed_entries
     return result
+
+
+def fix_url_path(url):
+    # Change https://xx.dfs.core.windows.net/test/dir1%2Fdir2 to https://xx.dfs.core.windows.net/test/dir1/dir2
+    from urllib.parse import urlparse, urlunparse, unquote, quote
+    url_parts = urlparse(url)
+    fixed_path = quote(unquote(url_parts.path), '/()$=\',~')
+    return urlunparse(url_parts[:2] + (fixed_path,) + url_parts[3:])
+
+
+def generate_sas_directory_uri(client, cmd, file_system_name, directory_name, permission=None,
+                               expiry=None, start=None, id=None, ip=None,  # pylint: disable=redefined-builtin
+                               protocol=None, cache_control=None, content_disposition=None,
+                               content_encoding=None, content_language=None,
+                               content_type=None, full_uri=False, as_user=False, ):
+    from urllib.parse import quote
+    generate_directory_sas = cmd.get_models('_shared_access_signature#generate_directory_sas')
+
+    sas_kwargs = {}
+    if as_user:
+        user_delegation_key = client.get_user_delegation_key(
+            get_datetime_from_string(start) if start else datetime.utcnow(),
+            get_datetime_from_string(expiry))
+
+    sas_token = generate_directory_sas(account_name=client.account_name, file_system_name=file_system_name,
+                                       directory_name=directory_name,
+                                       credential=user_delegation_key if as_user else client.credential.account_key,
+                                       permission=permission, expiry=expiry, start=start, policy_id=id,
+                                       ip=ip, protocol=protocol,
+                                       cache_control=cache_control, content_disposition=content_disposition,
+                                       content_encoding=content_encoding, content_language=content_language,
+                                       content_type=content_type, **sas_kwargs)
+    sas_token = quote(sas_token, safe='&%()$=\',~')
+    if full_uri:
+        t_directory_client = cmd.get_models('_data_lake_directory_client#DataLakeDirectoryClient')
+        directory_client = t_directory_client(account_url=client.url, file_system_name=file_system_name,
+                                              directory_name=directory_name, credential=sas_token)
+        return fix_url_path(directory_client.url)
+
+    return sas_token

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_fs_directory_generate_sas_as_user.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_fs_directory_generate_sas_as_user.yaml
@@ -1,0 +1,184 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account keys list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g --query -o
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-storage/20.0.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2021-09-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2022-04-22T07:13:23.2978609Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-04-22T07:13:23.2978609Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Fri, 22 Apr 2022 07:13:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11997'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage fs create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-storage-dfs/12.6.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+      x-ms-date:
+      - Fri, 22 Apr 2022 07:13:44 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/filesystem000003?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 22 Apr 2022 07:13:45 GMT
+      etag:
+      - '"0x8DA242FA3E2B343"'
+      last-modified:
+      - Fri, 22 Apr 2022 07:13:45 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage fs directory create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -f --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-storage-dfs/12.6.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+      x-ms-date:
+      - Fri, 22 Apr 2022 07:13:45 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-10-02'
+    method: PUT
+    uri: https://clitest000002.dfs.core.windows.net/filesystem000003/testdir%2Fsubdir?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 22 Apr 2022 07:13:47 GMT
+      etag:
+      - '"0x8DA242FA4E1B435"'
+      last-modified:
+      - Fri, 22 Apr 2022 07:13:47 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <KeyInfo><Start>2022-04-22T07:13:47Z</Start><Expiry>2022-04-22T08:13:00Z</Expiry></KeyInfo>'
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage fs directory generate-sas
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '130'
+      Content-Type:
+      - application/xml
+      ParameterSetName:
+      - --account-name -n -f --expiry --permissions --https-only --as-user --auth-mode
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.9.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+      x-ms-date:
+      - Fri, 22 Apr 2022 07:13:47 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: POST
+    uri: https://clitest000002.blob.core.windows.net/?restype=service&comp=userdelegationkey
+  response:
+    body:
+      string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><UserDelegationKey><SignedOid>fe87037c-4c23-46ac-9fcf-5ad3d7e5ba3e</SignedOid><SignedTid>54826b22-38d6-4fb2-bad9-b7b93a3e9c5a</SignedTid><SignedStart>2022-04-22T07:13:47Z</SignedStart><SignedExpiry>2022-04-22T08:13:00Z</SignedExpiry><SignedService>b</SignedService><SignedVersion>2020-10-02</SignedVersion><Value>kTQDz/KnUpSKnoKAl3k84AO826kzce+9N6KUiViKBlA=</Value></UserDelegationKey>"
+    headers:
+      content-type:
+      - application/xml
+      date:
+      - Fri, 22 Apr 2022 07:13:48 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      transfer-encoding:
+      - chunked
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_fs_directory_generate_sas_full_uri.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_fs_directory_generate_sas_full_uri.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account keys list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g --query -o
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-storage/20.0.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2021-09-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2022-04-22T07:12:34.2026095Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-04-22T07:12:34.2026095Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Fri, 22 Apr 2022 07:12:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage fs create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-storage-dfs/12.6.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+      x-ms-date:
+      - Fri, 22 Apr 2022 07:12:55 GMT
+      x-ms-version:
+      - '2020-10-02'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/filesystem000003?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 22 Apr 2022 07:12:56 GMT
+      etag:
+      - '"0x8DA242F86C57D85"'
+      last-modified:
+      - Fri, 22 Apr 2022 07:12:56 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage fs directory create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -f --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.35.0 azsdk-python-storage-dfs/12.6.0 Python/3.9.12 (macOS-12.3.1-arm64-arm-64bit)
+      x-ms-date:
+      - Fri, 22 Apr 2022 07:12:57 GMT
+      x-ms-properties:
+      - ''
+      x-ms-version:
+      - '2020-10-02'
+    method: PUT
+    uri: https://clitest000002.dfs.core.windows.net/filesystem000003/testdir%2Fsubdir?resource=directory
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 22 Apr 2022 07:12:58 GMT
+      etag:
+      - '"0x8DA242F880383B8"'
+      last-modified:
+      - Fri, 22 Apr 2022 07:12:59 GMT
+      server:
+      - Windows-Azure-HDFS/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2020-10-02'
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
Fix #21819,  use `az storage fs directory generate-sas` to generate SAS for directory, which is equivalent to `sr=d` and `sdd` is inferred from `name` param.

**Testing Guide**
`az storage fs directory create --name dir1/dir2 --file-system <filesystem> --account-name  <account>`
`az storage fs directory generate-sas --name dir1/dir2 --file-system <filesystem> --account-name  <account>`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
