### PR TITLE
[Packaging] Bump embedded Python to 3.10 for deb packages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -814,10 +814,6 @@ jobs:
   strategy:
     matrix:
       # https://wiki.ubuntu.com/Releases
-      Xenial:
-        # 16.04
-        deb_system: ubuntu
-        distro: xenial
       Bionic:
         # 18.04
         deb_system: ubuntu
@@ -836,10 +832,6 @@ jobs:
         distro: jammy
 
       # https://wiki.debian.org/DebianReleases
-      Stretch:
-        # 9
-        deb_system: debian
-        distro: stretch
       Buster:
         # 10
         deb_system: debian

--- a/scripts/release/debian/Dockerfile
+++ b/scripts/release/debian/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y libssl-dev libffi-dev python3-dev debhelper zlib1g-dev wget
 
 # Download Python source code
-ARG python_version="3.8.12"
+ARG python_version="3.10.4"
 ENV PYTHON_SRC_DIR=/usr/src/python
 RUN mkdir -p ${PYTHON_SRC_DIR} && \
     wget -qO- https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz \

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.8.13"
+PYTHON_VERSION="3.10.4"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages

--- a/scripts/release/debian/prepare.sh
+++ b/scripts/release/debian/prepare.sh
@@ -90,7 +90,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 EOM
 
-# TODO: Instead of "_ssl.cpython-38-x86_64-linux-gnu.so" only, find all .so files with "find debian/azure-cli/opt/az -type f -name '*.so'"
+# TODO: Instead of "_ssl.cpython-310-x86_64-linux-gnu.so" only, find all .so files with "find debian/azure-cli/opt/az -type f -name '*.so'"
 
 cat > $debian_dir/rules << EOM
 #!/usr/bin/make -f
@@ -110,7 +110,7 @@ ${TAB}echo "\043!/usr/bin/env bash\nbin_dir=\140cd \"\044(dirname \"\044BASH_SOU
 ${TAB}chmod 0755 debian/azure-cli/usr/bin/az
 ${TAB}mkdir -p debian/azure-cli/etc/bash_completion.d/
 ${TAB}cat ${completion_script} > debian/azure-cli/etc/bash_completion.d/azure-cli
-${TAB}dpkg-shlibdeps -v --warnings=7 -Tdebian/azure-cli.substvars -dDepends -edebian/azure-cli/opt/az/bin/python3 debian/azure-cli/opt/az/lib/python3.8/lib-dynload/_ssl.cpython-38-x86_64-linux-gnu.so
+${TAB}dpkg-shlibdeps -v --warnings=7 -Tdebian/azure-cli.substvars -dDepends -edebian/azure-cli/opt/az/bin/python3 debian/azure-cli/opt/az/lib/python3.10/lib-dynload/_ssl.cpython-310-x86_64-linux-gnu.so
 
 
 override_dh_strip:

--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -7,7 +7,7 @@ import os
 import sys
 import subprocess
 
-root_dir = '/opt/az/lib/python3.8/site-packages/azure/cli/command_modules'
+root_dir = '/opt/az/lib/python3.10/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
 pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --boxed -p no:warnings --log-level=WARN'


### PR DESCRIPTION
**Description**<!--Mandatory-->

Other packages are already running on Python 3.10:

1. Windows MSI 
2. Homebrew
3. PyPI
4. Docker image

DEB should also use latest Python 3.10. However, Python 3.10 can't be built on 

- Ubuntu 16.04 Xenial
- Debian 9 Stretch

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1526760&view=logs&j=91b655fa-e277-54b4-6e7f-39b6e68dea4d&t=21d122d2-92ba-55a1-c034-df1ef1abfc1e

```
2022-04-25T03:13:20.0783879Z Failed to build these modules:
2022-04-25T03:13:20.0785025Z _hashlib              _ssl                                     
2022-04-25T03:13:20.0785784Z 
2022-04-25T03:13:20.0786409Z 
2022-04-25T03:13:20.0787449Z Could not build the ssl module!
2022-04-25T03:13:20.0788592Z Python requires a OpenSSL 1.1.1 or newer
```

According to their official docs, both systems are already out of their standard support. 

https://wiki.ubuntu.com/Releases

![image](https://user-images.githubusercontent.com/4003950/165017434-3acec178-27c5-4da8-8504-b6c96a238ad3.png)

https://wiki.debian.org/DebianReleases

![image](https://user-images.githubusercontent.com/4003950/165016722-5240b58c-74f6-4de7-8918-bc1bf405e6c9.png)

Azure DevOps has also dropped Ubuntu 16.04 on September 20, 2021 (https://github.com/actions/virtual-environments/issues/3287).

