### PR TITLE
[Packaging] Bump embedded Python to 3.9 for deb packages

### DIFF
--- a/scripts/release/debian/Dockerfile
+++ b/scripts/release/debian/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 RUN apt-get install -y libssl-dev libffi-dev python3-dev debhelper zlib1g-dev wget
 
 # Download Python source code
-ARG python_version="3.8.12"
+ARG python_version="3.9.12"
 ENV PYTHON_SRC_DIR=/usr/src/python
 RUN mkdir -p ${PYTHON_SRC_DIR} && \
     wget -qO- https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz \

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -15,7 +15,7 @@ set -exv
 ls -Rl /mnt/artifacts
 
 WORKDIR=`cd $(dirname $0); cd ../../../; pwd`
-PYTHON_VERSION="3.8.13"
+PYTHON_VERSION="3.9.12"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Update APT packages

--- a/scripts/release/debian/prepare.sh
+++ b/scripts/release/debian/prepare.sh
@@ -90,7 +90,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 EOM
 
-# TODO: Instead of "_ssl.cpython-38-x86_64-linux-gnu.so" only, find all .so files with "find debian/azure-cli/opt/az -type f -name '*.so'"
+# TODO: Instead of "_ssl.cpython-39-x86_64-linux-gnu.so" only, find all .so files with "find debian/azure-cli/opt/az -type f -name '*.so'"
 
 cat > $debian_dir/rules << EOM
 #!/usr/bin/make -f
@@ -110,7 +110,7 @@ ${TAB}echo "\043!/usr/bin/env bash\nbin_dir=\140cd \"\044(dirname \"\044BASH_SOU
 ${TAB}chmod 0755 debian/azure-cli/usr/bin/az
 ${TAB}mkdir -p debian/azure-cli/etc/bash_completion.d/
 ${TAB}cat ${completion_script} > debian/azure-cli/etc/bash_completion.d/azure-cli
-${TAB}dpkg-shlibdeps -v --warnings=7 -Tdebian/azure-cli.substvars -dDepends -edebian/azure-cli/opt/az/bin/python3 debian/azure-cli/opt/az/lib/python3.8/lib-dynload/_ssl.cpython-38-x86_64-linux-gnu.so
+${TAB}dpkg-shlibdeps -v --warnings=7 -Tdebian/azure-cli.substvars -dDepends -edebian/azure-cli/opt/az/bin/python3 debian/azure-cli/opt/az/lib/python3.9/lib-dynload/_ssl.cpython-39-x86_64-linux-gnu.so
 
 
 override_dh_strip:

--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -7,7 +7,7 @@ import os
 import sys
 import subprocess
 
-root_dir = '/opt/az/lib/python3.8/site-packages/azure/cli/command_modules'
+root_dir = '/opt/az/lib/python3.9/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
 pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --boxed -p no:warnings --log-level=WARN'


### PR DESCRIPTION
**Description**<!--Mandatory-->

https://github.com/Azure/azure-cli/pull/22035 dropped tests for Python 3.9. However, Mariner's built-in Python is 3.9.

```
> docker run -it --rm cblmariner2preview.azurecr.io/base/core:2.0 python3 -V
Python 3.9.10
```

To make sure Azure CLI works perfectly with Python 3.9, we will have to bring back tests for Python 3.9. Then we will have 

- Python 3.6: RHEL 7/8 RPMs (this can't be updated)
- Python 3.8: DEB
- Python 3.9: Mariner RPMs
- Python 3.10: Windows MSI, Homebrew, PyPI, Docker image

Such inconsistency introduces maintenance difficulty. Testing for all these Python versions also adds lots of burden to the CI pipeline. 

If DEB's Python is bumped to Python 3.9, Python 3.8's test can be replaced by Python 3.9 tests. Or, we can take one step even further - to use the latest Python 3.10 directly (https://github.com/Azure/azure-cli/pull/22170) for better security and performance.

Mariner should also use Python 3.10 (https://github.com/microsoft/CBL-Mariner/issues/2860).


