### PR TITLE
{CI} Add back Python 3.9 tests for Mariner

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -22,8 +22,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -42,8 +42,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -62,8 +62,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -106,8 +106,8 @@ jobs:
         instance_idx: '$(Instance_idx)'
         fullTest: true
 
-- job: AutomationFullTestPython38ProfileLatest
-  displayName: Automation Full Test Python38 Profile Latest
+- job: AutomationFullTestPython39ProfileLatest
+  displayName: Automation Full Test Python39 Profile Latest
   timeoutInMinutes: 9999
   strategy:
     maxParallel: 8
@@ -133,7 +133,7 @@ jobs:
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
-        pythonVersion: '3.8'
+        pythonVersion: '3.9'
         profile: 'latest'
         instance_cnt: '8'
         instance_idx: '$(Instance_idx)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -386,9 +386,9 @@ jobs:
          --rm -v $PYPI_FILES:/mnt/pypi python:3.7 \
          /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
 
-       echo "== Testing pip install on Python 3.8 =="
+       echo "== Testing pip install on Python 3.9 =="
        docker run \
-         --rm -v $PYPI_FILES:/mnt/pypi python:3.8 \
+         --rm -v $PYPI_FILES:/mnt/pypi python:3.9 \
          /bin/bash -c "ls /mnt/pypi && pip install -f /mnt/pypi -q azure-cli==$CLI_VERSION.* && az self-test && az --version && sleep 5"
 
        echo "== Testing pip install on Python 3.10 =="
@@ -407,8 +407,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -426,8 +426,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -448,8 +448,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -471,8 +471,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -490,8 +490,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -509,8 +509,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -528,8 +528,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   steps:
@@ -957,8 +957,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
       Python310:
         python.version: '3.10'
   pool:


### PR DESCRIPTION
**Description**<!--Mandatory-->

Revert https://github.com/Azure/azure-cli/pull/22035

As Mariner uses Python 3.9, we should bring back Python 3.9 tests.

```
> docker run -it --rm cblmariner2preview.azurecr.io/base/core:2.0 python3 -V
Python 3.9.10
```

DEB's Python will be bumped from 3.8 to Python 3.10, so no need to test for Python 3.8.
