### PR TITLE
[Compute] `az vm image list`: Add new server version aliases `Win2022AzureEditionCore` for offline list

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_alias.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_alias.py
@@ -62,6 +62,18 @@ alias_json = """
           }
         },
         "Windows": {
+          "Win2022Datacenter": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2022-Datacenter",
+            "version": "latest"
+          },
+          "Win2022AzureEditionCore": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2022-datacenter-azure-edition-core",
+            "version": "latest"
+          },
           "Win2019Datacenter": {
             "publisher": "MicrosoftWindowsServer",
             "offer": "WindowsServer",


### PR DESCRIPTION
**Description**

This change adds alias for VM images: Win2022Datacenter and Win2022AzureEditionCore.

Note: the word 'datacenter' is in all new images, so there is no reason to repeat it in each alias. I chose to remove it when introducing 'AzureEdition' to try and keep spacing similar to the original alias length.

**Testing Guide**
az vm create -n MyVm -g MyResourceGroup --image Win2022AzureEditionCore

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
