### PR TITLE
[ARM] `az resource wait`: Fix `--created` keeps waiting even when `az resource show` returns "provisioningState": "Succeeded"

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -463,10 +463,16 @@ class WaitCommandOperation(BaseCommandOperation):
             properties = getattr(instance, 'properties', None)
             if properties:
                 provisioning_state = getattr(properties, 'provisioning_state', None)
+                if provisioning_state:
+                    return provisioning_state
                 # some SDK, like keyvault, has 'provisioningState' under 'properties.additional_properties'
-                if not provisioning_state:
-                    additional_properties = getattr(properties, 'additional_properties', {})
-                    provisioning_state = additional_properties.get('provisioningState')
+                additional_properties = getattr(properties, 'additional_properties', {})
+                provisioning_state = additional_properties.get('provisioningState')
+                if provisioning_state:
+                    return provisioning_state
+                # some SDK, like resource, has 'provisioningState' under 'properties' dict
+                provisioning_state = properties['provisioningState']
+
         return provisioning_state
 
     def arguments_loader(self):

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -471,7 +471,8 @@ class WaitCommandOperation(BaseCommandOperation):
                 if provisioning_state:
                     return provisioning_state
                 # some SDK, like resource, has 'provisioningState' under 'properties' dict
-                provisioning_state = properties['provisioningState']
+                if 'provisioningState' in properties:
+                    provisioning_state = properties['provisioningState']
 
         return provisioning_state
 

--- a/src/azure-cli-core/azure/cli/core/commands/command_operation.py
+++ b/src/azure-cli-core/azure/cli/core/commands/command_operation.py
@@ -463,17 +463,14 @@ class WaitCommandOperation(BaseCommandOperation):
             properties = getattr(instance, 'properties', None)
             if properties:
                 provisioning_state = getattr(properties, 'provisioning_state', None)
-                if provisioning_state:
-                    return provisioning_state
                 # some SDK, like keyvault, has 'provisioningState' under 'properties.additional_properties'
-                additional_properties = getattr(properties, 'additional_properties', {})
-                provisioning_state = additional_properties.get('provisioningState')
-                if provisioning_state:
-                    return provisioning_state
-                # some SDK, like resource, has 'provisioningState' under 'properties' dict
-                if 'provisioningState' in properties:
-                    provisioning_state = properties['provisioningState']
+                if not provisioning_state:
+                    additional_properties = getattr(properties, 'additional_properties', {})
+                    provisioning_state = additional_properties.get('provisioningState')
 
+                # some SDK, like resource, has 'provisioningState' under 'properties' dict
+                if not provisioning_state:
+                    provisioning_state = properties.get('provisioningState')
         return provisioning_state
 
     def arguments_loader(self):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -300,6 +300,10 @@ class ResourceCreateAndShowScenarioTest(ScenarioTest):
         self.cmd('resource create --id {app_settings_id} --properties "{{\\"key2\\":\\"value12\\"}}"',
                  checks=[self.check('properties.key2', 'value12')])
 
+        self.cmd('resource wait --id {app_settings_id} --created')
+
+        self.cmd('resource wait --id {app_settings_id} --exists')
+
         self.cmd('resource show --id {app_config_id}',
                  checks=self.check('properties.publishingUsername', '${app}'))
         self.cmd('resource show --id {app_config_id} --include-response-body',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When executing `az resource wait` command, calling `_get_provisioning_state()` method can't get provisioning_state.
code link: [command_operation.py](https://github.com/kairu-ms/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/commands/command_operation.py#L459)
![image](https://user-images.githubusercontent.com/16612065/166448806-042a17d9-160a-4320-b808-8b77a4c78a79.png)

Because `instance.properties` is `dict` type at this time, so it can only be obtained through `instance.properties['provisioningState']`
![image](https://user-images.githubusercontent.com/16612065/166448961-7b32438c-c5b0-4ae7-8824-4ef1a779bd20.png)

In addition, this problem has **existed since very early CLI versions** and even it may never worked correctly before (there had been no related scenario tests). I even tried the `2.23.0` version of CLI, which relies on the **Track 1** Python SDK, this problem can still be reproduced. 
Therefore, this is a very old legacy problem, so I submitted this PR to add correct parsing logic to method `_get_provisioning_state()`


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
