### PR TITLE
{Compute} Fix `CloudError` in VM module

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -21,7 +21,7 @@ except ImportError:
 from knack.util import CLIError
 from knack.log import get_logger
 
-from msrestazure.azure_exceptions import CloudError
+from azure.core.exceptions import HttpResponseError
 from msrestazure.tools import is_valid_resource_id, resource_id, parse_resource_id
 
 from azure.cli.core.commands import cached_get, cached_put
@@ -281,7 +281,7 @@ def process_image_template_create_namespace(cmd, namespace):  # pylint: disable=
             }
 
             logger.info("%s, looks like a managed image name. Using resource ID: %s", image_name, namespace.source)  # pylint: disable=line-too-long
-        except CloudError:
+        except HttpResponseError:
             pass
 
     if not source:

--- a/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_image_builder.py
@@ -21,8 +21,9 @@ except ImportError:
 from knack.util import CLIError
 from knack.log import get_logger
 
-from azure.core.exceptions import HttpResponseError
 from msrestazure.tools import is_valid_resource_id, resource_id, parse_resource_id
+
+from azure.core.exceptions import HttpResponseError
 
 from azure.cli.core.commands import cached_get, cached_put
 from azure.cli.core.commands.client_factory import get_subscription_id

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -240,7 +240,7 @@ def _parse_image_argument(cmd, namespace):
     """ Systematically determines what type is supplied for the --image parameter. Updates the
         namespace and returns the type for subsequent processing. """
     from msrestazure.tools import is_valid_resource_id
-    from msrestazure.azure_exceptions import CloudError
+    from azure.core.exceptions import HttpResponseError
     import re
 
     # 1 - check if a fully-qualified ID (assumes it is an image ID)
@@ -304,7 +304,7 @@ def _parse_image_argument(cmd, namespace):
         namespace.image = _get_resource_id(cmd.cli_ctx, namespace.image, namespace.resource_group_name,
                                            'images', 'Microsoft.Compute')
         return 'image_id'
-    except CloudError:
+    except HttpResponseError:
         if images is not None:
             err = 'Invalid image "{}". Use a valid image URN, custom image name, custom image id, ' \
                   'VHD blob URI, or pick an image from {}.\nSee vm create -h for more information ' \
@@ -317,7 +317,7 @@ def _parse_image_argument(cmd, namespace):
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):
-    from msrestazure.azure_exceptions import CloudError
+    from azure.core.exceptions import ResourceNotFoundError
     try:
         compute_client = _compute_client_factory(cmd.cli_ctx)
         if namespace.os_version.lower() == 'latest':
@@ -334,7 +334,7 @@ def _get_image_plan_info_if_exists(cmd, namespace):
 
         # pylint: disable=no-member
         return image.plan
-    except CloudError as ex:
+    except ResourceNotFoundError as ex:
         logger.warning("Querying the image of '%s' failed for an error '%s'. Configuring plan settings "
                        "will be skipped", namespace.image, ex.message)
 
@@ -1719,7 +1719,7 @@ def validate_vmss_disk(cmd, namespace):
 
 
 def process_disk_or_snapshot_create_namespace(cmd, namespace):
-    from msrestazure.azure_exceptions import CloudError
+    from azure.core.exceptions import HttpResponseError
     validate_tags(namespace)
     validate_edge_zone(cmd, namespace)
     if namespace.source:
@@ -1749,7 +1749,7 @@ def process_disk_or_snapshot_create_namespace(cmd, namespace):
                     get_default_location_from_resource_group(cmd, namespace)
                 # if the source location differs from target location, then it's copy_start scenario
                 namespace.copy_start = source_info.location != namespace.location
-        except CloudError:
+        except HttpResponseError:
             raise CLIError(usage_error)
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_validators.py
@@ -317,7 +317,6 @@ def _parse_image_argument(cmd, namespace):
 
 
 def _get_image_plan_info_if_exists(cmd, namespace):
-    from azure.core.exceptions import ResourceNotFoundError
     try:
         compute_client = _compute_client_factory(cmd.cli_ctx)
         if namespace.os_version.lower() == 'latest':

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1730,7 +1730,7 @@ def get_boot_log(cmd, resource_group_name, vm_name):
     import re
     import sys
     from azure.cli.core.profiles import get_sdk
-    from msrestazure.azure_exceptions import CloudError
+    from azure.core.exceptions import HttpResponseError
     BlockBlobService = get_sdk(cmd.cli_ctx, ResourceType.DATA_STORAGE, 'blob.blockblobservice#BlockBlobService')
 
     client = _compute_client_factory(cmd.cli_ctx)
@@ -1747,7 +1747,7 @@ def get_boot_log(cmd, resource_group_name, vm_name):
         try:
             boot_diagnostics_data = client.virtual_machines.retrieve_boot_diagnostics_data(resource_group_name, vm_name)
             blob_uri = boot_diagnostics_data.serial_console_log_blob_uri
-        except CloudError:
+        except HttpResponseError:
             pass
         if blob_uri is None:
             raise CLIError('Please enable boot diagnostics.')

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2018_03_01/test_vm_actions.py
@@ -207,7 +207,7 @@ class TestActions(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.vm._validators.logger.warning', autospec=True)
     def test_parse_staging_image_argument(self, logger_mock, client_factory_mock):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         compute_client = mock.MagicMock()
         resp = mock.MagicMock()
         cmd = mock.MagicMock()
@@ -215,7 +215,7 @@ class TestActions(unittest.TestCase):
         resp.status_code = 404
         resp.text = '{"Message": "Not Found"}'
 
-        compute_client.virtual_machine_images.get.side_effect = CloudError(resp, error='image not found')
+        compute_client.virtual_machine_images.get.side_effect = ResourceNotFoundError('image not found')
         client_factory_mock.return_value = compute_client
 
         np = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2019_03_01/test_vm_actions.py
@@ -206,7 +206,7 @@ class TestActions(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.vm._validators.logger.warning', autospec=True)
     def test_parse_staging_image_argument(self, logger_mock, client_factory_mock):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         compute_client = mock.MagicMock()
         resp = mock.MagicMock()
         cmd = mock.MagicMock()
@@ -214,7 +214,7 @@ class TestActions(unittest.TestCase):
         resp.status_code = 404
         resp.text = '{"Message": "Not Found"}'
 
-        compute_client.virtual_machine_images.get.side_effect = CloudError(resp, error='image not found')
+        compute_client.virtual_machine_images.get.side_effect = ResourceNotFoundError('image not found')
         client_factory_mock.return_value = compute_client
 
         np = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/hybrid_2020_09_01/test_vm_actions.py
@@ -206,7 +206,7 @@ class TestActions(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.vm._validators.logger.warning', autospec=True)
     def test_parse_staging_image_argument(self, logger_mock, client_factory_mock):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         compute_client = mock.MagicMock()
         resp = mock.MagicMock()
         cmd = mock.MagicMock()
@@ -214,7 +214,7 @@ class TestActions(unittest.TestCase):
         resp.status_code = 404
         resp.text = '{"Message": "Not Found"}'
 
-        compute_client.virtual_machine_images.get.side_effect = CloudError(resp, error='image not found')
+        compute_client.virtual_machine_images.get.side_effect = ResourceNotFoundError('image not found')
         client_factory_mock.return_value = compute_client
 
         np = mock.MagicMock()

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_actions.py
@@ -219,7 +219,7 @@ class TestActions(unittest.TestCase):
     @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.vm._validators.logger.warning', autospec=True)
     def test_parse_staging_image_argument(self, logger_mock, client_factory_mock):
-        from msrestazure.azure_exceptions import CloudError
+        from azure.core.exceptions import ResourceNotFoundError
         compute_client = mock.MagicMock()
         resp = mock.MagicMock()
         cmd = mock.MagicMock()
@@ -227,7 +227,7 @@ class TestActions(unittest.TestCase):
         resp.status_code = 404
         resp.text = '{"Message": "Not Found"}'
 
-        compute_client.virtual_machine_images.get.side_effect = CloudError(resp, error='image not found')
+        compute_client.virtual_machine_images.get.side_effect = ResourceNotFoundError('image not found')
         client_factory_mock.return_value = compute_client
 
         np = mock.MagicMock()


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Since vm module has already been migrated to Track 2 #15750,  `CloudError` should be replaced with `HttpResponseError` or more specifically `ResourceNotFoundError`

Related PR: #22267

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
