### PR TITLE
{Misc.} Replace NBSP with normal ASCII space

### DIFF
--- a/doc/authoring_command_modules/README.md
+++ b/doc/authoring_command_modules/README.md
@@ -176,11 +176,11 @@ History notes are auto-generated based on PR titles and descriptions starting fr
 2. [**Mandatory**] If it's a breaking change, the second part should be `BREAKING CHANGE` followed by a colon. In the case of hotfix, put `Hotfix` in this part. If it's related to fixing an issue, put `Fix #number` in this part. For other cases, this part could be empty.
 3. [**Recommendation**] If the change can be mapped into a command, then the next part could be the command name starting with `az`, followed by a colon.
 4. [**Recommendation**] Use the right verb with **present-tense** in **base form** and **capitalized first letter** to describe what is done:
-    * **Add** for new features.
-    * **Change** for changes in existing functionality.
-    * **Deprecate** for once-stable features removed in upcoming releases.
-    * **Remove** for deprecated features removed in this release.
-    * **Fix** for any bug fixes.
+    * **Add** for new features.
+    * **Change** for changes in existing functionality.
+    * **Deprecate** for once-stable features removed in upcoming releases.
+    * **Remove** for deprecated features removed in this release.
+    * **Fix** for any bug fixes.
 
 Examples of customer-facing change PR title:
 

--- a/doc/azure2az_commands.rst
+++ b/doc/azure2az_commands.rst
@@ -18,33 +18,33 @@ azure account list                                           az account list
 azure account set                                            az account set
 azure account show                                           az account show
 azure location list                                          az account list-locations
-azure network application-gateway address-pool create        az network application-gateway address-pool create
-azure network application-gateway address-pool delete        az network application-gateway address-pool delete
-azure network application-gateway create                     az network application-gateway create
-azure network application-gateway delete                     az network application-gateway delete
-azure network application-gateway frontend-ip create         az network application-gateway frontend-ip create
-azure network application-gateway frontend-ip delete         az network application-gateway frontend-ip delete
-azure network application-gateway frontend-port create       az network application-gateway frontend-port create
-azure network application-gateway frontend-port delete       az network application-gateway frontend-port delete
-azure network application-gateway http-listener create       az network application-gateway http-listener create
-azure network application-gateway http-listener delete       az network application-gateway http-listener delete
-azure network application-gateway http-settings create       az network application-gateway http-settings create
-azure network application-gateway http-settings delete       az network application-gateway http-settings delete
-azure network application-gateway list                       az network application-gateway list
-azure network application-gateway probe create               az network application-gateway probe create
-azure network application-gateway probe delete               az network application-gateway probe delete
-azure network application-gateway rule create                az network application-gateway rule create
-azure network application-gateway rule delete                az network application-gateway rule delete
-azure network application-gateway set                        az network application-gateway update
-azure network application-gateway show                       az network application-gateway show
-azure network application-gateway ssl-cert create            az network application-gateway ssl-cert create
-azure network application-gateway ssl-cert delete            az network application-gateway ssl-cert delete
-azure network application-gateway start                      az network application-gateway start
-azure network application-gateway stop                       az network application-gateway stop
-azure network application-gateway url-path-map create        az network application-gateway url-path-map create
-azure network application-gateway url-path-map delete        az network application-gateway url-path-map delete
-azure network application-gateway url-path-map rule create   az network application-gateway url-path-map rule create
-azure network application-gateway url-path-map rule delete   az network application-gateway url-path-map rule delete
+azure network application-gateway address-pool create        az network application-gateway address-pool create
+azure network application-gateway address-pool delete        az network application-gateway address-pool delete
+azure network application-gateway create                     az network application-gateway create
+azure network application-gateway delete                     az network application-gateway delete
+azure network application-gateway frontend-ip create         az network application-gateway frontend-ip create
+azure network application-gateway frontend-ip delete         az network application-gateway frontend-ip delete
+azure network application-gateway frontend-port create       az network application-gateway frontend-port create
+azure network application-gateway frontend-port delete       az network application-gateway frontend-port delete
+azure network application-gateway http-listener create       az network application-gateway http-listener create
+azure network application-gateway http-listener delete       az network application-gateway http-listener delete
+azure network application-gateway http-settings create       az network application-gateway http-settings create
+azure network application-gateway http-settings delete       az network application-gateway http-settings delete
+azure network application-gateway list                       az network application-gateway list
+azure network application-gateway probe create               az network application-gateway probe create
+azure network application-gateway probe delete               az network application-gateway probe delete
+azure network application-gateway rule create                az network application-gateway rule create
+azure network application-gateway rule delete                az network application-gateway rule delete
+azure network application-gateway set                        az network application-gateway update
+azure network application-gateway show                       az network application-gateway show
+azure network application-gateway ssl-cert create            az network application-gateway ssl-cert create
+azure network application-gateway ssl-cert delete            az network application-gateway ssl-cert delete
+azure network application-gateway start                      az network application-gateway start
+azure network application-gateway stop                       az network application-gateway stop
+azure network application-gateway url-path-map create        az network application-gateway url-path-map create
+azure network application-gateway url-path-map delete        az network application-gateway url-path-map delete
+azure network application-gateway url-path-map rule create   az network application-gateway url-path-map rule create
+azure network application-gateway url-path-map rule delete   az network application-gateway url-path-map rule delete
 azure network dns record-set add-record                      az network dns record-set [ptr|mx|*] add
 azure network dns record-set create                          az network dns record-set create
 azure network dns record-set delete                          az network dns record-set delete
@@ -56,22 +56,22 @@ azure network dns zone delete                                az network dns zone
 azure network dns zone list                                  az network dns zone list
 azure network dns zone set                                   az network dns zone update
 azure network dns zone show                                  az network dns zone show
-azure network express-route authorization create             az network express-route circuit-auth create
-azure network express-route authorization delete             az network express-route circuit-auth delete
-azure network express-route authorization list               az network express-route circuit-auth list
-azure network express-route authorization set                az network express-route circuit-auth update
-azure network express-route authorization show               az network express-route circuit-auth show
-azure network express-route circuit create                   az network express-route circuit create
+azure network express-route authorization create             az network express-route circuit-auth create
+azure network express-route authorization delete             az network express-route circuit-auth delete
+azure network express-route authorization list               az network express-route circuit-auth list
+azure network express-route authorization set                az network express-route circuit-auth update
+azure network express-route authorization show               az network express-route circuit-auth show
+azure network express-route circuit create                   az network express-route circuit create
 azure network express-route circuit delete                   az network express-route circuit delete
-azure network express-route circuit list                     az network express-route circuit list
-azure network express-route circuit set                      az network express-route circuit update
-azure network express-route circuit show                     az network express-route circuit show
-azure network express-route peering create                   az network express-route circuit-peering create
-azure network express-route peering delete                   az network express-route circuit-peering delete
-azure network express-route peering list                     az network express-route circuit-peering list
-azure network express-route peering set                      az network express-route circuit-peering update
-azure network express-route peering show                     az network express-route circuit-peering show
-azure network express-route provider list                    az network express-route service-provider list
+azure network express-route circuit list                     az network express-route circuit list
+azure network express-route circuit set                      az network express-route circuit update
+azure network express-route circuit show                     az network express-route circuit show
+azure network express-route peering create                   az network express-route circuit-peering create
+azure network express-route peering delete                   az network express-route circuit-peering delete
+azure network express-route peering list                     az network express-route circuit-peering list
+azure network express-route peering set                      az network express-route circuit-peering update
+azure network express-route peering show                     az network express-route circuit-peering show
+azure network express-route provider list                    az network express-route service-provider list
 azure network lb address-pool create                         az network lb address-pool create
 azure network lb address-pool delete                         az network lb address-pool delete
 azure network lb address-pool list                           az network lb address-pool list
@@ -164,14 +164,14 @@ azure network vnet subnet delete                             az network vnet sub
 azure network vnet subnet list                               az network vnet subnet list
 azure network vnet subnet set                                az network vnet subnet update
 azure network vnet subnet show                               az network vnet subnet show
-azure network vpn-connection create                          az network vpn-connection create
-azure network vpn-connection delete                          az network vpn-connection delete
-azure network vpn-connection list                            az network vpn-connection list
-azure network vpn-connection set                             az network vpn-connection update
+azure network vpn-connection create                          az network vpn-connection create
+azure network vpn-connection delete                          az network vpn-connection delete
+azure network vpn-connection list                            az network vpn-connection list
+azure network vpn-connection set                             az network vpn-connection update
 azure network vpn-connection shared-key reset                az network vpn-connection shared-key reset
-azure network vpn-connection shared-key set                  az network vpn-connection shared-key update
+azure network vpn-connection shared-key set                  az network vpn-connection shared-key update
 azure network vpn-connection shared-key show                 az network vpn-connection shared-key show
-azure network vpn-connection show                            az network vpn-connection show
+azure network vpn-connection show                            az network vpn-connection show
 azure network vpn-gateway create                             az network vpn-gateway create
 azure network vpn-gateway delete                             az network vpn-gateway delete
 azure network vpn-gateway list                               az network vpn-gateway list

--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -56,7 +56,7 @@ setup() {
     if [[ -z $DIST_CODE ]]; then
         CLI_REPO=$(lsb_release -cs)
         shopt -s nocasematch
-        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
+        ERROR_MSG="Unable to find a package for your system. Please check if an existing package in https://packages.microsoft.com/repos/azure-cli/dists/ can be used in your system and install with the dist name: 'curl -sL https://aka.ms/InstallAzureCLIDeb | sudo DIST_CODE=<dist_code_name> bash'"
         if [[ ! $(curl -sL https://packages.microsoft.com/repos/azure-cli/dists/) =~ $CLI_REPO ]]; then
             DIST=$(lsb_release -is)
             if [[ $DIST =~ "Ubuntu" ]]; then

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -1092,7 +1092,7 @@ Hotfix: Fix #19468: pip installs azure-cli 2.0.73 because of the dependency on d
 * Upgrade api-version for VM and VMSS from `2021-03-01` to `2021-04-01` (#19158)
 * `az vmss create/update`: Support spot restore policy to VM scale sets (#19189)
 * Add new examples for creating disk from share image gallery (#19270)
-* `az vm image​ list/list-offers/list-skus/list-publishers/show`: Add new parameter ​`--edge-zone`​ to support querying the image under edge zone (#19206)
+* `az vm image list/list-offers/list-skus/list-publishers/show`: Add new parameter `--edge-zone` to support querying the image under edge zone (#19206)
 * Fix the issue caused by the lack of `os_type` when creating VM from shared gallery id (#19291)
 * Update shared image gallery doc (#19427)
 * `az capacity reservation`: Add new commands to manage capacity reservation (#19416)

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2716,7 +2716,7 @@ def create_managed_ssl_cert(cmd, resource_group_name, name, hostname, slot=None)
     webapp = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
     if not webapp:
         slot_text = "Deployment slot {} in ".format(slot) if slot else ''
-        raise ResourceNotFoundError("{0}app {1} doesn't exist in resource group {2}".format(slot_text,
+        raise ResourceNotFoundError("{0}app {1} doesn't exist in resource group {2}".format(slot_text,
                                                                                             name,
                                                                                             resource_group_name))
 
@@ -2727,7 +2727,7 @@ def create_managed_ssl_cert(cmd, resource_group_name, name, hostname, slot=None)
 
     if not _verify_hostname_binding(cmd, resource_group_name, name, hostname, slot):
         slot_text = " --slot {}".format(slot) if slot else ""
-        raise ValidationError("Hostname (custom domain) '{0}' is not registered with {1}. "
+        raise ValidationError("Hostname (custom domain) '{0}' is not registered with {1}. "
                               "Use 'az webapp config hostname add --resource-group {2} "
                               "--webapp-name {1}{3} --hostname {0}' "
                               "to register the hostname.".format(hostname, name, resource_group_name, slot_text))


### PR DESCRIPTION
**Description**<!--Mandatory-->

For unknown reason, https://github.com/Azure/azure-cli/pull/15998 added NBSP ([Non-breaking space U+00A0](https://en.wikipedia.org/wiki/Non-breaking_space)) to `scripts/release/debian/deb_install.sh`

PyCharm:

![image](https://user-images.githubusercontent.com/4003950/167337822-27e9a78e-f067-43be-b496-f4802ca8e9dc.png)

VS Code:

![image](https://user-images.githubusercontent.com/4003950/167337961-deb3033e-5e87-42a8-87a9-7c3481a7a926.png)

This leads to display issue in Edge browser:

https://azurecliprod.blob.core.windows.net/$root/deb_install.sh

![image](https://user-images.githubusercontent.com/4003950/167337890-bb192ca6-698f-4ee5-ad13-a8955be537b1.png)

This PR replaces NBSP with normal ASCII space.

We've seen this issue before:

- https://github.com/Azure/azure-cli/pull/19442
- https://github.com/Azure/azure-cli/pull/8785