### PR TITLE
[CosmosDB] Update deps to enable support for MongoDB server version 4.2

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -34,7 +34,7 @@ azure-mgmt-containerinstance==9.1.0
 azure-mgmt-containerregistry==8.2.0
 azure-mgmt-containerservice==19.0.0
 azure-mgmt-core==1.3.0
-azure-mgmt-cosmosdb==7.0.0b2
+azure-mgmt-cosmosdb==7.0.0b5
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1
 azure-mgmt-datalake-nspkg==3.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -34,7 +34,7 @@ azure-mgmt-containerinstance==9.1.0
 azure-mgmt-containerregistry==8.2.0
 azure-mgmt-containerservice==19.0.0
 azure-mgmt-core==1.3.0
-azure-mgmt-cosmosdb==7.0.0b2
+azure-mgmt-cosmosdb==7.0.0b5
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1
 azure-mgmt-datalake-nspkg==3.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -34,7 +34,7 @@ azure-mgmt-containerinstance==9.1.0
 azure-mgmt-containerregistry==8.2.0
 azure-mgmt-containerservice==19.0.0
 azure-mgmt-core==1.3.0
-azure-mgmt-cosmosdb==7.0.0b2
+azure-mgmt-cosmosdb==7.0.0b5
 azure-mgmt-databoxedge==1.0.0
 azure-mgmt-datalake-analytics==0.2.1
 azure-mgmt-datalake-nspkg==3.0.1

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -79,7 +79,7 @@ DEPENDENCIES = [
     'azure-mgmt-containerinstance~=9.1.0',
     'azure-mgmt-containerregistry==8.2.0',
     'azure-mgmt-containerservice~=19.0.0',
-    'azure-mgmt-cosmosdb==7.0.0b2',
+    'azure-mgmt-cosmosdb==7.0.0b5',
     'azure-mgmt-databoxedge~=1.0.0',
     'azure-mgmt-datalake-analytics~=0.2.1',
     'azure-mgmt-datalake-store~=0.5.0',


### PR DESCRIPTION
Update azure-mgmt-cosmosdb dep to 7.0.0b5

 - This has the changes in the Python SDK to include support
   for MongoDB server version 4.2
 - This enables creating CosmosDB (MongoDB API) accounts with
   server version 4.2 via the az-cli

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**
Update the `azure-mgmt-cosmosdb` dependency to pull in the Python SDK changes to enable support for creating accounts with MongoDB server version 4.2

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
