### PR TITLE
{QueueStorage} Fixes Azure/azure-cli#22268

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/queue.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/queue.py
@@ -83,4 +83,8 @@ def delete_queue(cmd, client, fail_not_exist=False, timeout=None, **kwargs):
 
 def receive_messages(client, **kwargs):
     page_iter = client.receive_messages(**kwargs).by_page()
-    return list(next(page_iter))
+    try:
+        page = next(page_iter)
+    except StopIteration:
+        return []
+    return list(page)


### PR DESCRIPTION
"az storage message get" crashes when there are no messages in the queue.

Debug error output:
File "/opt/az/lib/python3.8/site-packages/azure/cli/core/commands/init.py", line 328, in call
return self.handler(*args, **kwargs)
File "/opt/az/lib/python3.8/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
return op(**command_args)
File "/opt/az/lib/python3.8/site-packages/azure/cli/command_modules/storage/operations/queue.py", line 86, in receive_messages
return list(next(page_iter))
File "/opt/az/lib/python3.8/site-packages/azure/core/paging.py", line 84, in next
self.continuation_token, self._current_page = self._extract_data(self._response)
File "/opt/az/lib/python3.8/site-packages/azure/multiapi/storagev2/queue/v2018_03_28/_models.py", line 288, in _extract_data_cb
raise StopIteration("End of paging")
StopIteration: End of paging

Fixes #22268

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
