### PR TITLE
[Network] `az network lb create`: Add warnings for default SKU

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -3674,6 +3674,12 @@ def create_load_balancer(cmd, load_balancer_name, resource_group_name, location=
     DeploymentProperties = cmd.get_models('DeploymentProperties', resource_type=ResourceType.MGMT_RESOURCE_RESOURCES)
     IPAllocationMethod = cmd.get_models('IPAllocationMethod')
 
+    if public_ip_address is None:
+        logger.warning(
+            "Please note that the default public IP used for creation will be changed from Basic to Standard "
+            "in the future."
+        )
+
     tags = tags or {}
     public_ip_address = public_ip_address or 'PublicIP{}'.format(load_balancer_name)
     backend_pool_name = backend_pool_name or '{}bepool'.format(load_balancer_name)
@@ -3901,6 +3907,12 @@ def create_lb_frontend_ip_configuration(
         public_ip_address=SubResource(id=public_ip_address) if public_ip_address else None,
         public_ip_prefix=SubResource(id=public_ip_prefix) if public_ip_prefix else None,
         subnet=Subnet(id=subnet) if subnet else None)
+
+    if new_config.public_ip_address is None:
+        logger.warning(
+            "Please note that the default public IP used for LB frontend will be changed from Basic to Standard "
+            "in the future."
+        )
 
     if zone and cmd.supported_api_version(min_api='2017-06-01'):
         new_config.zones = zone
@@ -6359,15 +6371,11 @@ def create_public_ip(cmd, resource_group_name, public_ip_address_name, location=
                      allocation_method=None, dns_name=None,
                      idle_timeout=4, reverse_fqdn=None, version=None, sku=None, tier=None, zone=None, ip_tags=None,
                      public_ip_prefix=None, edge_zone=None, ip_address=None):
-
-    # In the latest profile, the default public IP will be expected to be changed from Basic to Standard.
-    # In order to avoid breaking change which has a big impact to users,
-    # we use the hint to guide users to use Standard sku to create public IP.
-    if sku is None and cmd.cli_ctx.cloud.profile == 'latest':
+    if sku is None:
         logger.warning(
-            'It is recommended to use parameter "--sku Standard" to create new public IP. '
-            'Please note that the default public IP used for creation will be changed from Basic to Standard '
-            'in the future.')
+            "Please note that the default public IP used for creation will be changed from Basic to Standard "
+            "in the future."
+        )
 
     IPAllocationMethod, PublicIPAddress, PublicIPAddressDnsSettings, SubResource = cmd.get_models(
         'IPAllocationMethod', 'PublicIPAddress', 'PublicIPAddressDnsSettings', 'SubResource')

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -3896,6 +3896,11 @@ def create_lb_frontend_ip_configuration(
     ncf = network_client_factory(cmd.cli_ctx)
     lb = lb_get(ncf.load_balancers, resource_group_name, load_balancer_name)
 
+    if public_ip_address is None:
+        logger.warning(
+            "Please note that the default public IP used for LB frontend will be changed from Basic to Standard "
+            "in the future."
+        )
     if private_ip_address_allocation is None:
         private_ip_address_allocation = 'static' if private_ip_address else 'dynamic'
 
@@ -3907,12 +3912,6 @@ def create_lb_frontend_ip_configuration(
         public_ip_address=SubResource(id=public_ip_address) if public_ip_address else None,
         public_ip_prefix=SubResource(id=public_ip_prefix) if public_ip_prefix else None,
         subnet=Subnet(id=subnet) if subnet else None)
-
-    if new_config.public_ip_address is None:
-        logger.warning(
-            "Please note that the default public IP used for LB frontend will be changed from Basic to Standard "
-            "in the future."
-        )
 
     if zone and cmd.supported_api_version(min_api='2017-06-01'):
         new_config.zones = zone


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
> In the latest profile and the profiles that use the same api-version as latest profile, the default public IP used for creation for an LB frontend with "az network lb create" and/or "az network lb frontend-ip create" will be changed from Basic to Standard. In advance of eventual breaking change, would like to add warning for users.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
