### PR TITLE
{Compute} `az vmss create`: Add hint to suggest Standard lb

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2886,10 +2886,10 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
                                                                 build_application_gateway_resource,
                                                                 build_msi_role_assignment, build_nsg_resource)
 
-    # In the latest profile, the default lb will be expected to be changed from Basic to Standard.
+    # The default lb will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,
     # we use the hint to guide users to use Standard lb to create VMSS in the first stage.
-    if load_balancer_sku is None and cmd.cli_ctx.cloud.profile == 'latest':
+    if load_balancer_sku is None:
         logger.warning(
             'It is recommended to use parameter "--lb-sku Standard" to create new VMSS with Standard lb. '
             'Please note that the default lb used for VMSS creation will be changed from Basic to Standard '

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2886,13 +2886,13 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
                                                                 build_application_gateway_resource,
                                                                 build_msi_role_assignment, build_nsg_resource)
 
-    # The default lb will be expected to be changed from Basic to Standard.
+    # The default load balancer will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,
-    # we use the hint to guide users to use Standard lb to create VMSS in the first stage.
+    # we use the hint to guide users to use Standard load balancer to create VMSS in the first stage.
     if load_balancer_sku is None:
         logger.warning(
-            'It is recommended to use parameter "--lb-sku Standard" to create new VMSS with Standard lb. '
-            'Please note that the default lb used for VMSS creation will be changed from Basic to Standard '
+            'It is recommended to use parameter "--lb-sku Standard" to create new VMSS with Standard load balancer. '
+            'Please note that the default load balancer used for VMSS creation will be changed from Basic to Standard '
             'in the future.')
 
     # Build up the ARM template

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2885,7 +2885,7 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
                                                                 build_vmss_storage_account_pool_resource,
                                                                 build_application_gateway_resource,
                                                                 build_msi_role_assignment, build_nsg_resource)
-    
+
     # In the latest profile, the default lb will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,
     # we use the hint to guide users to use Standard lb to create VMSS in the first stage.
@@ -2894,7 +2894,7 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
             'It is recommended to use parameter "--lb-sku Standard" to create new VMSS with Standard lb. '
             'Please note that the default lb used for VMSS creation will be changed from Basic to Standard '
             'in the future.')
-    
+
     # Build up the ARM template
     master_template = ArmTemplateBuilder()
 

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2885,6 +2885,16 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
                                                                 build_vmss_storage_account_pool_resource,
                                                                 build_application_gateway_resource,
                                                                 build_msi_role_assignment, build_nsg_resource)
+    
+    # In the latest profile, the default lb will be expected to be changed from Basic to Standard.
+    # In order to avoid breaking change which has a big impact to users,
+    # we use the hint to guide users to use Standard lb to create VMSS in the first stage.
+    if load_balancer_sku is None and cmd.cli_ctx.cloud.profile == 'latest':
+        logger.warning(
+            'It is recommended to use parameter "--lb-sku Standard" to create new VMSS with Standard lb. '
+            'Please note that the default lb used for VMSS creation will be changed from Basic to Standard '
+            'in the future.')
+    
     # Build up the ARM template
     master_template = ArmTemplateBuilder()
 


### PR DESCRIPTION
**Related command**
Fix: https://github.com/Azure/azure-cli/issues/22322
Add hint for `az vmss create`
The default lb will be expected to be changed from Basic to Standard. In order to avoid big impact to users, we use the hint to guide users to use Standard lb to create VMSS in the first stage.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
