### PR TITLE
[SQL] Fix #22316: `az sql server ad-admin create`: Fix Display Name and Object ID to be required

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -261,10 +261,12 @@ allow_data_loss_param_type = CLIArgumentType(
 
 aad_admin_login_param_type = CLIArgumentType(
     options_list=['--display-name', '-u'],
+    required=True,
     help='Display name of the Azure AD administrator user or group.')
 
 aad_admin_sid_param_type = CLIArgumentType(
     options_list=['--object-id', '-i'],
+    required=True,
     help='The unique ID of the Azure AD administrator.')
 
 read_scale_param_type = CLIArgumentType(

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -1181,6 +1181,13 @@ class AzureActiveDirectoryAdministratorScenarioTest(ScenarioTest):
 
         print('Arguments are updated with login and sid data')
 
+        with self.assertRaisesRegexp(SystemExit, "2"):
+            self.cmd('sql server ad-admin create -s {sn} -g {rg}')
+        with self.assertRaisesRegexp(SystemExit, "2"):
+            self.cmd('sql server ad-admin create -s {sn} -g {rg} -u {user}')
+        with self.assertRaisesRegexp(SystemExit, "2"):
+            self.cmd('sql server ad-admin create -s {sn} -g {rg} -i {oid}')
+
         self.cmd('sql server ad-admin create -s {sn} -g {rg} -i {oid} -u {user}',
                  checks=[
                      self.check('login', '{user}'),


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az sql server ad-admin create --resource-group {} --server-name {} --display-name {} --object-id {}
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Both the Display Name and Object ID are required by the underlying ARM API, but are currently misclassified as optional arguments

Fixes #22316

**Testing Guide**
<!--Example commands with explanations.-->

Currently, all of the following commands fail with an error from the REST API instead of clearly stating that a required parameter is missing

```sh
az sql server ad-admin create --resource-group {} --server-name {}
az sql server ad-admin create --resource-group {} --server-name {} --display-name {}
az sql server ad-admin create --resource-group {} --server-name {} --object-id {}
```

With this PR, the command should fail with the Exit Code 2 and message clearly mentioning that the required parameters are missing. Something like this

```
ERROR: the following arguments are required: --display-name/-u, --object-id/-i
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
