### PR TITLE
[AppService] Fix #22332: `az appservice plan create`: Fix windows container app service plan creation for ASEv3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1896,8 +1896,6 @@ def create_app_service_plan(cmd, resource_group_name, name, is_linux, hyper_v, p
 
     client = web_client_factory(cmd.cli_ctx)
     if app_service_environment:
-        if hyper_v:
-            raise ArgumentUsageError('Windows containers is not yet supported in app service environment')
         ase_list = client.app_service_environments.list()
         ase_found = False
         ase = None
@@ -1910,6 +1908,8 @@ def create_app_service_plan(cmd, resource_group_name, name, is_linux, hyper_v, p
         if not ase_found:
             err_msg = "App service environment '{}' not found in subscription.".format(app_service_environment)
             raise ResourceNotFoundError(err_msg)
+        if hyper_v and ase.kind in ('ASEV1', 'ASEV2'):
+            raise ArgumentUsageError('Windows containers are only supported in app service environment v3 and newer')
     else:  # Non-ASE
         ase_def = None
         if location is None:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az appservice plan create --name {} --resource-group {} --app-service-environment {} --hyper-v --sku {}
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Windows Container are supported from ASEV3 but is not possible to create an app service plan for windows containers using Azure CLI today

Resolves #22332 

**Testing Guide**
<!--Example commands with explanations.-->

Creating an ASP for Windows Containers should work on ASEv3 but fail for ASEv2 and ASEv1, with the following command

```sh
az appservice plan create --name {} --resource-group {} --app-service-environment {} --hyper-v --sku {}
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
