### PR TITLE
{CI} Fix automation full test fails but ci does not report an error

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -185,7 +185,7 @@ class AutomaticScheduling(object):
                   serial_tests + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
-                subprocess.run(cmd)
+                subprocess.run(cmd, check=True)
             except subprocess.CalledProcessError:
                 error_flag = True
         if parallel_tests:
@@ -193,7 +193,7 @@ class AutomaticScheduling(object):
                   parallel_tests + ['--profile', f'{profile}', '--pytest-args', '"--durations=0"']
             logger.info(cmd)
             try:
-                subprocess.run(cmd)
+                subprocess.run(cmd, check=True)
             except subprocess.CalledProcessError:
                 error_flag = True
         return error_flag


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1560515&view=logs&j=1eb45de9-c733-5264-c426-7b7aa2f821f2&t=0cbae84f-4be8-59ee-bab5-cbee55e4301c
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1560514&view=logs&j=15e5eb7c-cf66-5b91-00a2-db9b11b5e0f9&t=845fa2ee-a602-59f5-4e4c-07ee6d0283b9
Automation full test fails but ci does not report an error.
![image](https://user-images.githubusercontent.com/18628534/167876957-bd9de536-6c46-4ca1-95b7-61014b46c1c0.png)
If check is true, and the process exits with a non-zero exit code, a [CalledProcessError](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError) exception will be raised.
After add check=True, ci will report the error.
![image](https://user-images.githubusercontent.com/18628534/167869967-41e55b16-b41a-4415-a493-875935895aaa.png)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
