### PR TITLE
[Storage] `az storage copy`: Fix `--exclude-path` TypeError

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -28,7 +28,7 @@ def storage_copy(source, destination, put_md5=None, recursive=None, blob_type=No
         flags.append('--exclude-pattern=' + exclude_pattern)
     if include_path is not None:
         flags.append('--include-path=' + include_path)
-    if exclude_pattern is not None:
+    if exclude_path is not None:
         flags.append('--exclude-path=' + exclude_path)
     if content_type is not None:
         flags.append('--content-type=' + content_type)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage copy`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When building `flags` arg of `azcopy.copy`, there is a typo causing it to error out on type error:

```
+ az storage copy --recursive --account-key <redacted> -s 'public/*' -d https://<redacted>.blob.core.windows.net/public --exclude-pattern '.*'
Positional argument '<EXTRA_OPTIONS>' is experimental and under development. Reference and support levels: https://aka.ms/CLI_refstatus
The command failed with an unexpected error. Here is the traceback:
can only concatenate str (not "NoneType") to str
Traceback (most recent call last):
  File "/opt/azure-cli/lib/python3.10/site-packages/knack/cli.py", line 231, in invoke
    cmd_result = self.invocation.execute(args)
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 658, in execute
    raise ex
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 721, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 692, in _run_job
    result = cmd_copy(params)
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 328, in __call__
    return self.handler(*args, **kwargs)
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/opt/azure-cli/lib/python3.10/site-packages/azure/cli/command_modules/storage/operations/azcopy.py", line 32, in storage_copy
    flags.append('--exclude-path=' + exclude_path)
TypeError: can only concatenate str (not "NoneType") to str
To open an issue, please run: 'az feedback'
```

Fix #20324

**Testing Guide**
<!--Example commands with explanations.-->
```
  az storage copy \
    --recursive \
    --account-key "$account_key" \
    -s "$dir/*" \
    -d https://account.blob.core.windows.net/container \
    --exclude-pattern '.*'
```

Add `--exclude-pattern` arg but not `--exclude-path` will cause az to error out.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] `az storage copy`: Fix `--exclude-path` TypeError

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
