### PR TITLE
[Packaging] Use Mariner 2.0 GA image to build RPM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -689,10 +689,10 @@ jobs:
   strategy:
     matrix:
       1.0:
-        acr: cblmariner
+        image: cblmariner.azurecr.io/base/core
         tag: 1.0
       2.0:
-        acr: cblmariner2preview
+        image: mcr.microsoft.com/cbl-mariner/base/core
         tag: 2.0
   steps:
   - task: Bash@3
@@ -701,7 +701,7 @@ jobs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
     env:
-      ACR: $(acr)
+      IMAGE: $(image)
       TAG: $(tag)
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -1,7 +1,7 @@
 ARG tag=2.0
-ARG acr=cblmariner2preview
+ARG image=mcr.microsoft.com/cbl-mariner/base/core
 
-FROM ${acr}.azurecr.io/base/core:${tag} AS build-env
+FROM ${image}:${tag} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
@@ -15,7 +15,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
 
-FROM ${acr}.azurecr.io/base/core:${tag} AS execution-env
+FROM ${image}:${tag} AS execution-env
 
 RUN tdnf update -y
 RUN tdnf install -y python3 python3-virtualenv

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -18,7 +18,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
 FROM ${image}:${tag} AS execution-env
 
 RUN tdnf update -y
-RUN tdnf install -y python3 python3-virtualenv
+RUN tdnf install -y python3 python3-virtualenv rpm
 
 COPY --from=build-env /azure-cli-dev.rpm ./
 RUN rpm -i ./azure-cli-dev.rpm && \

--- a/scripts/release/rpm/pipeline_mariner.sh
+++ b/scripts/release/rpm/pipeline_mariner.sh
@@ -5,7 +5,7 @@
 set -exv
 
 : "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
-: "${ACR:?ACR environment variable not set.}"
+: "${IMAGE:?IMAGE environment variable not set.}"
 : "${TAG:?TAG environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
@@ -13,7 +13,7 @@ CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/
 # Create a container image that includes the source code and a built RPM using this file.
 docker build \
     --target build-env \
-    --build-arg acr=${ACR} \
+    --build-arg image=${IMAGE} \
     --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/mariner.dockerfile \
@@ -22,7 +22,7 @@ docker build \
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
-    --build-arg acr=${ACR} \
+    --build-arg image=${IMAGE} \
     --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
     -f ./scripts/release/rpm/mariner.dockerfile \


### PR DESCRIPTION
**Description**<!--Mandatory-->

Mariner 2.0 is now GA and available at `mcr.microsoft.com/cbl-mariner/base/core:2.0`.

Now we use the GA image instead of preview to build RPMs.

This also fixed CI failure due to https://github.com/microsoft/CBL-Mariner/issues/2858:

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1526709&view=logs&j=e3c62b71-8b77-544e-81f5-f423af72ca92&t=e76499ae-d6f0-5b8b-06ad-e635f5f3b0f4

```
Error(1525) : rpm transaction failed
The command '/bin/sh -c tdnf update -y' returned a non-zero code: 245
```

Email: _azcli | mariner.dockerfile modification_