### PR TITLE
[AKS] Fix #22032: `az aks nodepool add/update`: Fix autoscaler parameters for user node pools

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -985,10 +985,10 @@ parameters:
     short-summary: Enable cluster autoscaler.
   - name: --min-count
     type: int
-    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [1, 1000]
+    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
   - name: --max-count
     type: int
-    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [1, 1000]
+    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
   - name: --scale-down-mode
     type: string
     short-summary: "Describe how VMs are added to or removed from nodepools."
@@ -1101,10 +1101,10 @@ parameters:
     short-summary: Update min-count or max-count for cluster autoscaler.
   - name: --min-count
     type: int
-    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [1, 1000]
+    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
   - name: --max-count
     type: int
-    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [1, 1000]
+    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
   - name: --scale-down-mode
     type: string
     short-summary: "Describe how VMs are added to or removed from nodepools."

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -985,10 +985,10 @@ parameters:
     short-summary: Enable cluster autoscaler.
   - name: --min-count
     type: int
-    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
+    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000] for user nodepool, and [1,1000] for system nodepool.
   - name: --max-count
     type: int
-    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
+    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000] for user nodepool, and [1,1000] for system nodepool.
   - name: --scale-down-mode
     type: string
     short-summary: "Describe how VMs are added to or removed from nodepools."
@@ -1101,10 +1101,10 @@ parameters:
     short-summary: Update min-count or max-count for cluster autoscaler.
   - name: --min-count
     type: int
-    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
+    short-summary: Minimum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000] for user nodepool, and [1,1000] for system nodepool.
   - name: --max-count
     type: int
-    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000]
+    short-summary: Maximum nodes count used for autoscaler, when "--enable-cluster-autoscaler" specified. Please specify the value in the range of [0, 1000] for user nodepool, and [1,1000] for system nodepool.
   - name: --scale-down-mode
     type: string
     short-summary: "Describe how VMs are added to or removed from nodepools."

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -224,13 +224,13 @@ def validate_nat_gateway_idle_timeout(namespace):
 
 
 def validate_nodes_count(namespace):
-    """Validates that min_count and max_count is set between 1-100"""
+    """Validates that min_count and max_count is set between 0-1000"""
     if namespace.min_count is not None:
-        if namespace.min_count < 1 or namespace.min_count > 100:
-            raise CLIError('--min-count must be in the range [1,100]')
+        if namespace.min_count < 0 or namespace.min_count > 1000:
+            raise CLIError('--min-count must be in the range [0,1000]')
     if namespace.max_count is not None:
-        if namespace.max_count < 1 or namespace.max_count > 100:
-            raise CLIError('--max-count must be in the range [1,100]')
+        if namespace.max_count < 0 or namespace.max_count > 1000:
+            raise CLIError('--max-count must be in the range [0,1000]')
 
 
 def validate_taints(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -172,6 +172,7 @@ class AKSAgentPoolContext(BaseAKSContext):
         enable_cluster_autoscaler,
         min_count,
         max_count,
+        mode,
         decorator_mode,
     ) -> None:
         """Helper function to check the validity of serveral count-related parameters in autoscaler.
@@ -200,6 +201,11 @@ class AKSAgentPoolContext(BaseAKSContext):
                 if node_count < min_count or node_count > max_count:
                     raise InvalidArgumentValueError(
                         "node-count is not in the range of min-count and max-count"
+                    )
+            if mode == CONST_NODEPOOL_MODE_SYSTEM:
+                if min_count < 1:
+                    raise InvalidArgumentValueError(
+                        "Value of min-count should be greater than or equal to 1 for System node pools"
                     )
         else:
             if min_count is not None or max_count is not None:
@@ -628,6 +634,13 @@ class AKSAgentPoolContext(BaseAKSContext):
         if self.agentpool and self.agentpool.max_count is not None:
             max_count = self.agentpool.max_count
 
+        # mode
+        # read the original value passed by the command
+        mode = self.raw_param.get("mode")
+        # try to read the property value corresponding to the parameter from the `agentpool` object
+        if self.agentpool and self.agentpool.mode is not None:
+            mode = self.agentpool.mode
+
         # these parameters do not need dynamic completion
 
         # validation
@@ -636,6 +649,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             enable_cluster_autoscaler,
             min_count,
             max_count,
+            mode,
             decorator_mode=DecoratorMode.CREATE,
         )
         return node_count, enable_cluster_autoscaler, min_count, max_count
@@ -679,6 +693,10 @@ class AKSAgentPoolContext(BaseAKSContext):
         # read the original value passed by the command
         max_count = self.raw_param.get("max_count")
 
+        # mode
+        # read the original value passed by the command, defaulting to the value from the `agentpool` object
+        mode = self.raw_param.get("mode", self.agentpool.mode)
+
         # these parameters do not need dynamic completion
 
         # validation
@@ -701,6 +719,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             enable_cluster_autoscaler or update_cluster_autoscaler,
             min_count,
             max_count,
+            mode,
             decorator_mode=DecoratorMode.UPDATE,
         )
 

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -634,13 +634,6 @@ class AKSAgentPoolContext(BaseAKSContext):
         if self.agentpool and self.agentpool.max_count is not None:
             max_count = self.agentpool.max_count
 
-        # mode
-        # read the original value passed by the command
-        mode = self.raw_param.get("mode")
-        # try to read the property value corresponding to the parameter from the `agentpool` object
-        if self.agentpool and self.agentpool.mode is not None:
-            mode = self.agentpool.mode
-
         # these parameters do not need dynamic completion
 
         # validation
@@ -649,7 +642,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             enable_cluster_autoscaler,
             min_count,
             max_count,
-            mode,
+            mode=self.get_mode(),
             decorator_mode=DecoratorMode.CREATE,
         )
         return node_count, enable_cluster_autoscaler, min_count, max_count
@@ -693,10 +686,6 @@ class AKSAgentPoolContext(BaseAKSContext):
         # read the original value passed by the command
         max_count = self.raw_param.get("max_count")
 
-        # mode
-        # read the original value passed by the command, defaulting to the value from the `agentpool` object
-        mode = self.raw_param.get("mode", self.agentpool.mode)
-
         # these parameters do not need dynamic completion
 
         # validation
@@ -719,7 +708,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             enable_cluster_autoscaler or update_cluster_autoscaler,
             min_count,
             max_count,
-            mode,
+            mode=self.get_mode(),
             decorator_mode=DecoratorMode.UPDATE,
         )
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_agentpool_decorator.py
@@ -156,30 +156,37 @@ class AKSAgentPoolContextCommonTestCase(unittest.TestCase):
             self.cmd, AKSAgentPoolParamDict({}), self.models, DecoratorMode.CREATE, self.agentpool_decorator_mode
         )
         # default
-        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(3, False, None, None, DecoratorMode.CREATE)
+        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(3, False, None, None, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
         # custom value
-        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 1, 10, DecoratorMode.CREATE)
+        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 1, 10, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
         # fail on min_count/max_count not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, None, None, DecoratorMode.CREATE)
+            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, None, None, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
         # fail on min_count > max_count
         with self.assertRaises(InvalidArgumentValueError):
-            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 3, 1, DecoratorMode.CREATE)
+            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 3, 1, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
         # fail on node_count < min_count in create mode
         with self.assertRaises(InvalidArgumentValueError):
-            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 7, 10, DecoratorMode.CREATE)
+            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 7, 10, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
         # skip node_count check in update mode
-        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 7, 10, DecoratorMode.UPDATE)
-        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(None, True, 7, 10, DecoratorMode.UPDATE)
+        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, True, 7, 10, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.UPDATE)
+        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(None, True, 7, 10, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.UPDATE)
 
         # fail on enable_cluster_autoscaler not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, False, 3, None, DecoratorMode.UPDATE)
+            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(5, False, 3, None, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.UPDATE)
+
+        # min_count set to 0 for user node pools
+        ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(0, True, 0, 1, CONST_NODEPOOL_MODE_USER, DecoratorMode.CREATE)
+
+        # fail on min_count < 1 for system node pools
+        with self.assertRaises(InvalidArgumentValueError):
+            ctx._AKSAgentPoolContext__validate_counts_in_autoscaler(1, True, 0, 1, CONST_NODEPOOL_MODE_SYSTEM, DecoratorMode.CREATE)
 
     def common_get_resource_group_name(self):
         # default


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```
az aks nodepool add
az aks nodepool update
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR address 2 changes

- Node Pools can be scaled from 0 to 1000 nodes from the Azure Portal, but the CLI has a check restricting them between 1 and 100
- Only User Node Pools support scaling to 0 nodes, which after the fix for the acceptable range above, results in unintuitive error messages from the ARM endpoint

After the fix for the first, the following commands were tested, resulting in errors from ARM as below
```sh
# Creating a System Node Pool with Min Count set to 0 and Node Count set to 0
$ az aks nodepool add --name {} --cluster-name {} --resource-group {} --enable-cluster-autoscaler --node-count 0 --min-count 0 --max-count 1 --mode System
(InvalidParameter) The value of parameter agentPoolProfile.count is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Code: InvalidParameter
Message: The value of parameter agentPoolProfile.count is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Target: agentPoolProfile.count

# Creating a System Node Pool with Min Count set to 0 and Node Count set to 1
$ az aks nodepool add --name {} --cluster-name {} --resource-group {} --enable-cluster-autoscaler --node-count 1 --min-count 0 --max-count 1 --mode System
(InvalidParameter) The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Code: InvalidParameter
Message: The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Target: agentPoolProfile.minCount

# Updating a System Node Pool to have Min Count set to 0
$ az aks nodepool update --name {} --cluster-name {} --resource-group {} --update-cluster-autoscaler --min-count 0 --max-count 1
(InvalidParameter) The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Code: InvalidParameter
Message: The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Target: agentPoolProfile.minCount

# Updating a User Node Pool to a System Node Pool with Min Count set to 0
$ az aks nodepool update --name {} --cluster-name {} --resource-group {} --update-cluster-autoscaler --min-count 0 --max-count 1 --mode System
(InvalidParameter) The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Code: InvalidParameter
Message: The value of parameter agentPoolProfile.minCount is invalid. Please see https://aka.ms/aks-naming-rules for more details.
Target: agentPoolProfile.minCount
```

With the other set of changes in this PR, all of the above commands will result in the following error instead
```
Value of min-count should be greater than or equal to 1 for System node pools
```

resolves #22032
resolves #22438

**Testing Guide**
<!--Example commands with explanations.-->

Run the commands mentioned above

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
