### PR TITLE
[AKS] GA Kubernetes version alias

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -72,6 +72,7 @@ def _aks_table_format(result):
         location: location,
         resourceGroup: resourceGroup,
         kubernetesVersion: kubernetesVersion,
+        currentKubernetesVersion: currentKubernetesVersion,
         provisioningState: provisioningState,
         fqdn: fqdn || privateFqdn
     }""")

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -100,7 +100,7 @@ def validate_k8s_version(namespace):
             namespace.kubernetes_version = found[0]
         else:
             raise CLIError('--kubernetes-version should be the full version number or major.minor version number, '
-                            'such as "1.7.12" or "1.7"')
+                           'such as "1.7.12" or "1.7"')
 
 
 def validate_nodepool_name(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -94,13 +94,13 @@ def validate_k8s_version(namespace):
     """Validates a string as a possible Kubernetes version. An empty string is also valid, which tells the server
     to use its default version."""
     if namespace.kubernetes_version:
-        k8s_release_regex = re.compile(r'^[v|V]?(\d+\.\d+\.\d+.*)$')
+        k8s_release_regex = re.compile(r'^[v|V]?(\d+\.\d+(?:\.\d+)?)$')
         found = k8s_release_regex.findall(namespace.kubernetes_version)
         if found:
             namespace.kubernetes_version = found[0]
         else:
-            raise CLIError('--kubernetes-version should be the full version number, '
-                           'such as "1.11.8" or "1.12.6"')
+            raise CLIError('--kubernetes-version should be the full version number or major.minor version number, '
+                            'such as "1.7.12" or "1.7"')
 
 
 def validate_nodepool_name(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -95,9 +95,10 @@ class TestValidateIPRanges(unittest.TestCase):
 
 
 class Namespace:
-    def __init__(self, api_server_authorized_ip_ranges=None, cluster_autoscaler_profile=None):
+    def __init__(self, api_server_authorized_ip_ranges=None, cluster_autoscaler_profile=None, kubernetes_version=None):
         self.api_server_authorized_ip_ranges = api_server_authorized_ip_ranges
         self.cluster_autoscaler_profile = cluster_autoscaler_profile
+        self.kubernetes_version = kubernetes_version
 
 
 class TestVNetSubnetId(unittest.TestCase):
@@ -418,6 +419,45 @@ class TestCredentialFormat(unittest.TestCase):
         namespace = CredentialFormatNamespace(credential_format)
 
         validators.validate_credential_format(namespace)
+
+class TestValidateKubernetesVersion(unittest.TestCase):
+
+     def test_valid_full_kubernetes_version(self):
+         kubernetes_version = "1.11.8"
+         namespace = Namespace(kubernetes_version=kubernetes_version)
+
+         validators.validate_k8s_version(namespace)
+
+     def test_valid_alias_minor_version(self):
+         kubernetes_version = "1.11"
+         namespace = Namespace(kubernetes_version=kubernetes_version)
+
+         validators.validate_k8s_version(namespace)
+
+     def test_valid_empty_kubernetes_version(self):
+         kubernetes_version = ""
+         namespace = Namespace(kubernetes_version=kubernetes_version)
+
+         validators.validate_k8s_version(namespace)
+
+     def test_invalid_kubernetes_version(self):
+         kubernetes_version = "1.2.3.4"
+
+         namespace = Namespace(kubernetes_version=kubernetes_version)
+         err = ("--kubernetes-version should be the full version number or major.minor version number, "
+                "such as \"1.7.12\" or \"1.7\"")
+
+         with self.assertRaises(CLIError) as cm:
+             validators.validate_k8s_version(namespace)
+         self.assertEqual(str(cm.exception), err)
+
+         kubernetes_version = "1."
+
+         namespace = Namespace(kubernetes_version=kubernetes_version)
+
+         with self.assertRaises(CLIError) as cm:
+             validators.validate_k8s_version(namespace)
+         self.assertEqual(str(cm.exception), err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az aks create --kubernetes-version
az aks show

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
(1) AKS supports ManagedCluster kubernetes version with format major.minor, so remove the original limitation version number must have patch number
(2) AKS has both kubernetesVersion and currentKubernetesVersion, currentKubernetesVersion is the actual version that MC running. We add it in the az aks show command

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
