### PR TITLE
[App Service] Fix #19492: `az webapp config backup restore` fails

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2105,7 +2105,7 @@ def restore_backup(cmd, resource_group_name, webapp_name, storage_account_url, b
     if slot:
         return client.web_apps.begin_restore_slot(resource_group_name, webapp_name, 0, slot, restore_request)
 
-    return client.web_apps.begin_restore(resource_group_name, webapp_name, 0, restore_request)
+    return client.web_apps.begin_restore_from_backup_blob(resource_group_name, webapp_name, restore_request)
 
 
 def list_snapshots(cmd, resource_group_name, name, slot=None):


### PR DESCRIPTION
**Related command**
az webapp config backup restore

**Description**<!--Mandatory-->
Updated the API methods used for the backup restore.

**Testing Guide**
az webapp config backup create --backup-name {} --container-url {} --resource-group {} --webapp-name {} --overwrite
az webapp config backup restore --backup-name {} --container-url {} --resource-group {} --webapp-name {} --overwrite

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
