### PR TITLE
[Storage] Fix #22209: `az storage entity insert`: Fix `Edm.Boolean` not working

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -10,7 +10,7 @@ azure-cli==2.36.0
 azure-common==1.1.22
 azure-core==1.21.1
 azure-cosmos==3.2.0
-azure-data-tables==12.2.0
+azure-data-tables==12.4.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-keyvault-administration==4.0.0b3

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -10,7 +10,7 @@ azure-cli==2.36.0
 azure-common==1.1.22
 azure-core==1.21.1
 azure-cosmos==3.2.0
-azure-data-tables==12.2.0
+azure-data-tables==12.4.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-keyvault-administration==4.0.0b3

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -10,7 +10,7 @@ azure-cli==2.36.0
 azure-common==1.1.22
 azure-core==1.21.1
 azure-cosmos==3.2.0
-azure-data-tables==12.2.0
+azure-data-tables==12.4.0
 azure-datalake-store==0.0.49
 azure-graphrbac==0.60.0
 azure-keyvault-administration==4.0.0b3

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -56,7 +56,7 @@ DEPENDENCIES = [
     'azure-batch~=12.0.0',
     'azure-cli-core=={}'.format(VERSION),
     'azure-cosmos~=3.0,>=3.0.2',
-    'azure-data-tables==12.2.0',
+    'azure-data-tables==12.4.0',
     'azure-datalake-store~=0.0.49',
     'azure-graphrbac~=0.60.0',
     'azure-keyvault-administration==4.0.0b3',


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage entity insert`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #22209 
Pick up the SDK fix for `odata.type="Edm.Boolean"` in https://github.com/Azure/azure-sdk-for-python/pull/24290

**Testing Guide**
<!--Example commands with explanations.-->
Insert an entity with boolean attribute:
```
az storage entity insert -t ystable --account-name yssa --if-exists replace -e PartitionKey=123 RowKey=456 Active=true Active@odata.type="Edm.Boolean"
```
Query the entity:
```
az storage entity query -t ystable --account-name yssa --filter "PartitionKey eq '123' and RowKey eq '456'"
```
The response should contain `"Active": true` instead of `"Active": "true"`


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
