### PR TITLE
{Role} Raise `GraphError` only when Graph request fails

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -267,4 +267,11 @@ class RecommendationError(ClientError):
 class AuthenticationError(ServiceError):
     """ Raised when AAD authentication fails. """
 
+
+class HTTPError(CLIError):
+    """ Raised when send_raw_request receives HTTP status code >=400. """
+    def __init__(self, error_msg, response):
+        super().__init__(error_msg)
+        self.response = response
+
 # endregion

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -978,9 +978,8 @@ def send_raw_request(cli_ctx, method, url, headers=None, uri_parameters=None,  #
         reason = r.reason
         if r.text:
             reason += '({})'.format(r.text)
-        ex = CLIError(reason)
-        ex.response = r
-        raise ex
+        from .azclierror import HTTPError
+        raise HTTPError(reason, r)
     if output_file:
         with open(output_file, 'wb') as fd:
             for chunk in r.iter_content(chunk_size=128):

--- a/src/azure-cli/azure/cli/command_modules/role/msgrpah/_graph_client.py
+++ b/src/azure-cli/azure/cli/command_modules/role/msgrpah/_graph_client.py
@@ -7,7 +7,7 @@ import json
 from azure.cli.core._profile import Profile
 from azure.cli.core.util import send_raw_request
 from azure.cli.core.auth.util import resource_to_scopes
-from knack.util import CLIError
+from azure.cli.core.azclierror import HTTPError
 
 
 # pylint: disable=redefined-builtin, too-many-public-methods
@@ -36,8 +36,9 @@ class GraphClient:
         while True:
             try:
                 r = send_raw_request(self.cli_ctx, method, url, resource=self.resource, uri_parameters=param, body=body)
-            except CLIError as ex:
+            except HTTPError as ex:
                 raise GraphError(ex.response.json()['error']['message'], ex.response) from ex
+            # Other exceptions like AuthenticationError should not be handled here, so we don't catch CLIError
 
             if r.text:
                 dic = r.json()


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->

Currently, all subclasses of `CLIError` are re-raised as `GraphError`. This is not correct and causes failure for `AuthenticationError` handling.

For example, we change `microsoft_graph_resource_id` to an invalid value like `https://graph1.microsoft.com/`, which is then used as a `scope` to get an access token:

https://github.com/Azure/azure-cli/blob/31e396bed780b8db5641d73ba02fb4ce66db194e/src/azure-cli-core/azure/cli/core/cloud.py#L308

The error handling procedure failed:

```
 > az ad app show --id 0e33fcf1-8a78-4941-9479-75d29681f4dc
...
    result = self._send("GET", "/applications" + _filter_to_query(filter))
  File "d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\role\msgrpah\_graph_client.py", line 40, in _send
    raise GraphError(ex.response.json()['error']['message'], ex.response) from ex
AttributeError: 'AuthenticationError' object has no attribute 'response'
```

This PR makes `send_raw_request` raise a dedicated error `HTTPError` and it is then re-raised as `GraphError`. Since `HTTPError` is a sub-class of `CLIError`, it is backward compatible.

Now invalid `scope` will result in

```
> az ad app show --id 0e33fcf1-8a78-4941-9479-75d29681f4dc
This command or command group has been migrated to Microsoft Graph API. Please carefully review all breaking changes introduced during this migration: https://docs.microsoft.com/cli/azure/microsoft-graph-migration
AADSTS500011: The resource principal named https://graph1.microsoft.com/ was not found in the tenant named AzureSDKTeam. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant.
Trace ID: 4afc0638-c613-4eba-8556-0031e7c8a500
Correlation ID: 17b08664-450c-41fa-a69b-09002c9d5c4d
Timestamp: 2022-05-19 06:52:07Z
To re-authenticate, please run:
az login --scope https://graph1.microsoft.com//.default
```
