### PR TITLE
{AzureRedisCache} Fix the --set shardCount parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/redis/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/redis/_help.py
@@ -152,10 +152,10 @@ examples:
     text: az redis update --name MyRedisCache --resource-group MyResourceGroup --set "sku.name"="Premium" "sku.capacity"="1" "sku.family"="P"
     crafted: true
   - name: Scale an Azure Cache for Redis Instance - Enable Clustering.
-    text: az redis update --name MyRedisCache --resource-group MyResourceGroup --set "shardCount"="1"
+    text: az redis update --name MyRedisCache --resource-group MyResourceGroup --set shardCount=1
     crafted: true
   - name: Scale an Azure Cache for Redis Instance in/out using Redis Cluster.
-    text: az redis update --name MyRedisCache --resource-group MyResourceGroup --set "shardCount"="2"
+    text: az redis update --name MyRedisCache --resource-group MyResourceGroup --set shardCount=2
     crafted: true
 """
 


### PR DESCRIPTION
The CLI command to update the Redis cache shardCount using --set parameter doesnt require double quote.
If you run the command with --set parameter in double quotes like "shardCount"="1" it will fail with below error:

usage error: Empty key in --set. Correct syntax: --set KEY=VALUE [KEY=VALUE ...]

Fixes Azure/azure-cli#22498

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
