### PR TITLE
{AKS} Let AKS RP handle validation of setting pod CIDR and network plugin 

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2852,8 +2852,9 @@ class AKSContext:
             )
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    logger.warning(
+                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +\
+                        f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
                     )
             else:
                 if (
@@ -2959,12 +2960,7 @@ class AKSContext:
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2853,8 +2853,9 @@ class AKSContext:
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +
-                        f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
+                        "When using `--network-plugin azure` without the preview feature  " +
+                        "`--network-plugin-mode overlay` the provided pod CIDR '%s' will be " +
+                        "overwritten with the subnet CIDR.", pod_cidr
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2853,7 +2853,7 @@ class AKSContext:
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +\
+                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +
                         f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
                     )
             else:

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2850,7 +2850,12 @@ class AKSContext:
             ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
                 enable_validation=False
             )
-            if not network_plugin:
+            if network_plugin:
+                if network_plugin == "azure" and pod_cidr:
+                    raise InvalidArgumentValueError(
+                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    )
+            else:
                 if (
                     pod_cidr or
                     service_cidr or
@@ -2954,7 +2959,12 @@ class AKSContext:
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if not network_plugin:
+            if network_plugin:
+                if network_plugin == "azure" and pod_cidr:
+                    raise InvalidArgumentValueError(
+                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    )
+            else:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2853,9 +2853,9 @@ class AKSContext:
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature  " +
-                        "`--network-plugin-mode overlay` the provided pod CIDR '%s' will be " +
-                        "overwritten with the subnet CIDR.", pod_cidr
+                        'When using `--network-plugin azure` without the preview feature '
+                        '`--network-plugin-mode overlay` the provided pod CIDR "%s" will be '
+                        'overwritten with the subnet CIDR.', pod_cidr
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/decorator.py
@@ -2850,12 +2850,7 @@ class AKSContext:
             ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
                 enable_validation=False
             )
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or
@@ -2959,12 +2954,7 @@ class AKSContext:
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1805,7 +1805,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +\
+                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +
                         f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
                     )
             else:

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1805,9 +1805,9 @@ class AKSManagedClusterContext(BaseAKSContext):
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature  " +
-                        "`--network-plugin-mode overlay` the provided pod CIDR '%s' will be " +
-                        "overwritten with the subnet CIDR.", pod_cidr
+                        'When using `--network-plugin azure` without the preview feature '
+                        '`--network-plugin-mode overlay` the provided pod CIDR "%s" will be '
+                        'overwritten with the subnet CIDR.', pod_cidr
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1805,8 +1805,9 @@ class AKSManagedClusterContext(BaseAKSContext):
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
                     logger.warning(
-                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +
-                        f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
+                        "When using `--network-plugin azure` without the preview feature  " +
+                        "`--network-plugin-mode overlay` the provided pod CIDR '%s' will be " +
+                        "overwritten with the subnet CIDR.", pod_cidr
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1804,8 +1804,9 @@ class AKSManagedClusterContext(BaseAKSContext):
             )
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    logger.warning(
+                        "When using `--network-plugin azure` without the preview feature `--network-plugin-mode overlay` the " +\
+                        f"provided pod CIDR {pod_cidr} will be overwritten with the subnet CIDR."
                     )
             else:
                 if (
@@ -1911,12 +1912,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1802,7 +1802,12 @@ class AKSManagedClusterContext(BaseAKSContext):
             ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
                 enable_validation=False
             )
-            if not network_plugin:
+            if network_plugin:
+                if network_plugin == "azure" and pod_cidr:
+                    raise InvalidArgumentValueError(
+                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    )
+            else:
                 if (
                     pod_cidr or
                     service_cidr or
@@ -1906,7 +1911,12 @@ class AKSManagedClusterContext(BaseAKSContext):
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if not network_plugin:
+            if network_plugin:
+                if network_plugin == "azure" and pod_cidr:
+                    raise InvalidArgumentValueError(
+                        "Please use kubenet as the network plugin type when pod_cidr is specified"
+                    )
+            else:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1802,12 +1802,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             ) = self._get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
                 enable_validation=False
             )
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or
@@ -1911,12 +1906,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # validation
         if enable_validation:
             network_plugin = self._get_network_plugin(enable_validation=False)
-            if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    raise InvalidArgumentValueError(
-                        "Please use kubenet as the network plugin type when pod_cidr is specified"
-                    )
-            else:
+            if not network_plugin:
                 if (
                     pod_cidr or
                     service_cidr or

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -2508,20 +2508,6 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_2 = AKSContext(
             self.cmd,
             {
-                "network_plugin": "azure",
-                "pod_cidr": "test_pod_cidr",
-            },
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        # fail on invalid network_plugin (azure) when pod_cidr is specified
-        with self.assertRaises(InvalidArgumentValueError):
-            ctx_2.get_network_plugin()
-
-        # invalid parameter
-        ctx_3 = AKSContext(
-            self.cmd,
-            {
                 "pod_cidr": "test_pod_cidr",
             },
             self.models,
@@ -2529,7 +2515,7 @@ class AKSContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_3.get_network_plugin()
+            ctx_2.get_network_plugin()
 
     def test_get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
         self,

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -2577,20 +2577,6 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_2 = AKSContext(
             self.cmd,
             {
-                "network_plugin": "azure",
-                "pod_cidr": "test_pod_cidr",
-            },
-            self.models,
-            decorator_mode=DecoratorMode.CREATE,
-        )
-        # fail on invalid network_plugin (azure) when pod_cidr is specified
-        with self.assertRaises(InvalidArgumentValueError):
-            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
-
-        # invalid parameter
-        ctx_3 = AKSContext(
-            self.cmd,
-            {
                 "pod_cidr": "test_pod_cidr",
             },
             self.models,
@@ -2598,10 +2584,10 @@ class AKSContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
 
         # invalid parameter
-        ctx_4 = AKSContext(
+        ctx_3 = AKSContext(
             self.cmd,
             {
                 "service_cidr": "test_service_cidr",
@@ -2614,7 +2600,7 @@ class AKSContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_4.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
 
     def test_get_addon_consts(self):
         # default

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -1710,22 +1710,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.cmd,
             AKSManagedClusterParamDict(
                 {
-                    "network_plugin": "azure",
-                    "pod_cidr": "test_pod_cidr",
-                }
-            ),
-            self.models,
-            DecoratorMode.CREATE,
-        )
-        # fail on invalid network_plugin (azure) when pod_cidr is specified
-        with self.assertRaises(InvalidArgumentValueError):
-            ctx_2.get_network_plugin()
-
-        # invalid parameter
-        ctx_3 = AKSManagedClusterContext(
-            self.cmd,
-            AKSManagedClusterParamDict(
-                {
                     "pod_cidr": "test_pod_cidr",
                 }
             ),
@@ -1734,7 +1718,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_3.get_network_plugin()
+            ctx_2.get_network_plugin()
 
     def test_get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy(
         self,

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -1783,22 +1783,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.cmd,
             AKSManagedClusterParamDict(
                 {
-                    "network_plugin": "azure",
-                    "pod_cidr": "test_pod_cidr",
-                }
-            ),
-            self.models,
-            DecoratorMode.CREATE,
-        )
-        # fail on invalid network_plugin (azure) when pod_cidr is specified
-        with self.assertRaises(InvalidArgumentValueError):
-            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
-
-        # invalid parameter
-        ctx_3 = AKSManagedClusterContext(
-            self.cmd,
-            AKSManagedClusterParamDict(
-                {
                     "pod_cidr": "test_pod_cidr",
                 }
             ),
@@ -1807,10 +1791,10 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_2.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
 
         # invalid parameter
-        ctx_4 = AKSManagedClusterContext(
+        ctx_3 = AKSManagedClusterContext(
             self.cmd,
             AKSManagedClusterParamDict(
                 {
@@ -1825,7 +1809,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         )
         # fail on network_plugin not specified
         with self.assertRaises(RequiredArgumentMissingError):
-            ctx_4.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
+            ctx_3.get_pod_cidr_and_service_cidr_and_dns_service_ip_and_docker_bridge_address_and_network_policy()
 
     def test_get_addon_consts(self):
         # default


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks create --network-plugin azure --pod-cidr 10.224.0.0/12`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Should not need client side validation for specifying network plugin azure and a pod CIDR. With `networkPluginMode` in the aks-preview extension it is possible to set the pod-cidr with network plugin azure.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
