### PR TITLE
{CI} Keep the logic consistent with generate_history_notes.py, always check history notes

### DIFF
--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -80,10 +80,10 @@ def main():
 
 def check_pull_request(title, body):
     if title.startswith('[') or title.startswith('{'):
+        error_flag = False
+        # only check title which start with `[`
         if title.startswith('['):
-            error_flag = regex_line(title)
-        else:
-            error_flag = False
+            error_flag = check_line(title)
         is_edit_history_note = False
         history_note_error_flag = False
         for line in body:
@@ -92,8 +92,9 @@ def check_pull_request(title, body):
                 ref = re.findall(r'[\[](.*?)[\]]', line)
                 if ref and ref[0] not in ['Component Name 1', 'Component Name 2']:
                     is_edit_history_note = True
-                    history_note_error_flag = regex_line(line) or history_note_error_flag
-        # If edit history notes, ignore title check result
+                    history_note_error_flag = check_line(line) or history_note_error_flag
+        # If the `History Notes` is edited:
+        # Use the history notes check result (history_note_error_flag), ignore the title check result (error_flag).
         error_flag = error_flag if not is_edit_history_note else history_note_error_flag
     else:
         logger.error('Pull Request title should start with [ or { , Please follow https://aka.ms/submitAzPR')
@@ -101,7 +102,8 @@ def check_pull_request(title, body):
     return error_flag
 
 
-def regex_line(line):
+def check_line(line):
+    # check every line
     error_flag = False
     # Check Fix #number in title, just give a warning here, because it is not necessarily.
     if 'Fix' in line:

--- a/scripts/ci/check_pull_request.py
+++ b/scripts/ci/check_pull_request.py
@@ -79,8 +79,11 @@ def main():
 
 
 def check_pull_request(title, body):
-    if title.startswith('['):
-        error_flag = regex_line(title)
+    if title.startswith('[') or title.startswith('{'):
+        if title.startswith('['):
+            error_flag = regex_line(title)
+        else:
+            error_flag = False
         is_edit_history_note = False
         history_note_error_flag = False
         for line in body:
@@ -90,10 +93,8 @@ def check_pull_request(title, body):
                 if ref and ref[0] not in ['Component Name 1', 'Component Name 2']:
                     is_edit_history_note = True
                     history_note_error_flag = regex_line(line) or history_note_error_flag
-		# If edit history notes, ignore title check result
+        # If edit history notes, ignore title check result
         error_flag = error_flag if not is_edit_history_note else history_note_error_flag
-    elif title.startswith('{'):
-        error_flag = False
     else:
         logger.error('Pull Request title should start with [ or { , Please follow https://aka.ms/submitAzPR')
         error_flag = True


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Now we only check history notes when title starts with `[`.
But `scripts/release/generate_history_notes.py` will get all history notes even if the title starts with `{`.
In azure-cli-2.37.0, the following problems were not detected because #22507‘s title starts with `{`：
![image](https://user-images.githubusercontent.com/18628534/169444173-ae473896-44f6-4b14-b900-e960ee10dad3.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
