### PR TITLE
{Keyvault} Fix #22540: Create keyvault with service principal

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -304,15 +304,9 @@ def list_vault(client, resource_group_name=None):
     return list(vault_list)
 
 
-# pylint: disable=inconsistent-return-statements
 def _get_current_user_object_id(graph_client):
-    from azure.cli.command_modules.role import GraphError
-    try:
-        current_user = graph_client.signed_in_user_get()
-        if current_user and current_user.get('id', None):  # pylint:disable=no-member
-            return current_user['id']  # pylint:disable=no-member
-    except GraphError:
-        pass
+    current_user = graph_client.signed_in_user_get()
+    return current_user['id']
 
 
 def _get_object_id_by_spn(graph_client, spn):


### PR DESCRIPTION
**Related command**
`az keyvault create`

**Description**<!--Mandatory-->

- Fix #22540

https://github.com/Azure/azure-cli/pull/22203 changed `msrestazure.azure_exceptions.CloudError` to `azure.cli.command_modules.role.GraphError` in `azure.cli.command_modules.keyvault.custom._get_current_user_object_id`.

Some background: **`azure-graphrbac` Python SDK raises inconsistent exceptions for Graph errors**:

`DomainsOperations.get` raises `CloudError`:

https://github.com/Azure/azure-sdk-for-python/blob/dfa109c36598d93aaf74238feded516352c20f4c/sdk/graphrbac/azure-graphrbac/azure/graphrbac/operations/domains_operations.py#L150-L153

```py
        if response.status_code not in [200]:
            exp = CloudError(response)
            exp.request_id = response.headers.get('x-ms-request-id')
            raise exp
```

`SignedInUserOperations.get` raises `GraphErrorException`:

https://github.com/Azure/azure-sdk-for-python/blob/dfa109c36598d93aaf74238feded516352c20f4c/sdk/graphrbac/azure-graphrbac/azure/graphrbac/operations/signed_in_user_operations.py#L79-L80


```py
        if response.status_code not in [200]:
            raise models.GraphErrorException(self._deserialize, response)
```

Since `SignedInUserOperations.get` doesn't raise `CloudError`, this `except CloudError` will never be hit:

https://github.com/Azure/azure-cli/blob/1451bd570fd0fe54771cedaecdbd49cdb4b8d69c/src/azure-cli/azure/cli/command_modules/keyvault/custom.py#L312-L317

**Therefore, this `except CloudError` clause has no effect and should NOT be replaced by `GraphError`.** Doing so will make `GraphError` be intercepted and the outer `except GraphError` have no effect:

https://github.com/Azure/azure-cli/blob/cac3f06cf483d8c81f93c9cd556116e27aff2182/src/azure-cli/azure/cli/command_modules/keyvault/custom.py#L747-L750

This PR lets `_get_current_user_object_id` raise `GraphError` so that it can be caught by outer `except GraphError`.

**Testing Guide**
```sh
az ad sp create-for-rbac --role Owner --scopes /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590 --verbose

# Copy the login command from log and run:
az login --service-principal --username 558c5061-b77b-4dfa-8118-168068c9be4a --password xxx --tenant 54826b22-38d6-4fb2-bad9-b7b93a3e9c5a

az group create -n my-kv-testrg -l eastasia
az keyvault create -n my-kv-test -g my-kv-testrg
```
