### PR TITLE
{Graph} Build base URL correctly for sovereign clouds

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/msgrpah/_graph_client.py
+++ b/src/azure-cli/azure/cli/command_modules/role/msgrpah/_graph_client.py
@@ -19,10 +19,12 @@ class GraphClient:
         self.scopes = resource_to_scopes(cli_ctx.cloud.endpoints.microsoft_graph_resource_id)
 
         # https://graph.microsoft.com/ (AzureCloud)
+        # https://microsoftgraph.chinacloudapi.cn (AzureChinaCloud)
         self.resource = cli_ctx.cloud.endpoints.microsoft_graph_resource_id
 
         # https://graph.microsoft.com/v1.0
-        self.base_url = cli_ctx.cloud.endpoints.microsoft_graph_resource_id + 'v1.0'
+        # https://microsoftgraph.chinacloudapi.cn/v1.0
+        self.base_url = cli_ctx.cloud.endpoints.microsoft_graph_resource_id.rstrip('/') + '/v1.0'
 
     def _send(self, method, url, param=None, body=None):
         url = self.base_url + url


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->

Sovereign clouds' `microsoft_graph_resource_id` may not have a trailing slash `/`.

AzureCloud:
https://github.com/Azure/azure-cli/blob/31e396bed780b8db5641d73ba02fb4ce66db194e/src/azure-cli-core/azure/cli/core/cloud.py#L308

AzureChinaCloud:
https://github.com/Azure/azure-cli/blob/31e396bed780b8db5641d73ba02fb4ce66db194e/src/azure-cli-core/azure/cli/core/cloud.py#L345

AzureUSGovernment:
https://github.com/Azure/azure-cli/blob/31e396bed780b8db5641d73ba02fb4ce66db194e/src/azure-cli-core/azure/cli/core/cloud.py#L376

AzureGermanCloud:
https://github.com/Azure/azure-cli/blob/31e396bed780b8db5641d73ba02fb4ce66db194e/src/azure-cli-core/azure/cli/core/cloud.py#L408

In order to build Microsoft Graph base URL correctly, trailing slash `/` should be stripped (if possible) and then added back, otherwise, AzureChinaCloud's Graph base URL becomes:

```
https://microsoftgraph.chinacloudapi.cnv1.0
```