### PR TITLE
[Security] `az security atp cosmosdb`: Add CLI support for ATP settings (Defender) on Cosmos DB

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/security/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_help.py
@@ -148,7 +148,7 @@ short-summary: Display Advanced Threat Protection settings for an Azure Cosmos D
 examples:
   - name: Retrieve Advanced Threat Protection settings for an Azure Cosmos DB account on a subscription scope.
     text: >
-        az security atp cosmosdb show --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount
+        az security atp cosmosdb show --resource-group MyResourceGroup --cosmosdb-account MyCosmosDbAccount
 """
 
 helps['security atp storage update'] = """
@@ -169,10 +169,10 @@ short-summary: Toggle status of Advanced Threat Protection for an Azure Cosmos D
 examples:
   - name: Enable Advanced Threat Protection for an Azure Cosmos DB account on a subscription scope.
     text: >
-        az security atp cosmosdb update --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount --is-enabled true
+        az security atp cosmosdb update --resource-group MyResourceGroup --cosmosdb-account MyCosmosDbAccount --is-enabled true
   - name: Disable Advanced Threat Protection for an Azure Cosmos DB account on a subscription scope.
     text: >
-        az security atp cosmosdb update --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount --is-enabled false
+        az security atp cosmosdb update --resource-group MyResourceGroup --cosmosdb-account MyCosmosDbAccount --is-enabled false
 """
 
 helps['security va'] = """

--- a/src/azure-cli/azure/cli/command_modules/security/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_help.py
@@ -128,6 +128,11 @@ type: group
 short-summary: View and manage Advanced Threat Protection settings for storage accounts.
 """
 
+helps['security atp cosmosdb'] = """
+type: group
+short-summary: View and manage Advanced Threat Protection settings for Cosmos DB accounts.
+"""
+
 helps['security atp storage show'] = """
 type: command
 short-summary: Display Advanced Threat Protection settings for a storage account.
@@ -135,6 +140,15 @@ examples:
   - name: Retrieve Advanced Threat Protection settings for a storage account on a subscription scope.
     text: >
         az security atp storage show --resource-group MyResourceGroup --storage-account MyStorageAccount
+"""
+
+helps['security atp cosmosdb show'] = """
+type: command
+short-summary: Display Advanced Threat Protection settings for an Azure Cosmos DB account.
+examples:
+  - name: Retrieve Advanced Threat Protection settings for an Azure Cosmos DB account on a subscription scope.
+    text: >
+        az security atp cosmosdb show --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount
 """
 
 helps['security atp storage update'] = """
@@ -147,6 +161,18 @@ examples:
   - name: Disable Advanced Threat Protection for a storage account on a subscription scope.
     text: >
         az security atp storage update --resource-group MyResourceGroup --storage-account MyStorageAccount --is-enabled false
+"""
+
+helps['security atp cosmosdb update'] = """
+type: command
+short-summary: Toggle status of Advanced Threat Protection for an Azure Cosmos DB account.
+examples:
+  - name: Enable Advanced Threat Protection for an Azure Cosmos DB account on a subscription scope.
+    text: >
+        az security atp cosmosdb update --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount --is-enabled true
+  - name: Disable Advanced Threat Protection for an Azure Cosmos DB account on a subscription scope.
+    text: >
+        az security atp cosmosdb update --resource-group MyResourceGroup --cosmos-db-account MyCosmosDbAccount --is-enabled false
 """
 
 helps['security va'] = """

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -39,8 +39,8 @@ suppression_rule_scope_contains_arg_type = CLIArgumentType(options_list=('--cont
 suppression_rule_scope_any_of_arg_type = CLIArgumentType(options_list=('--any-of'), metavar='ANYOF', help='A list of strings to scope the suppression rule by.')
 
 # Atp
-storage_account_arg_type = CLIArgumentType(options_list=('--storage-account'), metavar='NAME', help='Name of an existing storage account.')
-cosmos_db_account_arg_type = CLIArgumentType(options_list=('--cosmosdb-account'), metavar='NAME', help='Name of an existing cosmos db account.')
+storage_account_arg_type = CLIArgumentType(options_list=('--storage-account'), metavar='NAME', help='Name of an existing Storage account.')
+cosmos_db_account_arg_type = CLIArgumentType(options_list=('--cosmosdb-account'), metavar='NAME', help='Name of an existing Cosmos DB account.')
 
 # Sql Vulnerability Assessment
 va_sql_vm_resource_id_arg_type = CLIArgumentType(options_list=('--vm-resource-id'), metavar='VMRESOURCEID', help='Resource ID of the scanned machine. For On-Premise machines, please provide your workspace resource ID')

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -40,6 +40,7 @@ suppression_rule_scope_any_of_arg_type = CLIArgumentType(options_list=('--any-of
 
 # Atp
 storage_account_arg_type = CLIArgumentType(options_list=('--storage-account'), metavar='NAME', help='Name of an existing storage account.')
+cosmos_db_account_arg_type = CLIArgumentType(options_list=('--cosmos-db-account'), metavar='NAME', help='Name of an existing cosmos db account.')
 
 # Sql Vulnerability Assessment
 va_sql_vm_resource_id_arg_type = CLIArgumentType(options_list=('--vm-resource-id'), metavar='VMRESOURCEID', help='Resource ID of the scanned machine. For On-Premise machines, please provide your workspace resource ID')
@@ -179,6 +180,9 @@ def load_arguments(self, _):
                 'storage_account_name',
                 arg_type=storage_account_arg_type)
             c.argument(
+                'cosmos_db_account_name',
+                arg_type=cosmos_db_account_arg_type)
+            c.argument(
                 'vm_resource_id',
                 arg_type=va_sql_vm_resource_id_arg_type)
             c.argument(
@@ -286,9 +290,9 @@ def load_arguments(self, _):
                 validator=validate_auto_provisioning_toggle,
                 arg_type=auto_provisioning_auto_provision_arg_type)
 
-    for scope in ['atp storage update']:
+    for scope in ['atp storage update', 'atp cosmosdb update']:
         with self.argument_context('security {}'.format(scope)) as c:
-            c.argument('is_enabled', help='Enable or disable Advanced Threat Protection for a received storage account.', arg_type=get_three_state_flag())
+            c.argument('is_enabled', help='Enable or disable Advanced Threat Protection for a received storage or Cosmos DB account.', arg_type=get_three_state_flag())
 
     for scope in ['va sql scans show',
                   'va sql results']:

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -199,13 +199,13 @@ def load_arguments(self, _):
                 arg_type=va_sql_vm_uuid_arg_type)
 
     with self.argument_context('security atp storage') as c:
-            c.argument(
-                'storage_account_name',
-                arg_type=storage_account_arg_type)
+        c.argument(
+            'storage_account_name',
+            arg_type=storage_account_arg_type)
     with self.argument_context('security atp cosmosdb') as c:
-            c.argument(
-                'cosmos_db_account_name',
-                arg_type=cosmos_db_account_arg_type)
+        c.argument(
+            'cosmos_db_account_name',
+            arg_type=cosmos_db_account_arg_type)
 
     for scope in ['regulatory-compliance-controls']:
         with self.argument_context('security {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/security/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/security/_params.py
@@ -40,7 +40,7 @@ suppression_rule_scope_any_of_arg_type = CLIArgumentType(options_list=('--any-of
 
 # Atp
 storage_account_arg_type = CLIArgumentType(options_list=('--storage-account'), metavar='NAME', help='Name of an existing storage account.')
-cosmos_db_account_arg_type = CLIArgumentType(options_list=('--cosmos-db-account'), metavar='NAME', help='Name of an existing cosmos db account.')
+cosmos_db_account_arg_type = CLIArgumentType(options_list=('--cosmosdb-account'), metavar='NAME', help='Name of an existing cosmos db account.')
 
 # Sql Vulnerability Assessment
 va_sql_vm_resource_id_arg_type = CLIArgumentType(options_list=('--vm-resource-id'), metavar='VMRESOURCEID', help='Resource ID of the scanned machine. For On-Premise machines, please provide your workspace resource ID')
@@ -177,12 +177,6 @@ def load_arguments(self, _):
                 'location',
                 arg_type=location_arg_type)
             c.argument(
-                'storage_account_name',
-                arg_type=storage_account_arg_type)
-            c.argument(
-                'cosmos_db_account_name',
-                arg_type=cosmos_db_account_arg_type)
-            c.argument(
                 'vm_resource_id',
                 arg_type=va_sql_vm_resource_id_arg_type)
             c.argument(
@@ -203,6 +197,15 @@ def load_arguments(self, _):
             c.argument(
                 'vm_uuid',
                 arg_type=va_sql_vm_uuid_arg_type)
+
+    with self.argument_context('security atp storage') as c:
+            c.argument(
+                'storage_account_name',
+                arg_type=storage_account_arg_type)
+    with self.argument_context('security atp cosmosdb') as c:
+            c.argument(
+                'cosmos_db_account_name',
+                arg_type=cosmos_db_account_arg_type)
 
     for scope in ['regulatory-compliance-controls']:
         with self.argument_context('security {}'.format(scope)) as c:

--- a/src/azure-cli/azure/cli/command_modules/security/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/security/commands.py
@@ -289,6 +289,12 @@ def load_command_table(self, _):
         g.custom_show_command('show', 'get_atp_setting')
         g.custom_command('update', 'update_atp_setting')
 
+    with self.command_group('security atp cosmosdb',
+                            security_advanced_threat_protection_sdk,
+                            client_factory=cf_security_advanced_threat_protection) as g:
+        g.custom_show_command('show', 'get_atp_setting')
+        g.custom_command('update', 'update_atp_setting')
+
     with self.command_group('security va sql scans',
                             security_sql_vulnerability_assessment_scans_sdk,
                             client_factory=cf_sql_vulnerability_assessment_scans) as g:

--- a/src/azure-cli/azure/cli/command_modules/security/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/security/commands.py
@@ -283,17 +283,12 @@ def load_command_table(self, _):
         g.custom_command('upsert_scope', 'upsert_security_alerts_suppression_rule_scope')
         g.custom_command('delete_scope', 'delete_security_alerts_suppression_rule_scope')
 
-    with self.command_group('security atp storage',
-                            security_advanced_threat_protection_sdk,
-                            client_factory=cf_security_advanced_threat_protection) as g:
-        g.custom_show_command('show', 'get_atp_setting')
-        g.custom_command('update', 'update_atp_setting')
-
-    with self.command_group('security atp cosmosdb',
-                            security_advanced_threat_protection_sdk,
-                            client_factory=cf_security_advanced_threat_protection) as g:
-        g.custom_show_command('show', 'get_atp_setting')
-        g.custom_command('update', 'update_atp_setting')
+    for scope in ['storage', 'cosmosdb']:
+        with self.command_group(f"security atp {scope}",
+                                security_advanced_threat_protection_sdk,
+                                client_factory=cf_security_advanced_threat_protection) as g:
+            g.custom_command('show', f"get_{scope}_atp_setting")
+            g.custom_command('update', f"update_{scope}_atp_setting")
 
     with self.command_group('security va sql scans',
                             security_sql_vulnerability_assessment_scans_sdk,

--- a/src/azure-cli/azure/cli/command_modules/security/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/security/commands.py
@@ -287,7 +287,7 @@ def load_command_table(self, _):
         with self.command_group(f"security atp {scope}",
                                 security_advanced_threat_protection_sdk,
                                 client_factory=cf_security_advanced_threat_protection) as g:
-            g.custom_command('show', f"get_{scope}_atp_setting")
+            g.custom_show_command('show', f"get_{scope}_atp_setting")
             g.custom_command('update', f"update_{scope}_atp_setting")
 
     with self.command_group('security va sql scans',

--- a/src/azure-cli/azure/cli/command_modules/security/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/security/custom.py
@@ -459,16 +459,25 @@ def delete_security_workspace_setting(client, resource_name):
 
 def get_atp_setting(cmd, client, resource_group_name, storage_account_name):
 
-    return client.get(_construct_resource_id(cmd, resource_group_name, storage_account_name))
+    return client.get(_construct_storage_resource_id(cmd, resource_group_name, storage_account_name))
+
+def get_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name):
+
+    return client.get(_construct_cosmosdb_resource_id(cmd, resource_group_name, cosmos_db_account_name))
 
 
 def update_atp_setting(cmd, client, resource_group_name, storage_account_name, is_enabled):
 
-    return client.create(_construct_resource_id(cmd, resource_group_name, storage_account_name),
+    return client.create(_construct_storage_resource_id(cmd, resource_group_name, storage_account_name),
+                         AdvancedThreatProtectionSetting(is_enabled=is_enabled))
+
+def update_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name, is_enabled):
+
+    return client.create(_construct_cosmosdb_resource_id(cmd, resource_group_name, cosmos_db_account_name),
                          AdvancedThreatProtectionSetting(is_enabled=is_enabled))
 
 
-def _construct_resource_id(cmd, resource_group_name, storage_account_name):
+def _construct_storage_resource_id(cmd, resource_group_name, storage_account_name):
 
     return resource_id(
         subscription=get_subscription_id(cmd.cli_ctx),
@@ -476,6 +485,16 @@ def _construct_resource_id(cmd, resource_group_name, storage_account_name):
         namespace='Microsoft.Storage',
         type='storageAccounts',
         name=storage_account_name)
+
+
+def _construct_cosmosdb_resource_id(cmd, resource_group_name, cosmos_db_account_name):
+
+    return resource_id(
+        subscription=get_subscription_id(cmd.cli_ctx),
+        resource_group=resource_group_name,
+        namespace='Microsoft.DocumentDb',
+        type='databaseAccounts',
+        name=cosmos_db_account_name)
 
 
 # --------------------------------------------------------------------------------------------

--- a/src/azure-cli/azure/cli/command_modules/security/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/security/custom.py
@@ -457,21 +457,23 @@ def delete_security_workspace_setting(client, resource_name):
 # Security ATP
 # --------------------------------------------------------------------------------------------
 
-def get_atp_setting(cmd, client, resource_group_name, storage_account_name):
+def get_storage_atp_setting(cmd, client, resource_group_name, storage_account_name):
 
     return client.get(_construct_storage_resource_id(cmd, resource_group_name, storage_account_name))
 
-def get_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name):
+
+def get_cosmosdb_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name):
 
     return client.get(_construct_cosmosdb_resource_id(cmd, resource_group_name, cosmos_db_account_name))
 
 
-def update_atp_setting(cmd, client, resource_group_name, storage_account_name, is_enabled):
+def update_storage_atp_setting(cmd, client, resource_group_name, storage_account_name, is_enabled):
 
     return client.create(_construct_storage_resource_id(cmd, resource_group_name, storage_account_name),
                          AdvancedThreatProtectionSetting(is_enabled=is_enabled))
 
-def update_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name, is_enabled):
+
+def update_cosmosdb_atp_setting(cmd, client, resource_group_name, cosmos_db_account_name, is_enabled):
 
     return client.create(_construct_cosmosdb_resource_id(cmd, resource_group_name, cosmos_db_account_name),
                          AdvancedThreatProtectionSetting(is_enabled=is_enabled))

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_cosmosdb_atp_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_cosmosdb_atp_settings.yaml
@@ -1,0 +1,769 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-05-23T16:29:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '310'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:29:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
+      [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
+      "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '244'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2021-10-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-05-23T16:29:33.3833124Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"7055fd87-d465-4e1e-a24c-11460cf5879d","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
+        US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Invalid"}},"networkAclBypassResourceIds":[]},"identity":{"type":"None"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '1846'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:29:37 GMT
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002/operationResults/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:30:07 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:30:37 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:31:08 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/a4d32de6-8c82-421d-9824-f6eabbda3858?api-version=2021-10-15
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:31:39 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2021-10-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-05-23T16:30:59.1972278Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"7055fd87-d465-4e1e-a24c-11460cf5879d","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}},"networkAclBypassResourceIds":[]},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2141'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:31:39 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-cosmosdb/7.0.0b2 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002?api-version=2021-10-15
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000002","name":"cli000002","location":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-05-23T16:30:59.1972278Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000002.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"7055fd87-d465-4e1e-a24c-11460cf5879d","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000002-westus","locationName":"West
+        US","documentEndpoint":"https://cli000002-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000002-westus","locationName":"West
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Periodic","periodicModeProperties":{"backupIntervalInMinutes":240,"backupRetentionIntervalInHours":8,"backupStorageRedundancy":"Geo"}},"networkAclBypassResourceIds":[]},"identity":{"type":"None"}}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '2141'
+      content-type:
+      - application/json
+      date:
+      - Mon, 23 May 2022 16:31:40 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --cosmosdb-account
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '330'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:31:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"isEnabled": true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-group --cosmosdb-account --is-enabled
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '329'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:31:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --cosmosdb-account
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '329'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:31:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"isEnabled": false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-group --cosmosdb-account --is-enabled
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '330'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:32:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --cosmosdb-account
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '330'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:32:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"isEnabled": true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --resource-group --cosmosdb-account --is-enabled
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '329'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:32:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - security atp cosmosdb show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --resource-group --cosmosdb-account
+      User-Agent:
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
+  response:
+    body:
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.DocumentDb/databaseAccounts/cli000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '329'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 23 May 2022 16:32:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      request-context:
+      - appId=
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding,Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '4999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_storage_atp_settings.yaml
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/recordings/test_security_storage_atp_settings.yaml
@@ -13,21 +13,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '400'
+      - '330'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:06 GMT
+      - Mon, 23 May 2022 16:49:20 GMT
       expires:
       - '-1'
       pragma:
@@ -69,21 +69,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account --is-enabled
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '399'
+      - '329'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:10 GMT
+      - Mon, 23 May 2022 16:49:27 GMT
       expires:
       - '-1'
       pragma:
@@ -121,21 +121,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '399'
+      - '329'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:12 GMT
+      - Mon, 23 May 2022 16:49:31 GMT
       expires:
       - '-1'
       pragma:
@@ -177,21 +177,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account --is-enabled
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '400'
+      - '330'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:16 GMT
+      - Mon, 23 May 2022 16:49:37 GMT
       expires:
       - '-1'
       pragma:
@@ -229,21 +229,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":false}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '400'
+      - '330'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:17 GMT
+      - Mon, 23 May 2022 16:49:41 GMT
       expires:
       - '-1'
       pragma:
@@ -261,7 +261,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '4998'
+      - '4999'
       x-powered-by:
       - ASP.NET
     status:
@@ -285,21 +285,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account --is-enabled
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '399'
+      - '329'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:20 GMT
+      - Mon, 23 May 2022 16:49:49 GMT
       expires:
       - '-1'
       pragma:
@@ -337,21 +337,21 @@ interactions:
       ParameterSetName:
       - --resource-group --storage-account
       User-Agent:
-      - AZURECLI/2.25.0 azsdk-python-mgmt-security/1.0.0 Python/3.9.5 (Windows-10-10.0.19042-SP0)
+      - AZURECLI/2.37.0 azsdk-python-mgmt-security/2.0.0b1 Python/3.10.0 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current?api-version=2019-01-01
   response:
     body:
-      string: '{"id":"subscriptions/d32bb0ce-a0d0-4234-a7f4-1be3be0ec252/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
+      string: '{"id":"subscriptions/14060bff-305b-45c3-8127-33958b65631b/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/providers/Microsoft.Security/advancedThreatProtectionSettings/current","type":"Microsoft.Security/advancedThreatProtectionSettings","name":"current","properties":{"isEnabled":true}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '399'
+      - '329'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 Aug 2021 08:50:22 GMT
+      - Mon, 23 May 2022 16:49:51 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_atp_scenario.py
+++ b/src/azure-cli/azure/cli/command_modules/security/tests/latest/test_atp_scenario.py
@@ -9,38 +9,41 @@ from azure.cli.testsdk import (ScenarioTest, ResourceGroupPreparer, StorageAccou
 class SecurityAtpSettingsTests(ScenarioTest):
     @ResourceGroupPreparer()
     @StorageAccountPreparer()
-    def test_security_atp_settings(self, resource_group, resource_group_location, storage_account):
+    def test_security_storage_atp_settings(self, resource_group, storage_account):
+        self._test_security_atp_settings(resource_group, storage_account, "storage", "storage-account")
+    
+    
+    @ResourceGroupPreparer()
+    def test_security_cosmosdb_atp_settings(self, resource_group):
+        cosmosdb_account_name = self.create_random_name(prefix='cli', length=40)
+        self.cmd(f"az cosmosdb create -n {cosmosdb_account_name} -g {resource_group}")
+        self._test_security_atp_settings(resource_group, cosmosdb_account_name, "cosmosdb", "cosmosdb-account")
+
+    def _test_security_atp_settings(self, resource_group, resource_name, resource_type, resource_param_name):
         # run show cli
-        atp_settings = self.cmd('security atp storage show --resource-group {} --storage-account {}'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        atp_settings = self.cmd(f"security atp {resource_type} show --resource-group {resource_group} --{resource_param_name} {resource_name}").get_output_in_json()
         self.assertTrue(len(atp_settings) >= 0)
 
         # enable atp with --is-enabled = true
-        atp_settings = self.cmd('security atp storage update --resource-group {} --storage-account {} --is-enabled true'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        atp_settings = self.cmd(f"security atp {resource_type} update --resource-group {resource_group} --{resource_param_name} {resource_name} --is-enabled true").get_output_in_json()
         self.assertTrue(atp_settings["isEnabled"])
 
-        # validate atp setting
-        atp_settings = self.cmd('security atp storage show --resource-group {} --storage-account {}'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        # validate that atp setting is enabled
+        atp_settings = self.cmd(f"security atp {resource_type} show --resource-group {resource_group} --{resource_param_name} {resource_name}").get_output_in_json()
         self.assertTrue(atp_settings["isEnabled"])
 
         # disable atp with --is-enabled = false
-        atp_settings = self.cmd('security atp storage update --resource-group {} --storage-account {} --is-enabled false'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        atp_settings = self.cmd(f"security atp {resource_type} update --resource-group {resource_group} --{resource_param_name} {resource_name} --is-enabled false").get_output_in_json()
         self.assertFalse(atp_settings["isEnabled"])
 
-        # validate atp setting
-        self.cmd('security atp storage show --resource-group {} --storage-account {}'
-                 .format(resource_group, storage_account)).get_output_in_json()
+        # validate that atp setting is disabled
+        atp_settings = self.cmd(f"security atp {resource_type} show --resource-group {resource_group} --{resource_param_name} {resource_name}").get_output_in_json()
         self.assertFalse(atp_settings["isEnabled"])
 
-        # enable atp with--is-enabled empty
-        atp_settings = self.cmd('security atp storage update --resource-group {} --storage-account {} --is-enabled'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        # enable atp with--is-enabled (empty)
+        atp_settings = self.cmd(f"security atp {resource_type} update --resource-group {resource_group} --{resource_param_name} {resource_name} --is-enabled").get_output_in_json()
         self.assertTrue(atp_settings["isEnabled"])
 
-        # validate atp setting
-        atp_settings = self.cmd('security atp storage show --resource-group {} --storage-account {}'
-                                .format(resource_group, storage_account)).get_output_in_json()
+        # validate that atp setting is enabled
+        atp_settings = self.cmd(f"security atp {resource_type} show --resource-group {resource_group} --{resource_param_name} {resource_name}").get_output_in_json()
         self.assertTrue(atp_settings["isEnabled"])


### PR DESCRIPTION
**Related command**
```
az security atp cosmosdb show--resource-group MyResourceGroup --cosmosdb-account MyCosmosDbAccount 
az security atp cosmosdb update --resource-group MyResourceGroup --cosmosdb-account MyCosmosDbAccount --is-enabled 
true
```
**Description**
Adding support for get/set ATP settings (Defender) on Cosmos DB resources.
The REST api supports both Storage accounts and Cosmos DB accounts, but until now, the CLI supported only Storage accounts.
In this PR, we added support for Cosmos DB.

The REST api: 
https://docs.microsoft.com/en-us/rest/api/securitycenter/advanced-threat-protection/get
https://docs.microsoft.com/en-us/rest/api/securitycenter/advanced-threat-protection/create

**Testing Guide**
See related commands section above

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
