### PR TITLE
[Network] `az network application-gateway ssl-policy`: Support new SSL policy `CustomV2`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -453,7 +453,7 @@ def load_arguments(self, _):
 
     with self.argument_context('network application-gateway ssl-policy', min_api='2017-06-01') as c:
         c.argument('policy_name', name_arg_type, help='Name of SSL policy.')
-        c.argument('policy_type', help='Type of SSL Policy.', choices=['Custom', 'Predefined'])
+        c.argument('policy_type', help='Type of SSL Policy.', choices=['Custom', 'Predefined', 'CustomV2'])
         c.argument('cipher_suites', nargs='+', help='SSL cipher suites to be enabled in the specified order to application gateway.')
         c.argument('min_protocol_version', help='Minimum version of SSL protocol to be supported on application gateway.')
         c.argument('disabled_ssl_protocols', nargs='+', help='Space-separated list of protocols to disable.')
@@ -496,7 +496,7 @@ def load_arguments(self, _):
         c.argument('application_gateway_name', app_gateway_name_type)
         c.argument('ssl_profile_name', options_list='--name', help='Name of the SSL profile that is unique within an Application Gateway.')
         c.argument('policy_name', help='Name of Ssl Policy.')
-        c.argument('policy_type', help='Type of Ssl Policy.', choices=['Custom', 'Predefined'])
+        c.argument('policy_type', help='Type of Ssl Policy.', choices=['Custom', 'Predefined', 'CustomV2'])
         c.argument('min_protocol_version', help='Minimum version of Ssl protocol to be supported on application gateway.')
         c.argument('cipher_suites', nargs='+', help='Ssl cipher suites to be enabled in the specified order to application gateway.')
         c.argument('disabled_ssl_protocols', options_list=['--disabled-ssl-protocols', '--disabled-protocols'], nargs='+', help='Space-separated list of protocols to disable.')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. ---> az network application-gateway ssl-policy ...

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Application Gateway had introduced new Ssl Policies as a part of NRP release 165. This pr updates the cli to support the customv2 policy and tls1.3 protocol.

**Testing Guide**
<!--Example commands with explanations.-->
az network application-gateway ssl-policy set -g <rg-name> --gateway-name <name> --policy-type CustomV2 --min-protocol-version TLSv1_3 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
