### PR TITLE
[Packaging] Use Python 3.9 in RHEL 8's RPM

### DIFF
--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -10,7 +10,10 @@
   %define dist .el%{?rhel}
 %endif
 
-%define python_cmd python3
+# The Python package name for dnf/yum/tdnf, such as python39, python3
+%define python_package %{getenv:PYTHON_PACKAGE}
+# The Python executable name, such as python3.9, python3
+%define python_cmd %{getenv:PYTHON_CMD}
 
 %define name           azure-cli
 %define release        1%{?dist}
@@ -25,12 +28,12 @@ Version:        %{version}
 Release:        %{release}
 Url:            https://docs.microsoft.com/cli/azure/install-azure-cli
 BuildArch:      x86_64
-Requires:       %{python_cmd}
+Requires:       %{python_package}
 Prefix:         /usr
 Prefix:         /etc
 
 BuildRequires:  gcc, libffi-devel, openssl-devel, perl
-BuildRequires:  %{python_cmd}-devel
+BuildRequires:  %{python_package}-devel
 
 %global _python_bytecompile_errors_terminate_build 0
 
@@ -66,6 +69,7 @@ for d in %{buildroot}%{cli_lib_dir}/bin/*; do perl -p -i -e "s#%{buildroot}##g" 
 # The only solution left is to hard-code 'lib64' as we only release 64-bit RPM packages.
 mkdir -p %{buildroot}%{_bindir}
 python_version=$(ls %{buildroot}%{cli_lib_dir}/lib/ | head -n 1)
+# We make %{python_cmd} the default executable, but if there is a more precise match, such as python3.9, we prefer that.
 printf "#!/usr/bin/env bash
 bin_dir=\`cd \"\$(dirname \"\$BASH_SOURCE[0]\")\"; pwd\`
 python_cmd=%{python_cmd}

--- a/scripts/release/rpm/centos7.dockerfile
+++ b/scripts/release/rpm/centos7.dockerfile
@@ -10,8 +10,10 @@ WORKDIR /azure-cli
 
 COPY . .
 
+# CentOS 7 only has 'python3' package, which is Python 3.6.
 RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
-    REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=python3 PYTHON_CMD=python3 \
+    rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 
 FROM centos:${tag} AS execution-env

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -5,7 +5,7 @@ FROM ${image}:${tag} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
-RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch dos2unix python3-virtualenv perl
+RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch dos2unix perl sed
 
 WORKDIR /azure-cli
 
@@ -22,7 +22,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
 FROM ${image}:${tag} AS execution-env
 
 RUN tdnf update -y
-RUN tdnf install -y python3 python3-virtualenv rpm
+RUN tdnf install -y python3 rpm
 
 COPY --from=build-env /azure-cli-dev.rpm ./
 RUN rpm -i ./azure-cli-dev.rpm && \

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -11,8 +11,12 @@ WORKDIR /azure-cli
 
 COPY . .
 
+# Mariner only has 'python3' package. It has no version-specific packages, like 'python39'.
+# - On Mariner 1.0, 'python3' is Python 3.7
+# - On Mariner 2.0, 'python3' is Python 3.9
 RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
-    REPO_PATH=$(pwd) CLI_VERSION=$cli_version rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=python3 PYTHON_CMD=python3 \
+    rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
 
 FROM ${image}:${tag} AS execution-env


### PR DESCRIPTION
**Description**<!--Mandatory-->

Red Hat Enterprise Linux (RHEL) 8 now has Python 3.6, 3.8, and 3.9: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_installing-and-using-python_configuring-basic-system-settings

Since Python 3.6 has been deprecated (#19858), we use Python 3.9 on RHEL 8.

