### PR TITLE
[Core] shorthand syntax: Simplify the escape character usage in Single Quotes String

### DIFF
--- a/doc/shorthand_syntax.md
+++ b/doc/shorthand_syntax.md
@@ -6,6 +6,27 @@ Azure cli shorthand syntax can help cli users to pass complicated argument value
 
 The command lines written in shorthand syntax can run in both _Powershell_ and _Bash_ terminals without any change in must situations.
 
+[1. Shorthand syntax formats](#shorthand-syntax-formats)
+
+[1.1. `Full Value` format](#full-value-format)
+
+[1.2. `Partial Value` format](#partial-value-format)
+
+[1.3. Combine with `Full Value` and `Partial Value`](#combine-with-full-value-and-partial-value)
+
+[1.4. use `??` to show help](#use--to-show-help)
+
+[1.5. Pass a `null` Value](#pass-a-null-value)
+
+[2. Single Quotes String](#single-quotes-string)
+
+[2.1. Pass a string value with space and other special characters](#pass-a-string-value-with-space-and-other-special-characters)
+
+[2.2. Pass a "null" string value](#pass-a-null-string-value)
+
+[2.3. Use `'/` to Pass `'`](#use--to-pass-)
+
+
 # Shorthand syntax formats
 
 ## `Full Value` format
@@ -87,7 +108,7 @@ Json:
 ```json
 {
   "name": "Bill",
-  "homepage": "https://bill.microsft.com/blog",
+  "motto": "One man's bug is another man's lesson.",
   "age": 20,
   "paid": true,
   "emails": [
@@ -97,37 +118,43 @@ Json:
 }
 ```
 
-Because http url has `:` character, so in `Full Value` format, it should be a __Single Quotes String__(introduced below). In order to support both Powershell and Bash, _Single Quotes String_ uses `/` as escape character.
-which means `https://bill.microsft.com/blog` should be `'https:////bill.microsft.com//blog'` in `Full Value` format. It becomes longer than original, which obeys the goal of shorthand syntax.
+The motto property has ` ` character, so in `Full Value` format, it should be a [__Single Quotes String__](#single-quotes-string).
+However in __Single Quotes String__, the `'` should be replaced by `'/`. So in `Full Value`, it should be passed like `'One man'/s bug is another man'/s lesson.'`.
 
 Use `Full Value`:
 ```bash
-az some-command --contact "{name:Bill,homepage:'https:////bill.microsft.com//blog',age:20,paid:true,emails:[Bill@microsoft.com,Bill@outlook.com]}"
+az some-command --contact "{name:Bill,motto:'One man'/s bug is another man'/s lesson.',age:20,paid:true,emails:[Bill@microsoft.com,Bill@outlook.com]}"
 ```
 
-However in `Partial Value` format, the url can be parsed as string, and it doesn't need to be a __Single Quotes String__.
+However in `Partial Value` format, the motto can be parsed as string, and it doesn't need to be a __Single Quotes String__.
 
 Use `Partial Value`:
 ```bash
-az some-command --contact homepage="https://bill.microsft.com/blog"
+az some-command --contact motto="One man's bug is another man's lesson."
 ```
 
 Shorthand syntax arguments support to patch `Full Value` by adding `Partial Value` after it.
 
 Use `Full Value` and `Partial Value`:
 ```bash
-az some-command --contact "{name:Bill,age:20,paid:true,emails:[Bill@microsoft.com,Bill@outlook.com]}" homepage="https://bill.microsft.com/blog"
+az some-command --contact "{name:Bill,age:20,paid:true,emails:[Bill@microsoft.com,Bill@outlook.com]}" motto="One man's bug is another man's lesson."
+```
+
+You can also patch a new element of list property in `Full Value`. For example you can set the second email address by `Partial Value`:
+```bash
+az some-command --contact "{name:Bill,age:20,paid:true,emails:[Bill@microsoft.com]}" emails[1]="Bill@outlook.com" motto="One man's bug is another man's lesson."
 ```
 
 There's no limitation to put them after one --contact flag or put them after two --contact flags.
 
 Use `Full Value` and `Partial Value` in two --contact flags:
 ```bash
-az some-command --contact "{name:Bill,age:20,paid:true,emails:[Bill@microsoft.com,Bill@outlook.com]}" \
---contact homepage="https://bill.microsft.com/blog"
+az some-command --contact "{name:Bill,age:20,paid:true,emails:[Bill@microsoft.com]}" \
+--contact emails[1]="Bill@outlook.com" \
+--contact motto="One man's bug is another man's lesson."
 ```
 
-The __order__ of them is important!!! If you reverse the order, the final data will only be the `Full Value`. 
+The __order__ of them is important!!! If you reverse the order, the final data will only be the `Full Value` without properties defined in `Partial Value`. 
 
 ## use `??` to show help
 
@@ -312,9 +339,11 @@ Pass `Partial Value` format:
 az some-command --contact name="'null'"
 ```
 
-## escape character `/`
+## Use `'/` to Pass `'`
 
-_Single Quotes String_ use `/` as escape character to support add `'` and `/` in _Single Quotes String_.
+The character `'` needs special escape in _Single Quotes String_ in order to distinguish with end of _Single Quotes String_. You can use `'/` to pass `'` in _Single Quotes String_.
+It should be reminded that `/` is a escape character __only__ after `'` in _Single Quotes String_. If `/` is not in _Single Quotes String_ or `/` is not after `'`, `/` is a normal character.
+
 For example if you want to pass "bill's" string into name property in --contact argument:
 
 Json:
@@ -328,15 +357,15 @@ Json:
 
 Pass `Full Value` format:
 ```bash
-az some-command --contact "{name:'bill/'s',age:20,paid:true}"
+az some-command --contact "{name:'bill'/s',age:20,paid:true}"
 ```
 
 Pass `Partial Value` format:
 ```bash
-az some-command --contact name="'bill/'s'"
+az some-command --contact name="'bill'/s'"
 ```
 
-Only in _Single Quotes String_, the `/` character is escape character. If the value is a sample string, `/` is not required.
+If value is not in _Single Quotes String_, you don't need to add escape character after `'`.
 
 Pass `Partial Value` format:
 ```bash

--- a/src/azure-cli-core/azure/cli/core/aaz/_utils.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_utils.py
@@ -26,28 +26,28 @@ class AAZShortHandSyntaxParser:
             elif data in self.HELP_EXPRESSIONS:
                 raise AAZShowHelp()
             elif len(data) and data[0] == "'":
-                result, length = self.parse_shorthand_quote_string(data)
+                result, length = self.parse_single_quotes_string(data)
                 if length != len(data):
                     raise AAZInvalidShorthandSyntaxError(
                         data, length, len(data) - length, "Redundant tail for quota expression")
             else:
                 result = data
         else:
-            result, length = self.parse_shorthand_value(data)
+            result, length = self.parse_value(data)
             if length != len(data):
                 raise AAZInvalidShorthandSyntaxError(data, length, len(data) - length, "Redundant tail")
         return result
 
-    def parse_shorthand_value(self, remain):
+    def parse_value(self, remain):
         if remain.startswith('{'):
-            return self.parse_shorthand_dict(remain)
+            return self.parse_dict(remain)
 
         if remain.startswith('['):
-            return self.parse_shorthand_list(remain)
+            return self.parse_list(remain)
 
-        return self.parse_shorthand_string(remain)
+        return self.parse_string(remain)
 
-    def parse_shorthand_dict(self, remain):  # pylint: disable=too-many-statements
+    def parse_dict(self, remain):  # pylint: disable=too-many-statements
         result = OrderedDict()
         assert remain.startswith('{')
         idx = 1
@@ -58,7 +58,7 @@ class AAZShortHandSyntaxParser:
 
         while idx < len(remain):
             try:
-                key, length = self.parse_shorthand_string(remain[idx:])
+                key, length = self.parse_string(remain[idx:])
             except AAZInvalidShorthandSyntaxError as ex:
                 ex.error_data = remain
                 ex.error_at += idx
@@ -85,7 +85,7 @@ class AAZShortHandSyntaxParser:
                 raise AAZInvalidShorthandSyntaxError(remain, idx, 1, "Cannot parse empty")
 
             try:
-                value, length = self.parse_shorthand_value(remain[idx:])
+                value, length = self.parse_value(remain[idx:])
             except AAZInvalidShorthandSyntaxError as ex:
                 ex.error_data = remain
                 ex.error_at += idx
@@ -113,7 +113,7 @@ class AAZShortHandSyntaxParser:
 
         return result, idx
 
-    def parse_shorthand_list(self, remain):
+    def parse_list(self, remain):
         result = []
         assert remain.startswith('[')
         idx = 1
@@ -124,7 +124,7 @@ class AAZShortHandSyntaxParser:
 
         while idx < len(remain):
             try:
-                value, length = self.parse_shorthand_value(remain[idx:])
+                value, length = self.parse_value(remain[idx:])
             except AAZInvalidShorthandSyntaxError as ex:
                 ex.error_data = remain
                 ex.error_at += idx
@@ -150,10 +150,10 @@ class AAZShortHandSyntaxParser:
             raise AAZInvalidShorthandSyntaxError(remain, idx, 1, "Expect character ']'")
         return result, idx
 
-    def parse_shorthand_string(self, remain):
+    def parse_string(self, remain):
         idx = 0
         if len(remain) and remain[0] == "'":
-            return self.parse_shorthand_quote_string(remain)
+            return self.parse_single_quotes_string(remain)
 
         while idx < len(remain):
             if remain[idx] in (',', ':', ']', '}'):
@@ -178,7 +178,8 @@ class AAZShortHandSyntaxParser:
 
         return remain[:idx], idx
 
-    def parse_shorthand_quote_string(self, remain):
+    @staticmethod
+    def parse_single_quotes_string(remain):
         assert remain[0] == "'"
         quote = remain[0]
         idx = 1

--- a/src/azure-cli-core/azure/cli/core/aaz/_utils.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_utils.py
@@ -185,7 +185,7 @@ class AAZShortHandSyntaxParser:
         result = ''
         while idx < len(remain):
             if remain[idx] == quote:
-                if len(remain) > idx+1 and remain[idx+1] == '/':
+                if len(remain) > idx + 1 and remain[idx + 1] == '/':
                     # parse '/ as '
                     result += quote
                     idx += 2
@@ -200,4 +200,3 @@ class AAZShortHandSyntaxParser:
         if quote is not None:
             raise AAZInvalidShorthandSyntaxError(remain, idx, 1, f"Miss end quota character: {quote}")
         return result, idx
-

--- a/src/azure-cli-core/azure/cli/core/aaz/_utils.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_utils.py
@@ -185,36 +185,19 @@ class AAZShortHandSyntaxParser:
         result = ''
         while idx < len(remain):
             if remain[idx] == quote:
-                quote = None
-                idx += 1
-                break
-
-            if remain[idx] == '/':
-                try:
-                    c, length = self.parse_escape_character(remain[idx:])
-                except AAZInvalidShorthandSyntaxError as ex:
-                    ex.error_data = remain
-                    ex.error_at += idx
-                    raise ex
-
-                result += c
-                idx += length
+                if len(remain) > idx+1 and remain[idx+1] == '/':
+                    # parse '/ as '
+                    result += quote
+                    idx += 2
+                else:
+                    quote = None
+                    idx += 1
+                    break
             else:
                 result += remain[idx]
                 idx += 1
+
         if quote is not None:
             raise AAZInvalidShorthandSyntaxError(remain, idx, 1, f"Miss end quota character: {quote}")
         return result, idx
 
-    @staticmethod
-    def parse_escape_character(remain):
-        assert remain[0] == '/'
-        if len(remain) < 2:
-            raise AAZInvalidShorthandSyntaxError(remain, 0, 1, f"Invalid escape character: {remain}")
-        if remain[1] == "'":
-            return "'", 2
-        if remain[1] == '/':
-            return '/', 2
-        if remain[1] == '\\':
-            return '\\', 2
-        raise AAZInvalidShorthandSyntaxError(remain, 0, 2, f"Invalid escape character: {remain[:2]}")

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -25,15 +25,19 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
         assert parser("'None'", is_simple=True) == 'None'
 
         # test single quota
-        assert parser("'/''", is_simple=True) == "'"
+        assert parser("''/'", is_simple=True) == "'"
+        assert parser("'/'", is_simple=True) == "/"
         assert parser("'\"'", is_simple=True) == '"'
 
         assert parser('"\'"', is_simple=True) == '"\'"'
         assert parser('"\""', is_simple=True) == '"\""'
+        assert parser("'https://azure.microsoft.com/en-us/'", is_simple=True) == "https://azure.microsoft.com/en-us/"
+        assert parser("'C:\\Program Files (x86)\\'", is_simple=True) == "C:\\Program Files (x86)\\"
+        assert parser("'/usr/lib/python3.8/'", is_simple=True) == "/usr/lib/python3.8/"
 
         # test escape character
         assert parser("'\"'", is_simple=True) == "\""
-        assert parser("'/\''", is_simple=True) == "\'"
+        assert parser("'\'/'", is_simple=True) == "\'"
 
         assert parser("'\b'", is_simple=True) == "\b"
         assert parser("'\f'", is_simple=True) == "\f"
@@ -114,14 +118,19 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
             "c": "None",
             "d": ''
         }
-        assert parser("{a:1,b:'/''}") == {
+        assert parser("{a:1,b:''/'}") == {
             "a": "1",
             "b": "'"
         }
 
-        assert parser("{a:1,b:'//'}") == {
+        assert parser("{a:1,b:'/'}") == {
             "a": "1",
             "b": "/"
+        }
+
+        assert parser("{a:1,b:'//'}") == {
+            "a": "1",
+            "b": "//"
         }
 
         assert parser("{a:1,b:/}") == {
@@ -142,7 +151,7 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
             "d": ''
         }
 
-        assert parser("{a:{a1:' \n /\'',a2:2}}") == {
+        assert parser("{a:{a1:' \n '/',a2:2}}") == {
             "a": {
                 "a1": " \n '",
                 "a2": "2",
@@ -222,7 +231,10 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
             parser("{a:1,a:2}")
 
         with self.assertRaises(AAZInvalidShorthandSyntaxError):
-            parser("{a:1,b:'/'}")
+            parser("{a:1,b:'/''}")
+
+        with self.assertRaises(AAZInvalidShorthandSyntaxError):
+            parser("{a:1,b:''/}")
 
         with self.assertRaises(AAZInvalidShorthandSyntaxError):
             parser("{a:1,:1}")
@@ -267,7 +279,7 @@ class TestAAZArgShorthandSyntax(unittest.TestCase):
             parser("{a'1:1}")
 
         with self.assertRaises(AAZInvalidShorthandSyntaxError):
-            parser("{'a/'1':1}")
+            parser("{'a'/1':1}")
 
     def test_aaz_shorthand_syntax_list_value(self):
         from azure.cli.core.aaz._utils import AAZShortHandSyntaxParser


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In previous design, the escape character `/` is hard to use, customers have to double `/` characters when it appeared in Single Quotes String of shorthand syntax.

For example, when customer passes an url `https://bill.microsft.com/blog`, in previous design, it should be `'https:////bill.microsft.com//blog'` in `Full Value` format. It becomes longer than original, which obeys the goal of shorthand syntax.

This PR simplify the escape character usage in [Single Quotes String](https://github.com/Azure/azure-cli/blob/dev/doc/shorthand_syntax.md#single-quotes-string).

The reason we need escape character in Single Quotes String is that we need to distinguish the normal `'` in string or the end `'` to finish Single Quotes String. There's no reason to escape the escape character `/` itself, only `'` character in the Single Quotes String requires escape.

In the new design, we use `'/` to represent escaped `'` in Single Quotes String. The character '/' will only be the escape character when it's after the `'` in Single Quotes String. In other case, it will be normal character. Which means customer can pass an url `https://bill.microsft.com/blog` as what it looks like.

There are two reasons to put `/` after `'`, instead of before it.
- If we use `/'` to escape `'` character, then we have to find a way to represent string end with `/` in Single Quotes String, for example if the string is an url such as `https://azure.microsoft.com/en-us/`，in Single Quotes String it will be like `'https://azure.microsoft.com/en-us/'` and you can see the end of expression is `/'`, which is distinguished with the escape `'`. That's why in previous design, we have to escape `/` itself as well. If we put `/` after `'`, we will never have this issue.
- We choose `/` to escape because it can make commands run both in both Powershell and Bash terminals without any change. Its shape will let eyes focus on the character before it instead of after it. So `'/` is more readable than `/'`.

This PR is a breaking change for customer usage. Fortunately, we don't have any codegen v2 commands published. So it will not break customers. I will limit the extension generated to the new version of azure-cli.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
