### PR TITLE
[Storage] `az storage account generate-sas`: Fix output sas has random order for `srt` segment

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1290,12 +1290,20 @@ def resource_type_type(loader):
 def resource_type_type_v2(loader):
     """ Returns a function which validates that resource types string contains only a combination of service,
     container, and object. Their shorthand representations are s, c, and o. """
+    def _get_ordered_set(string):
+        if not string:
+            return string
+        result = []
+        for item in string:
+            if item not in result:
+                result.append(item)
+        return ''.join(result)
 
     def impl(string):
         t_resources = loader.get_models('_shared.models#ResourceTypes', resource_type=ResourceType.DATA_STORAGE_BLOB)
         if set(string) - set("sco"):
             raise ValueError
-        return t_resources.from_string(''.join(set(string)))
+        return t_resources.from_string(_get_ordered_set(string))
 
     return impl
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_sas_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_sas_scenarios.py
@@ -174,6 +174,7 @@ class StorageSASScenario(StorageScenarioMixin, LiveScenarioTest):
 
         self.assertIn('sig=', sas, 'SAS token {} does not contain sig segment'.format(sas))
         self.assertIn('se=', sas, 'SAS token {} does not contain se segment'.format(sas))
+        self.assertIn('srt=co', sas, 'SAS token {} does not match srt segment'.format(sas))
 
         account_info = self.get_account_info(resource_group, storage_account)
         container = self.create_container(account_info)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account generate-sas`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az storage account generate-sas --resource-type sco` will generate a sas with random order of `sco` in `srt` segment, for example:
- `se=2022-05-25&sp=r&sv=2021-06-08&ss=qb&srt=ocs&sig=XXXX`
- `se=2022-05-25&sp=r&sv=2021-06-08&ss=qb&srt=soc&sig=XXXX`

This will cause the sas token invalid for .NET SDK([IcM link](https://portal.microsofticm.com/imp/v3/incidents/details/308892616/home))

This PR fix the random order in output. We will totally honor the input order from `--resource-type`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
