### PR TITLE
{packaging} Bump sshtunnel version

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -131,7 +131,7 @@ requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
-sshtunnel==0.1.5
+sshtunnel==0.4.0
 tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -132,7 +132,7 @@ requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
-sshtunnel==0.1.5
+sshtunnel==0.4.0
 tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -132,7 +132,7 @@ requests[socks]==2.26.0
 scp==0.13.2
 semver==2.13.0
 six==1.14.0
-sshtunnel==0.1.5
+sshtunnel==0.4.0
 tabulate==0.8.9
 urllib3==1.26.7
 vsts==0.1.25

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,7 +149,7 @@ DEPENDENCIES = [
     'scp~=0.13.2',
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions
-    'sshtunnel~=0.1.4',
+    'sshtunnel~=0.4.0',
     'urllib3[secure]',
     'websocket-client~=1.3.1',
     'xmltodict~=0.12'


### PR DESCRIPTION
**Related command**
Unknown.

**Description**
Newer versions of the sshtunnel module improve IPv6 connectivity and
detect hangs in the ssh tunnel.

The version referenced in azure-cli, 0.1.5, was released in Sep 2019.

**Testing Guide**
Testing process is unchanged.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
