### PR TITLE
{Docs} Fix query syntax for `az provider list` command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2130,7 +2130,7 @@ type: command
 examples:
   - name: Display all resource types for the network resource provider.
     text: >
-        az provider list --query [?namespace=='Microsoft.Network'].resourceTypes[].resourceType
+        az provider list --query "[?namespace=='Microsoft.Network'].resourceTypes[].resourceType"
 """
 
 helps['provider permission'] = """


### PR DESCRIPTION
**Related command**
az provider list --query [?namespace=='Microsoft.Network'].resourceTypes[].resourceType

**Description**<!--Mandatory-->
Command **without surrounding quotes does not work**. Need to add "" around --query parameter.

**Testing Guide**
Wrong (initial) command syntax:
az provider list --query [?namespace=='Microsoft.Network'].resourceTypes[].resourceType
--> gives [] empty array

Correct command syntax:
az provider list --query "[?namespace=='Microsoft.Network'].resourceTypes[].resourceType"
--> gives proper list of resource types
