### PR TITLE
{appservice} Replace fabric/invoke w/parallel-ssh

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -98,10 +98,8 @@ cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
 cryptography==3.3.2
-fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
-invoke==1.2.0
 isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==3.0.3
@@ -115,6 +113,7 @@ msrest==0.6.21
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
+parallel-ssh==2.10.0
 paramiko==2.10.1
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -99,10 +99,8 @@ chardet==3.0.4
 colorama==0.4.4
 cryptography==3.3.2
 distro==1.6.0
-fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
-invoke==1.2.0
 isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==3.0.3
@@ -116,6 +114,7 @@ msrest==0.6.21
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
+parallel-ssh==2.10.0
 paramiko==2.10.1
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -98,10 +98,8 @@ cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
 cryptography==3.3.2
-fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
-invoke==1.2.0
 isodate==0.6.0
 javaproperties==0.5.1
 Jinja2==3.0.3
@@ -115,6 +113,7 @@ msrest==0.6.21
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
+parallel-ssh==2.10.0
 paramiko==2.10.1
 pbr==5.3.1
 pkginfo==1.8.2

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -140,10 +140,10 @@ DEPENDENCIES = [
     'colorama~=0.4.4',
     # On Linux, the distribution (Ubuntu, Debian, etc) and version are checked for `az feedback`
     'distro; sys_platform == "linux"',
-    'fabric~=2.4',
     'javaproperties~=0.5.1',
     'jsondiff~=2.0.0',
     'packaging>=20.9,<22.0',
+    'parallel-ssh~=2.10.0',
     'PyGithub~=1.38',
     'PyNaCl~=1.5.0',
     'scp~=0.13.2',


### PR DESCRIPTION
**Related command**
`az appservice`

**Description**
The `parallel-ssh` module is backed by the libssh/libssh2 libraries. This increases speed, reduces overhead, and allows for FIPS compliance. Fabric/invoke require paramiko and it makes FIPS compliance difficult.

In addition, `parallel-ssh` could be used for ssh tunnels (in the `batchai` command module) in a separate PR. Currently, `batchai` uses the `sshtunnel` package (which also requires `paramiko`) to make those connections.

**Testing Guide**
The testing process is unchanged.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
