### PR TITLE
{AKS} Graph module migration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -63,8 +63,8 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
 
 
 def cf_graph_client(cli_ctx):
-    from azure.cli.command_modules.role._graph_client import GraphClient
-    return GraphClient(cli_ctx)
+    from azure.cli.command_modules.role import graph_client_factory
+    return graph_client_factory(cli_ctx)
 
 
 def get_graph_rbac_management_client(cli_ctx, **_):

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -62,6 +62,11 @@ def get_auth_management_client(cli_ctx, scope=None, **_):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_AUTHORIZATION, subscription_id=subscription_id)
 
 
+def cf_graph_client(cli_ctx):
+    from azure.cli.command_modules.role._graph_client import GraphClient
+    return GraphClient(cli_ctx)
+
+
 def get_graph_rbac_management_client(cli_ctx, **_):
     from azure.cli.core.commands.client_factory import configure_common_settings
     from azure.cli.core._profile import Profile

--- a/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_client_factory.py
@@ -67,6 +67,8 @@ def cf_graph_client(cli_ctx):
     return graph_client_factory(cli_ctx)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 def get_graph_rbac_management_client(cli_ctx, **_):
     from azure.cli.core.commands.client_factory import configure_common_settings
     from azure.cli.core._profile import Profile

--- a/src/azure-cli/azure/cli/command_modules/acs/_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_graph.py
@@ -15,16 +15,16 @@ def resolve_object_id(cli_ctx, assignee):
     result = None
     if assignee is None:
         raise AzCLIError('Inputted parameter "assignee" is None.')
-    # looks like a user principal name, find by upn
+    # looks like a user principal name, find by upn (e.g., xxx@xxx.xxx)
     if assignee.find("@") >= 0:
         result = list(client.user_list(filter="userPrincipalName eq '{}'".format(assignee)))
-    # find by spn
+    # find by spn (e.g., appId like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
     if not result:
         result = list(client.service_principal_list(filter="servicePrincipalNames/any(c:c eq '{}')".format(assignee)))
-    # find by display name
+    # find by display name (e.g., my-aks-sp)
     if not result:
         result = list(client.service_principal_list(filter="displayName eq '{}'".format(assignee)))
-    # find by object id
+    # find by object id (e.g., (object) id like xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
     if not result:
         body = {"ids": [assignee], "types": ["user", "group", "servicePrincipal", "directoryObjectPartnerReference"]}
         result = list(client.directory_object_get_by_ids(body))

--- a/src/azure-cli/azure/cli/command_modules/acs/_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_graph.py
@@ -3,18 +3,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import binascii
-import datetime
-import os
-import time
-import uuid
-from typing import List
-
-import dateutil
 from azure.cli.command_modules.acs._client_factory import cf_graph_client
-from azure.cli.command_modules.role import GraphError
-from azure.cli.core.azclierror import AzCLIError
-from dateutil.relativedelta import relativedelta
+from azure.cli.core.azclierror import AzCLIError, RequiredArgumentMissingError
 from knack.log import get_logger
 
 logger = get_logger(__name__)
@@ -45,119 +35,7 @@ def resolve_object_id(cli_ctx, assignee):
     return result[0]["id"]
 
 
-def create_service_principal(cli_ctx, identifier, resolve_app=True, graph_client=None):
-    if graph_client is None:
-        graph_client = cf_graph_client(cli_ctx)
-
-    if resolve_app:
-        try:
-            uuid.UUID(identifier)
-            result = list(graph_client.application_list(filter="appId eq '{}'".format(identifier)))
-        except ValueError:
-            result = list(graph_client.application_list(filter="identifierUris/any(s:s eq '{}')".format(identifier)))
-
-        if not result:  # assume we get an object id
-            result = [graph_client.application_get(identifier)]
-        app_id = result[0]["appId"]
-    else:
-        app_id = identifier
-
-    sp_create_body = {"appId": app_id, "accountEnabled": True}
-    return graph_client.service_principal_create(sp_create_body)
-
-
-def _build_application_creds(password=None, start_date=None, end_date=None):
-    from azure.cli.command_modules.role.custom import _datetime_to_utc
-
-    if not start_date:
-        start_date = datetime.datetime.utcnow()
-    elif isinstance(start_date, str):
-        start_date = dateutil.parser.parse(start_date)
-
-    if not end_date:
-        end_date = start_date + relativedelta(years=1)
-    elif isinstance(end_date, str):
-        end_date = dateutil.parser.parse(end_date)
-
-    password_creds = None
-    if password:
-        password_creds = [
-            {
-                "startDateTime": _datetime_to_utc(start_date),
-                "endDateTime": _datetime_to_utc(end_date),
-                "keyId": str(uuid.uuid4()),
-                # "secretText": password,
-            }
-        ]
-    return password_creds
-
-
-def create_application(
-    client,
-    display_name: str,
-    homepage: str,
-    identifier_uris: List[str],
-    password=None,
-    start_date=None,
-    end_date=None,
-):
-    password_creds = _build_application_creds(password, start_date, end_date)
-    app_create_body = {
-        "displayName": display_name,
-        "identifierUris": identifier_uris,
-        "passwordCredentials": password_creds,
-        "web": {
-            "homePageUrl": homepage,
-        },
-    }
-    try:
-        result = client.application_create(app_create_body)
-        return result
-    except GraphError as ex:
-        if "insufficient privileges" in str(ex).lower():
-            link = "https://docs.microsoft.com/azure/azure-resource-manager/resource-group-create-service-principal-portal"  # pylint: disable=line-too-long
-            raise AzCLIError(
-                "Directory permission is needed for the current user to register the application. "
-                "For how to configure, please refer '{}'. Original error: {}".format(link, ex)
-            )
-        raise
-
-
-def build_service_principal(graph_client, cli_ctx, name, url, client_secret):
-    # use get_progress_controller
-    hook = cli_ctx.get_progress_controller(True)
-    hook.add(messsage="Creating service principal", value=0, total_val=1.0)
-    logger.info("Creating service principal")
-    # always create application with 5 years expiration
-    start_date = datetime.datetime.utcnow()
-    end_date = start_date + relativedelta(years=5)
-    result = create_application(
-        graph_client, name, url, [url], password=client_secret, start_date=start_date, end_date=end_date
-    )
-    service_principal = result["appId"]  # pylint: disable=no-member
-    for x in range(0, 10):
-        hook.add(message="Creating service principal", value=0.1 * x, total_val=1.0)
-        try:
-            create_service_principal(cli_ctx, service_principal, graph_client=graph_client)
-            break
-        # TODO figure out what exception AAD throws here sometimes.
-        except Exception as ex:  # pylint: disable=broad-except
-            logger.error(str(ex))
-        time.sleep(2 + 2 * x)
-    else:
-        return False
-    hook.add(message="Finished service principal creation", value=1.0, total_val=1.0)
-    logger.info("Finished service principal creation")
-    return service_principal
-
-
-def _create_client_secret():
-    # Add a special character to satisfy AAD SP secret requirements
-    special_char = "$"
-    client_secret = binascii.b2a_hex(os.urandom(10)).decode("utf-8") + special_char
-    return client_secret
-
-
+# TODO: deprecated, will remove this after the adoption of v2 decorator in aks-preview.
 # pylint: disable=unused-argument
 def ensure_aks_service_principal(
     cli_ctx,
@@ -169,32 +47,7 @@ def ensure_aks_service_principal(
     location=None,
     name=None,
 ):
-    aad_session_key = None
-    # TODO: This really needs to be unit tested.
-    graph_client = cf_graph_client(cli_ctx)
-    if not service_principal:
-        # --service-principal not specified, make one.
-        if not client_secret:
-            client_secret = _create_client_secret()
-        salt = binascii.b2a_hex(os.urandom(3)).decode("utf-8")
-        if dns_name_prefix:
-            url = "https://{}.{}.{}.cloudapp.azure.com".format(salt, dns_name_prefix, location)
-        else:
-            url = "https://{}.{}.{}.cloudapp.azure.com".format(salt, fqdn_subdomain, location)
-
-        service_principal = build_service_principal(graph_client, cli_ctx, name, url, client_secret)
-        if not service_principal:
-            raise AzCLIError(
-                "Could not create a service principal with the right permissions. " "Are you an Owner on this project?"
-            )
-        logger.info("Created a service principal: %s", service_principal)
-        # We don't need to add role assignment for this created SPN
-    else:
-        # --service-principal specfied, validate --client-secret was too
-        if not client_secret:
-            raise AzCLIError("--client-secret is required if --service-principal is specified")
-    return {
-        "client_secret": client_secret,
-        "service_principal": service_principal,
-        "aad_session_key": aad_session_key,
-    }
+    raise RequiredArgumentMissingError(
+        "Please provide both --service-principal and --client-secret to use sp as the cluster identity. "
+        "An sp can be created using the 'az ad sp create-for-rbac' command."
+    )

--- a/src/azure-cli/azure/cli/command_modules/acs/_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_graph.py
@@ -8,19 +8,15 @@ import datetime
 import os
 import time
 import uuid
+from typing import List
 
 import dateutil
-from azure.cli.command_modules.acs._client_factory import get_graph_rbac_management_client, cf_graph_client
+from azure.cli.command_modules.acs._client_factory import cf_graph_client
+from azure.cli.command_modules.role import GraphError
 from azure.cli.core.azclierror import AzCLIError
-from azure.graphrbac.models import (
-    ApplicationCreateParameters,
-    GraphErrorException,
-    KeyCredential,
-    PasswordCredential,
-    ServicePrincipalCreateParameters,
-)
 from dateutil.relativedelta import relativedelta
 from knack.log import get_logger
+
 logger = get_logger(__name__)
 
 
@@ -30,9 +26,8 @@ def resolve_object_id(cli_ctx, assignee):
     if assignee is None:
         raise AzCLIError('Inputted parameter "assignee" is None.')
     # looks like a user principal name, find by upn
-    if assignee.find('@') >= 0:
-        result = list(client.user_list(
-            filter="userPrincipalName eq '{}'".format(assignee)))
+    if assignee.find("@") >= 0:
+        result = list(client.user_list(filter="userPrincipalName eq '{}'".format(assignee)))
     # find by spn
     if not result:
         result = list(client.service_principal_list(filter="servicePrincipalNames/any(c:c eq '{}')".format(assignee)))
@@ -41,44 +36,38 @@ def resolve_object_id(cli_ctx, assignee):
         result = list(client.service_principal_list(filter="displayName eq '{}'".format(assignee)))
     # find by object id
     if not result:
-        body = {
-            "ids": [assignee],
-            "types": ['user', 'group', 'servicePrincipal', 'directoryObjectPartnerReference']
-        }
+        body = {"ids": [assignee], "types": ["user", "group", "servicePrincipal", "directoryObjectPartnerReference"]}
         result = list(client.directory_object_get_by_ids(body))
 
     # 2+ matches should never happen, so we only check 'no match' here
     if not result:
-        raise AzCLIError(
-            "No matches in graph database for '{}'".format(assignee))
+        raise AzCLIError("No matches in graph database for '{}'".format(assignee))
     return result[0]["id"]
 
 
-def create_service_principal(cli_ctx, identifier, resolve_app=True, rbac_client=None):
-    if rbac_client is None:
-        rbac_client = get_graph_rbac_management_client(cli_ctx)
+def create_service_principal(cli_ctx, identifier, resolve_app=True, graph_client=None):
+    if graph_client is None:
+        graph_client = cf_graph_client(cli_ctx)
 
     if resolve_app:
         try:
             uuid.UUID(identifier)
-            result = list(rbac_client.applications.list(filter="appId eq '{}'".format(identifier)))
+            result = list(graph_client.application_list(filter="appId eq '{}'".format(identifier)))
         except ValueError:
-            result = list(rbac_client.applications.list(filter="identifierUris/any(s:s eq '{}')".format(identifier)))
+            result = list(graph_client.application_list(filter="identifierUris/any(s:s eq '{}')".format(identifier)))
 
         if not result:  # assume we get an object id
-            result = [rbac_client.applications.get(identifier)]
-        app_id = result[0].app_id
+            result = [graph_client.application_get(identifier)]
+        app_id = result[0]["appId"]
     else:
         app_id = identifier
 
-    return rbac_client.service_principals.create(ServicePrincipalCreateParameters(app_id=app_id, account_enabled=True))
+    sp_create_body = {"appId": app_id, "accountEnabled": True}
+    return graph_client.service_principal_create(sp_create_body)
 
 
-def _build_application_creds(
-    password=None, key_value=None, key_type=None, key_usage=None, start_date=None, end_date=None
-):
-    if password and key_value:
-        raise AzCLIError("specify either --password or --key-value, but not both.")
+def _build_application_creds(password=None, start_date=None, end_date=None):
+    from azure.cli.command_modules.role.custom import _datetime_to_utc
 
     if not start_date:
         start_date = datetime.datetime.utcnow()
@@ -90,61 +79,41 @@ def _build_application_creds(
     elif isinstance(end_date, str):
         end_date = dateutil.parser.parse(end_date)
 
-    key_type = key_type or "AsymmetricX509Cert"
-    key_usage = key_usage or "Verify"
-
     password_creds = None
-    key_creds = None
     if password:
         password_creds = [
-            PasswordCredential(start_date=start_date, end_date=end_date, key_id=str(uuid.uuid4()), value=password)
+            {
+                "startDateTime": _datetime_to_utc(start_date),
+                "endDateTime": _datetime_to_utc(end_date),
+                "keyId": str(uuid.uuid4()),
+                # "secretText": password,
+            }
         ]
-    elif key_value:
-        key_creds = [
-            KeyCredential(
-                start_date=start_date,
-                end_date=end_date,
-                value=key_value,
-                key_id=str(uuid.uuid4()),
-                usage=key_usage,
-                type=key_type,
-            )
-        ]
-
-    return (password_creds, key_creds)
+    return password_creds
 
 
 def create_application(
     client,
-    display_name,
-    homepage,
-    identifier_uris,
-    available_to_other_tenants=False,
+    display_name: str,
+    homepage: str,
+    identifier_uris: List[str],
     password=None,
-    reply_urls=None,
-    key_value=None,
-    key_type=None,
-    key_usage=None,
     start_date=None,
     end_date=None,
-    required_resource_accesses=None,
 ):
-    password_creds, key_creds = _build_application_creds(password, key_value, key_type, key_usage, start_date, end_date)
-
-    app_create_param = ApplicationCreateParameters(
-        available_to_other_tenants=available_to_other_tenants,
-        display_name=display_name,
-        identifier_uris=identifier_uris,
-        homepage=homepage,
-        reply_urls=reply_urls,
-        key_credentials=key_creds,
-        password_credentials=password_creds,
-        required_resource_access=required_resource_accesses,
-    )
+    password_creds = _build_application_creds(password, start_date, end_date)
+    app_create_body = {
+        "displayName": display_name,
+        "identifierUris": identifier_uris,
+        "passwordCredentials": password_creds,
+        "web": {
+            "homePageUrl": homepage,
+        },
+    }
     try:
-        result = client.create(app_create_param, raw=True)
-        return result.output, result.response.headers["ocp-aad-session-key"]
-    except GraphErrorException as ex:
+        result = client.application_create(app_create_body)
+        return result
+    except GraphError as ex:
         if "insufficient privileges" in str(ex).lower():
             link = "https://docs.microsoft.com/azure/azure-resource-manager/resource-group-create-service-principal-portal"  # pylint: disable=line-too-long
             raise AzCLIError(
@@ -154,7 +123,7 @@ def create_application(
         raise
 
 
-def build_service_principal(rbac_client, cli_ctx, name, url, client_secret):
+def build_service_principal(graph_client, cli_ctx, name, url, client_secret):
     # use get_progress_controller
     hook = cli_ctx.get_progress_controller(True)
     hook.add(messsage="Creating service principal", value=0, total_val=1.0)
@@ -162,24 +131,24 @@ def build_service_principal(rbac_client, cli_ctx, name, url, client_secret):
     # always create application with 5 years expiration
     start_date = datetime.datetime.utcnow()
     end_date = start_date + relativedelta(years=5)
-    result, aad_session_key = create_application(
-        rbac_client.applications, name, url, [url], password=client_secret, start_date=start_date, end_date=end_date
+    result = create_application(
+        graph_client, name, url, [url], password=client_secret, start_date=start_date, end_date=end_date
     )
-    service_principal = result.app_id  # pylint: disable=no-member
+    service_principal = result["appId"]  # pylint: disable=no-member
     for x in range(0, 10):
         hook.add(message="Creating service principal", value=0.1 * x, total_val=1.0)
         try:
-            create_service_principal(cli_ctx, service_principal, rbac_client=rbac_client)
+            create_service_principal(cli_ctx, service_principal, graph_client=graph_client)
             break
         # TODO figure out what exception AAD throws here sometimes.
         except Exception as ex:  # pylint: disable=broad-except
             logger.error(str(ex))
         time.sleep(2 + 2 * x)
     else:
-        return False, aad_session_key
+        return False
     hook.add(message="Finished service principal creation", value=1.0, total_val=1.0)
     logger.info("Finished service principal creation")
-    return service_principal, aad_session_key
+    return service_principal
 
 
 def _create_client_secret():
@@ -202,7 +171,7 @@ def ensure_aks_service_principal(
 ):
     aad_session_key = None
     # TODO: This really needs to be unit tested.
-    rbac_client = get_graph_rbac_management_client(cli_ctx)
+    graph_client = cf_graph_client(cli_ctx)
     if not service_principal:
         # --service-principal not specified, make one.
         if not client_secret:
@@ -213,7 +182,7 @@ def ensure_aks_service_principal(
         else:
             url = "https://{}.{}.{}.cloudapp.azure.com".format(salt, fqdn_subdomain, location)
 
-        service_principal, aad_session_key = build_service_principal(rbac_client, cli_ctx, name, url, client_secret)
+        service_principal = build_service_principal(graph_client, cli_ctx, name, url, client_secret)
         if not service_principal:
             raise AzCLIError(
                 "Could not create a service principal with the right permissions. " "Are you an Owner on this project?"

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -98,13 +98,6 @@ from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_
 from azure.cli.core.keys import is_valid_ssh_rsa_public_key
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.util import in_cloud_console, sdk_no_wait
-from azure.graphrbac.models import (
-    ApplicationCreateParameters,
-    GetObjectsParameters,
-    KeyCredential,
-    PasswordCredential,
-    ServicePrincipalCreateParameters,
-)
 from dateutil.relativedelta import relativedelta
 from knack.log import get_logger
 from knack.prompting import NoTTYException, prompt_y_n
@@ -126,6 +119,8 @@ def get_cmd_test_hook_data(filename):
     return hook_data
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs browse / acs kubernetes browse / acs dcos browse / acs kubernetes get-credentials
 def _get_acs_info(cli_ctx, name, resource_group_name):
     """
@@ -140,6 +135,8 @@ def _get_acs_info(cli_ctx, name, resource_group_name):
     return container_services.get(resource_group_name, name)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs browse
 def acs_browse(cmd, client, resource_group_name, name, disable_browser=False, ssh_key_file=None):
     """
@@ -159,6 +156,8 @@ def acs_browse(cmd, client, resource_group_name, name, disable_browser=False, ss
         cmd, client, acs_info, resource_group_name, name, disable_browser, ssh_key_file)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs browse
 def _acs_browse_internal(cmd, client, acs_info, resource_group_name, name, disable_browser, ssh_key_file):
     from azure.mgmt.containerservice.models import ContainerServiceOrchestratorTypes
@@ -175,6 +174,8 @@ def _acs_browse_internal(cmd, client, acs_info, resource_group_name, name, disab
         'Unsupported orchestrator type {} for browse'.format(orchestrator_type))
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs kubernetes browse
 def k8s_browse(cmd, client, name, resource_group_name, disable_browser=False, ssh_key_file=None):
     """
@@ -186,6 +187,8 @@ def k8s_browse(cmd, client, name, resource_group_name, disable_browser=False, ss
     _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs kubernetes browse
 def _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file):
     if not which('kubectl'):
@@ -204,6 +207,8 @@ def _k8s_browse_internal(name, acs_info, disable_browser, ssh_key_file):
     subprocess.call(["kubectl", "--kubeconfig", browse_path, "proxy"])
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos browse
 def dcos_browse(cmd, client, name, resource_group_name, disable_browser=False, ssh_key_file=None):
     """
@@ -222,6 +227,8 @@ def dcos_browse(cmd, client, name, resource_group_name, disable_browser=False, s
     _dcos_browse_internal(acs_info, disable_browser, ssh_key_file)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos browse
 def _dcos_browse_internal(acs_info, disable_browser, ssh_key_file):
     if not os.path.isfile(ssh_key_file):
@@ -264,6 +271,8 @@ def _dcos_browse_internal(acs_info, disable_browser, ssh_key_file):
         proxy.disable_http_proxy()
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos browse
 def _rand_str(n):
     """
@@ -273,6 +282,8 @@ def _rand_str(n):
     return ''.join(random.SystemRandom().choice(choices) for _ in range(n))
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos browse
 def _get_host_name(acs_info):
     """
@@ -290,6 +301,8 @@ def _get_host_name(acs_info):
     return acs_info.master_profile.fqdn
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos browse
 def _get_username(acs_info):
     """
@@ -303,6 +316,8 @@ def _get_username(acs_info):
     return None
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs dcos install-cli
 def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
     """
@@ -336,6 +351,8 @@ def dcos_install_cli(cmd, install_location=None, client_version='1.8'):
             'Connection error while attempting to download client ({})'.format(err))
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _get_default_dns_prefix(name, resource_group_name, subscription_id):
     # Use subscription id to provide uniqueness and prevent DNS name clashes
@@ -347,6 +364,8 @@ def _get_default_dns_prefix(name, resource_group_name, subscription_id):
     return '{}-{}-{}'.format(name_part, resource_group_part, subscription_id[0:6])
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _generate_windows_profile(windows, admin_username, admin_password):
     if windows:
@@ -362,6 +381,8 @@ def _generate_windows_profile(windows, admin_username, admin_password):
     return None
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _generate_master_pool_profile(api_version, master_profile, master_count, dns_name_prefix,
                                   master_vm_size, master_osdisk_size, master_vnet_subnet_id,
@@ -389,6 +410,8 @@ def _generate_master_pool_profile(api_version, master_profile, master_count, dns
     return master_pool_profile
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _generate_agent_pool_profiles(api_version, agent_profiles, agent_count, dns_name_prefix,
                                   agent_vm_size, os_type, agent_osdisk_size, agent_vnet_subnet_id,
@@ -426,6 +449,8 @@ def _generate_agent_pool_profiles(api_version, agent_profiles, agent_count, dns_
     return agent_pool_profiles
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _update_dict(dict1, dict2):
     cp = dict1.copy()
@@ -433,6 +458,8 @@ def _update_dict(dict1, dict2):
     return cp
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _generate_outputs(name, orchestrator_type, admin_username):
     # define outputs
@@ -459,6 +486,8 @@ def _generate_outputs(name, orchestrator_type, admin_username):
     return outputs
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _generate_properties(api_version, orchestrator_type, orchestrator_version, master_pool_profile,
                          agent_pool_profiles, ssh_key_value, admin_username, windows_profile):
@@ -487,6 +516,8 @@ def _generate_properties(api_version, orchestrator_type, orchestrator_version, m
     return properties
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 # pylint: disable=too-many-locals
 def acs_create(cmd, client, resource_group_name, deployment_name, name, ssh_key_value, dns_name_prefix=None,
@@ -685,6 +716,8 @@ def acs_create(cmd, client, resource_group_name, deployment_name, name, ssh_key_
     raise retry_exception
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _invoke_deployment(cmd, resource_group_name, deployment_name, template, parameters, validate, no_wait,
                        subscription_id=None):
@@ -713,6 +746,8 @@ def _invoke_deployment(cmd, resource_group_name, deployment_name, template, para
     return sdk_no_wait(no_wait, smc.begin_create_or_update, resource_group_name, deployment_name, deployment)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _ensure_service_principal(cli_ctx,
                               service_principal=None,
@@ -753,6 +788,8 @@ def _ensure_service_principal(cli_ctx,
     }
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create / osa command
 def _create_client_secret():
     # Add a special character to satisfy AAD SP secret requirements
@@ -762,6 +799,8 @@ def _create_client_secret():
     return client_secret
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _build_service_principal(rbac_client, cli_ctx, name, url, client_secret):
     # use get_progress_controller
@@ -793,12 +832,14 @@ def _build_service_principal(rbac_client, cli_ctx, name, url, client_secret):
     return service_principal, aad_session_key
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def create_application(client, display_name, homepage, identifier_uris,
                        available_to_other_tenants=False, password=None, reply_urls=None,
                        key_value=None, key_type=None, key_usage=None, start_date=None,
                        end_date=None, required_resource_accesses=None):
-    from azure.graphrbac.models import GraphErrorException
+    from azure.graphrbac.models import ApplicationCreateParameters, GraphErrorException
     password_creds, key_creds = _build_application_creds(password, key_value, key_type,
                                                          key_usage, start_date, end_date)
 
@@ -821,9 +862,12 @@ def create_application(client, display_name, homepage, identifier_uris,
         raise
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _build_application_creds(password=None, key_value=None, key_type=None,
                              key_usage=None, start_date=None, end_date=None):
+    from azure.graphrbac.models import KeyCredential, PasswordCredential
     if password and key_value:
         raise CLIError(
             'specify either --password or --key-value, but not both.')
@@ -853,8 +897,11 @@ def _build_application_creds(password=None, key_value=None, key_type=None,
     return (password_creds, key_creds)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def create_service_principal(cli_ctx, identifier, resolve_app=True, rbac_client=None):
+    from azure.graphrbac.models import ServicePrincipalCreateParameters
     if rbac_client is None:
         rbac_client = get_graph_rbac_management_client(cli_ctx)
 
@@ -876,6 +923,8 @@ def create_service_principal(cli_ctx, identifier, resolve_app=True, rbac_client=
     return rbac_client.service_principals.create(ServicePrincipalCreateParameters(app_id=app_id, account_enabled=True))
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _add_role_assignment(cmd, role, service_principal_msi_id, is_service_principal=True, delay=2, scope=None):
     # AAD can have delays in propagating data, so sleep and retry
@@ -907,6 +956,8 @@ def _add_role_assignment(cmd, role, service_principal_msi_id, is_service_princip
     return True
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def create_role_assignment(cmd, role, assignee, is_service_principal, resource_group_name=None, scope=None):
     return _create_role_assignment(cmd,
@@ -914,6 +965,8 @@ def create_role_assignment(cmd, role, assignee, is_service_principal, resource_g
                                    scope, resolve_assignee=is_service_principal)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _create_role_assignment(cmd, role, assignee,
                             resource_group_name=None, scope=None, resolve_assignee=True):
@@ -972,6 +1025,8 @@ def _create_role_assignment(cmd, role, assignee,
     return assignments_client.create(scope, assignment_name, properties, custom_headers=custom_headers)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _build_role_scope(resource_group_name, scope, subscription_id):
     subscription_scope = '/subscriptions/' + subscription_id
@@ -986,6 +1041,8 @@ def _build_role_scope(resource_group_name, scope, subscription_id):
     return scope
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _resolve_role_id(role, scope, definitions_client):
     role_id = None
@@ -1007,6 +1064,8 @@ def _resolve_role_id(role, scope, definitions_client):
     return role_id
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _resolve_object_id(cli_ctx, assignee):
     client = get_graph_rbac_management_client(cli_ctx)
@@ -1028,13 +1087,18 @@ def _resolve_object_id(cli_ctx, assignee):
     return result[0].object_id
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs create
 def _get_object_stubs(graph_client, assignees):
+    from azure.graphrbac.models import GetObjectsParameters
     params = GetObjectsParameters(include_directory_object_references=True,
                                   object_ids=assignees)
     return list(graph_client.objects.get_objects_by_object_ids(params))
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs kubernetes get-credentials
 def k8s_get_credentials(cmd, client, name, resource_group_name,
                         path=os.path.join(os.path.expanduser(
@@ -1056,6 +1120,8 @@ def k8s_get_credentials(cmd, client, name, resource_group_name,
         name, acs_info, path, ssh_key_file, overwrite_existing)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs kubernetes browse/get-credentials
 def _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file, overwrite_existing):
     if ssh_key_file is not None and not os.path.isfile(ssh_key_file):
@@ -1090,6 +1156,8 @@ def _k8s_get_credentials_internal(name, acs_info, path, ssh_key_file, overwrite_
                 'The credentials have been saved to %s', path_candidate)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs kubernetes browse/get-credentials
 def _mkdir_p(path):
     # http://stackoverflow.com/a/600612
@@ -1102,6 +1170,8 @@ def _mkdir_p(path):
             raise
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs list
 def list_container_services(cmd, client, resource_group_name=None):
     ''' List Container Services. '''
@@ -1110,6 +1180,8 @@ def list_container_services(cmd, client, resource_group_name=None):
     return list(svc_list)
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs list-locations
 def list_acs_locations(cmd, client):
     return {
@@ -1118,6 +1190,8 @@ def list_acs_locations(cmd, client):
     }
 
 
+# TODO: deprecated, will remove this after container service commands (acs) are removed during
+# the next breaking change window.
 # legacy: acs scale
 def update_acs(cmd, client, resource_group_name, container_service_name, new_agent_count):
     from azure.mgmt.containerservice.models import ContainerServiceOrchestratorTypes

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -22,7 +22,6 @@ from azure.cli.command_modules.acs._consts import (
     DecoratorEarlyExitException,
     DecoratorMode,
 )
-from azure.cli.command_modules.acs._graph import ensure_aks_service_principal
 from azure.cli.command_modules.acs._helpers import (
     check_is_managed_aad_cluster,
     check_is_msi_cluster,
@@ -241,7 +240,6 @@ class AKSManagedClusterContext(BaseAKSContext):
                 "ensure_default_log_analytics_workspace_for_monitoring"
             ] = ensure_default_log_analytics_workspace_for_monitoring
             external_functions["ensure_aks_acr"] = ensure_aks_acr
-            external_functions["ensure_aks_service_principal"] = ensure_aks_service_principal
             external_functions[
                 "ensure_cluster_identity_permission_on_kubelet_identity"
             ] = ensure_cluster_identity_permission_on_kubelet_identity
@@ -1048,19 +1046,12 @@ class AKSManagedClusterContext(BaseAKSContext):
 
     # pylint: disable=too-many-statements
     def _get_service_principal_and_client_secret(
-        self, read_only: bool = False
+        self, enable_validation: bool = False, read_only: bool = False
     ) -> Tuple[Union[str, None], Union[str, None]]:
         """Internal function to dynamically obtain the values of service_principal and client_secret according to the
         context.
 
-        When service_principal and client_secret are not assigned and enable_managed_identity is True, dynamic
-        completion will not be triggered. For other cases, dynamic completion will be triggered.
-        When client_secret is given but service_principal is not, dns_name_prefix or fqdn_subdomain will be used to
-        create a service principal. The parameters subscription_id, location and name (cluster) are also required when
-        calling function "ensure_aks_service_principal", which internally used GraphRbacManagementClient to send
-        the request.
-        When service_principal is given but client_secret is not, function "ensure_aks_service_principal" would raise
-        CLIError.
+        This function supports the option of enable_validation.
 
         This function supports the option of read_only. When enabled, it will skip dynamic completion and validation.
 
@@ -1103,37 +1094,16 @@ class AKSManagedClusterContext(BaseAKSContext):
         if read_only:
             return service_principal, client_secret
 
-        # dynamic completion for service_principal and client_secret
-        dynamic_completion = False
-        # check whether the parameter meet the conditions of dynamic completion
-        enable_managed_identity = self._get_enable_managed_identity(read_only=True)
-        if not (
-            enable_managed_identity and
-            not service_principal and
-            not client_secret
-        ):
-            dynamic_completion = True
-        # disable dynamic completion if the value is read from `mc`
-        dynamic_completion = (
-            dynamic_completion and
-            not sp_read_from_mc and
-            not secret_read_from_mc
-        )
-        if dynamic_completion:
-            principal_obj = self.external_functions.ensure_aks_service_principal(
-                cli_ctx=self.cmd.cli_ctx,
-                service_principal=service_principal,
-                client_secret=client_secret,
-                subscription_id=self.get_subscription_id(),
-                dns_name_prefix=self._get_dns_name_prefix(enable_validation=False),
-                fqdn_subdomain=self._get_fqdn_subdomain(enable_validation=False),
-                location=self.get_location(),
-                name=self.get_name(),
-            )
-            service_principal = principal_obj.get("service_principal")
-            client_secret = principal_obj.get("client_secret")
+        # these parameters do not need dynamic completion
 
-        # these parameters do not need validation
+        # validation
+        if enable_validation:
+            # only one of service_principal and client_secret is provided, not both
+            if (service_principal or client_secret) and not (service_principal and client_secret):
+                raise RequiredArgumentMissingError(
+                    "Please provide both --service-principal and --client-secret to use sp as the cluster identity. "
+                    "An sp can be created using the 'az ad sp create-for-rbac' command."
+                )
         return service_principal, client_secret
 
     def get_service_principal_and_client_secret(
@@ -1141,19 +1111,10 @@ class AKSManagedClusterContext(BaseAKSContext):
     ) -> Tuple[Union[str, None], Union[str, None]]:
         """Dynamically obtain the values of service_principal and client_secret according to the context.
 
-        When service_principal and client_secret are not assigned and enable_managed_identity is True, dynamic
-        completion will not be triggered. For other cases, dynamic completion will be triggered.
-        When client_secret is given but service_principal is not, dns_name_prefix or fqdn_subdomain will be used to
-        create a service principal. The parameters subscription_id, location and name (cluster) are also required when
-        calling function "ensure_aks_service_principal", which internally used GraphRbacManagementClient to send
-        the request.
-        When service_principal is given but client_secret is not, function "ensure_aks_service_principal" would raise
-        CLIError.
-
         :return: a tuple containing two elements: service_principal of string type or None and client_secret of
         string type or None
         """
-        return self._get_service_principal_and_client_secret()
+        return self._get_service_principal_and_client_secret(enable_validation=True)
 
     def _get_enable_managed_identity(
         self, enable_validation: bool = False, read_only: bool = False
@@ -4102,9 +4063,6 @@ class AKSManagedClusterCreateDecorator(BaseAKSManagedClusterDecorator):
 
     def set_up_service_principal_profile(self, mc: ManagedCluster) -> ManagedCluster:
         """Set up service principal profile for the ManagedCluster object.
-
-        The function "ensure_aks_service_principal" will be called if the user provides an incomplete sp and secret
-        pair, which internally used GraphRbacManagementClient to send the request to create sp.
 
         :return: the ManagedCluster object
         """

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -20,7 +20,6 @@ from azure.cli.core.cloud import get_active_cloud
 from azure.cli.core.profiles import get_sdk, ResourceType, supported_api_version
 
 from msrestazure.azure_exceptions import CloudError
-from azure.graphrbac.models import GraphErrorException
 from azure.cli.command_modules.acs._params import (regions_in_preview,
                                                    regions_in_prod)
 from azure.cli.command_modules.acs.custom import (merge_kubernetes_configurations, list_acs_locations,
@@ -596,27 +595,6 @@ class AcsCustomCommandTest(unittest.TestCase):
         ]
         self.assertEqual(merged['users'], expected_users)
         self.assertEqual(merged['current-context'], obj2['current-context'])
-
-    def test_acs_sp_create_failed_with_polished_error_if_due_to_permission(self):
-
-        class FakedError(object):
-            def __init__(self, message):
-                self.message = message
-
-        def _test_deserializer(resp_type, response):
-            err = FakedError('Insufficient privileges to complete the operation')
-            return err
-
-        client = mock.MagicMock()
-        client.create.side_effect = GraphErrorException(_test_deserializer, None)
-
-        # action
-        with self.assertRaises(CLIError) as context:
-            create_application(client, 'acs_sp', 'http://acs_sp', ['http://acs_sp'])
-
-        # assert we handled such error
-        self.assertTrue(
-            'https://docs.microsoft.com/azure/azure-resource-manager/resource-group-create-service-principal-portal' in str(context.exception))
 
     @mock.patch('azure.cli.command_modules.acs.addonconfiguration.get_rg_location', return_value='eastus')
     @mock.patch('azure.cli.command_modules.acs.addonconfiguration.cf_resource_groups', autospec=True)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -38,7 +38,6 @@ from azure.cli.core._config import ENV_VAR_PREFIX, GLOBAL_CONFIG_DIR
 from azure.cli.core.cloud import get_active_cloud
 from azure.cli.core.profiles import ResourceType, get_sdk
 from azure.cli.core.util import CLIError
-from azure.graphrbac.models import GraphErrorException
 from azure.mgmt.containerservice.models import (
     ContainerService,
     ContainerServiceOrchestratorProfile,
@@ -606,27 +605,6 @@ class AcsCustomCommandTest(unittest.TestCase):
         ]
         self.assertEqual(merged['users'], expected_users)
         self.assertEqual(merged['current-context'], obj2['current-context'])
-
-    def test_acs_sp_create_failed_with_polished_error_if_due_to_permission(self):
-
-        class FakedError(object):
-            def __init__(self, message):
-                self.message = message
-
-        def _test_deserializer(resp_type, response):
-            err = FakedError('Insufficient privileges to complete the operation')
-            return err
-
-        client = mock.MagicMock()
-        client.create.side_effect = GraphErrorException(_test_deserializer, None)
-
-        # action
-        with self.assertRaises(CLIError) as context:
-            create_application(client, 'acs_sp', 'http://acs_sp', ['http://acs_sp'])
-
-        # assert we handled such error
-        self.assertTrue(
-            'https://docs.microsoft.com/azure/azure-resource-manager/resource-group-create-service-principal-portal' in str(context.exception))
 
     @mock.patch('azure.cli.command_modules.acs.addonconfiguration.get_rg_location', return_value='eastus')
     @mock.patch('azure.cli.command_modules.acs.addonconfiguration.cf_resource_groups', autospec=True)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_decorator.py
@@ -1642,12 +1642,16 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_2.set_intermediate(
             "subscription_id", "1234-5678", overwrite_exists=True
         )
+        principal_obj_2 = {
+            "service_principal": "test_service_principal",
+            "client_secret": "test_client_secret",
+        }
         with patch(
             "azure.cli.command_modules.acs.decorator.get_rg_location",
             return_value="test_location",
         ), patch(
-            "azure.cli.command_modules.acs._graph.get_graph_rbac_management_client",
-            return_value=None,
+            "azure.cli.command_modules.acs.decorator.ensure_aks_service_principal",
+            return_value=principal_obj_2,
         ):
             self.assertEqual(
                 ctx_2.get_service_principal_and_client_secret(),
@@ -1670,15 +1674,16 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_3.set_intermediate(
             "subscription_id", "1234-5678", overwrite_exists=True
         )
+        principal_obj_3 = {
+            "service_principal": "test_service_principal",
+            "client_secret": "test_client_secret",
+        }
         with patch(
             "azure.cli.command_modules.acs.decorator.get_rg_location",
             return_value="test_location",
         ), patch(
-            "azure.cli.command_modules.acs._graph.get_graph_rbac_management_client",
-            return_value=None,
-        ), patch(
-            "azure.cli.command_modules.acs._graph.build_service_principal",
-            return_value=("test_service_principal", "test_aad_session_key"),
+            "azure.cli.command_modules.acs.decorator.ensure_aks_service_principal",
+            return_value=principal_obj_3,
         ):
             self.assertEqual(
                 ctx_3.get_service_principal_and_client_secret(),
@@ -1717,12 +1722,16 @@ class AKSContextTestCase(unittest.TestCase):
         ctx_4.set_intermediate(
             "subscription_id", "1234-5678", overwrite_exists=True
         )
+        principal_obj_4 = {
+            "service_principal": "test_service_principal",
+            "client_secret": "test_client_secret",
+        }
         with patch(
             "azure.cli.command_modules.acs.decorator.get_rg_location",
             return_value="test_location",
         ), patch(
-            "azure.cli.command_modules.acs._graph.get_graph_rbac_management_client",
-            return_value=None,
+            "azure.cli.command_modules.acs.decorator.ensure_aks_service_principal",
+            side_effect=[CLIError],
         ):
             # fail on client_secret not specified
             with self.assertRaises(CLIError):
@@ -5108,12 +5117,16 @@ class AKSCreateDecoratorTestCase(unittest.TestCase):
         dec_2.context.set_intermediate(
             "subscription_id", "1234-5678", overwrite_exists=True
         )
+        principal_obj_2 = {
+            "service_principal": "test_service_principal",
+            "client_secret": "test_client_secret",
+        }
         with patch(
             "azure.cli.command_modules.acs.decorator.get_rg_location",
             return_value="test_location",
         ), patch(
-            "azure.cli.command_modules.acs._graph.get_graph_rbac_management_client",
-            return_value=None,
+            "azure.cli.command_modules.acs.decorator.ensure_aks_service_principal",
+            return_value=principal_obj_2,
         ):
             dec_mc_2 = dec_2.set_up_service_principal_profile(mc_2)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

- Graph module migration.
  - Remove most dependencies on graph SDK.
  - Only keep the functions that query object id by app id, which is used by role assignments.
  - Keep the graph SDK related calls used by the `acs` commands unchanged, and plan to remove the deprecated `acs` command group as a whole during the next breaking change window to eliminate the dependency on the legacy graph SDK.
  - Split the global import of legacy graph SDK in `custom.py` into each function, so that even if CLI removes the dependency, import errors should not occur without using these deprecated commands.
- After the changes in this PR, a service principal will no longer be implicitly created for the user when the user has not provided both app id and secret (through options `--service-principal` and `--client-secret`), instead a `RequiredArgumentMissingError` exception would be raised to prompt the users to create it by themselves.
  - Although the default behavior of aks create is to use managed identity as the cluster's identity, users can still set service principal as the cluster's identity by specifying the --service-principal and --client-secret options. And there is still a [piece of code](https://github.com/Azure/azure-cli/blob/62a01da2b5f2de505e37ed8f444e06c5b8dd5f09/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py#L1123) that helps create an [application and service principal](https://github.com/Azure/azure-cli/blob/62a01da2b5f2de505e37ed8f444e06c5b8dd5f09/src/azure-cli/azure/cli/command_modules/acs/_graph.py#L188) when the user only provides --client-secret. But with this graph module migration, the previously used Azure AD Graph API will be replaced by the Microsoft Graph API (see [doc](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview), which does not support specifying password credential when creating [application](https://docs.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-beta&tabs=http) and [service principals](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-beta&tabs=http), which makes it impossible for us to maintain the previous behavior.
  - Therefore, I propose that when the user does not provide the complete service principal information (i.e., provide the app id and secret at the same time), instead of trying to create an application and service principal for the users, an error is thrown to prompt the users to create it by themselves. In my opinion, this change will not be noticeable to most users of aks, because the default create behavior is to use managed identity, and users who use service principal as identity will generally provide both id and secret. In addition, after this change, we will basically remove the legacy dependency on the graph module on the CLI side, making the code more streamlined and conducive to subsequent maintenance.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
