### PR TITLE
[ARM] `az bicep build`: Fix #22621: `--stdout` does not work

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3684,7 +3684,7 @@ def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, no_resto
         args += ["--stdout"]
 
     output = run_bicep_command(args)
-    
+
     if stdout:
         print(output)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3678,10 +3678,10 @@ def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, no_resto
         args += ["--outdir", outdir]
     if outfile:
         args += ["--outfile", outfile]
-    if stdout:
-        args += ["--stdout"]
     if no_restore:
         args += ["--no-restore"]
+    if stdout:
+        args += ["--stdout"]
         print(run_bicep_command(args))
         return
     run_bicep_command(args)

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3682,9 +3682,11 @@ def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, no_resto
         args += ["--no-restore"]
     if stdout:
         args += ["--stdout"]
-        print(run_bicep_command(args))
-        return
-    run_bicep_command(args)
+
+    output = run_bicep_command(args)
+    
+    if stdout:
+        print(output)
 
 
 def publish_bicep_file(cmd, file, target):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
v2.37.0 has a regression where `--stdout` stops working for `az bicep build`. The PR fixes it.

Closes #22621.

**Testing Guide**
`az bicep build -f main.bicep --stdout`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
