### PR TITLE
{Keyvault} `az keyvault key set-attributes`: Make `--policy` required if `--immutable` provided

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -221,7 +221,7 @@ def process_key_release_policy(cmd, ns):
         del ns.immutable
 
     if not ns.release_policy and not default_cvm_policy:
-        if immutable:
+        if immutable is not None:
             raise InvalidArgumentValueError('Please provide policy when setting `--immutable`')
         return
 


### PR DESCRIPTION

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault key set-attributes`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We should alert if users set `--immutable` without providing `--policy`. But `--immutable false` skipped this validation.
This PR wants to fix this.

**Testing Guide**
<!--Example commands with explanations.-->
`az keyvault key set-attributes -n $keyName --hsm-name $hsmName --immutable false`


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
