### PR TITLE
{Core} `aaz`: fix issue in load_aaz_command_table for azdev and CI

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -303,8 +303,12 @@ def load_aaz_command_table(loader, aaz_pkg_name, args):
 
     command_table = {}
     command_group_table = {}
-    arg_str = ' '.join(args)
-    fully_load = os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true'  # used to disable cut logic
+    if args is None:
+        arg_str = ''
+        fully_load = True
+    else:
+        arg_str = ' '.join(args)
+        fully_load = os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true'  # used to disable cut logic
     if profile_pkg is not None:
         _load_aaz_pkg(loader, profile_pkg, command_table, command_group_table, arg_str, fully_load)
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -308,7 +308,7 @@ def load_aaz_command_table(loader, aaz_pkg_name, args):
         fully_load = True
     else:
         arg_str = ' '.join(args)
-        fully_load = os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true'  # used to disable cut logic
+        fully_load = os.environ.get(AAZ_PACKAGE_FULL_LOAD_ENV_NAME, 'False').lower() == 'true'  # disable cut logic
     if profile_pkg is not None:
         _load_aaz_pkg(loader, profile_pkg, command_table, command_group_table, arg_str, fully_load)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

azdev or CI script will pass None value as args. It caused the fail of load_aaz_command_table.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
