### PR TITLE
Fix incorrect Azure CLI reference links

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/feedback/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/custom.py
@@ -36,7 +36,7 @@ _QUESTIONS_URL = "aka.ms/azcli/questions"
 _CLI_ISSUES_URL = "aka.ms/azcli/issues"
 _RAW_CLI_ISSUES_URL = "https://github.com/azure/azure-cli/issues/new"
 
-_EXTENSIONS_ISSUES_URL = "aka.ms/azcli/ext/issues"
+_EXTENSIONS_ISSUES_URL = "aka.ms/azcli/issues"
 _RAW_EXTENSIONS_ISSUES_URL = "https://github.com/azure/azure-cli-extensions/issues/new"
 
 _MSG_INTR = \


### PR DESCRIPTION
Bulk update: Edit incorrect Azure CLI reference links by removing /ext.

This work is in accordance with [User Story 1948095](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1948095).


**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
