### PR TITLE
[Profile] `az account get-access-token`: Add `--show-claims` to show decoded claims

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/__init__.py
@@ -78,6 +78,7 @@ class ProfileCommandsLoader(AzCommandsLoader):
             c.argument('resource', options_list=['--resource'], help='Azure resource endpoints in AAD v1.0.')
             c.argument('scopes', options_list=['--scope'], nargs='*', help='Space-separated AAD scopes in AAD v2.0. Default to Azure Resource Manager.')
             c.argument('tenant', options_list=['--tenant', '-t'], help='Tenant ID for which the token is acquired. Only available for user and service principal account, not for MSI or Cloud Shell account')
+            c.argument('show_claims',  help='Show the decoded claims of the access token.')
 
 
 COMMAND_LOADER_CLS = ProfileCommandsLoader

--- a/src/azure-cli/azure/cli/command_modules/profile/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_help.py
@@ -96,6 +96,9 @@ examples:
     - name: Get an access token to use with MS Graph API
       text: >
         az account get-access-token --resource-type ms-graph
+    - name: Show the decoded claims of the access token, instead of the token itself
+      text: >
+        az account get-access-token --show-claims
 """
 
 helps['self-test'] = """

--- a/src/azure-cli/azure/cli/command_modules/profile/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/custom.py
@@ -53,7 +53,8 @@ def show_subscription(cmd, subscription=None):
     return profile.get_subscription(subscription)
 
 
-def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None):
+def get_access_token(cmd, subscription=None, resource=None, scopes=None, resource_type=None, tenant=None,
+                     show_claims=False):
     """
     get AAD token to access to a specified resource.
     Use 'az cloud show' command for other Azure resources
@@ -65,6 +66,10 @@ def get_access_token(cmd, subscription=None, resource=None, scopes=None, resourc
     profile = Profile(cli_ctx=cmd.cli_ctx)
     creds, subscription, tenant = profile.get_raw_token(subscription=subscription, resource=resource, scopes=scopes,
                                                         tenant=tenant)
+
+    if show_claims:
+        import jwt
+        return jwt.decode(creds[1], algorithms=['RS256'], options={'verify_signature': False})
 
     result = {
         'tokenType': creds[0],


### PR DESCRIPTION
**Related command**
`az account get-access-token`

**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/22776

Currently, in order to get the object ID of the signed in account, we have to query Microsoft Graph API:

- User account: `az ad signed-in-user show`
- Service principal account: `az ad sp show`

However, since some tenant (including Microsoft tenant) has Conditional Access policies that block accessing Microsoft Graph with device code (https://github.com/Azure/azure-cli/issues/22629), querying Microsoft Graph API is no longer possible with device code.

This PR provides a way to **get object ID from the `oid` claim in the access token retrieved with MSAL**, instead of querying Microsoft Graph API.

Actually, this feature was implemented during MSAL migration but was deferred (https://github.com/Azure/azure-cli/pull/19853). Now we are finally making it publicly available.

**Testing Guide**
```
> az account get-access-token --show-claims
{
  "acr": "1",
  "aio": "ATQAy/8TAAAA9t0fnf3TqvkKsCsD9P6EkOcF3e503G8sr3QfK9VOO0qJXf6PZAHDFGXXK7TE1vq7",
  "amr": [
    "pwd"
  ],
  "appid": "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
  "appidacr": "0",
  "aud": "https://management.core.windows.net/",
  "exp": 1654679388,
  "iat": 1654674494,
  "ipaddr": "167.220.255.27",
  "iss": "https://sts.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/",
  "name": "Azure CLI Test User",
  "nbf": 1654674494,
  "oid": "214ee69d-ef49-41ed-9fb7-4f3f2620fcf7",
  "puid": "10032002034DB0EB",
  "rh": "0.ATcAImuCVNY4sk-62be5Oj6cWkZIf3kAutdPukPawfj2MBM3APQ.",
  "scp": "user_impersonation",
  "sub": "I71mpyWL8QLnz6LgqtrcU4P16j9bvavH9668-z-z8dU",
  "tid": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
  "unique_name": "azure-cli-test-user@AzureSDKTeam.onmicrosoft.com",
  "upn": "azure-cli-test-user@AzureSDKTeam.onmicrosoft.com",
  "uti": "_YH6T5YIlke4uNkj7uU8AA",
  "ver": "1.0",
  "wids": [
    "b79fbf4d-3ef9-4689-8143-76b194e85509"
  ],
  "xms_tcdt": 1412206840
}
```
