### PR TITLE
{Graph} Remove unnecessary logic from `MSGraphClientPasswordReplacer`

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py
@@ -163,8 +163,6 @@ class MSGraphClientPasswordReplacer(RecordingProcessor):
         self._activated = False
 
     def process_request(self, request):
-        if request.body and self.PWD_REPLACEMENT in _byte_to_str(request.body):
-            return request
         if request.path.endswith('/addPassword') and request.method.lower() == 'post':
             self._activated = True
         return request


### PR DESCRIPTION
**Description**<!--Mandatory-->

Synapse test `src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py::SynapseScenarioTests::test_workspace_package` uploads a jar file as the request body:

https://github.com/Azure/azure-cli/blob/85ef3c7e506ccd077f70c0808e6574bb40802d99/src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py#L2652-L2657

As the jar is a binary file (`bytes`), `_byte_to_str` will fail to decode `bytes` as `utf-8`:

https://github.com/Azure/azure-cli/blob/cac3f06cf483d8c81f93c9cd556116e27aff2182/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py#L51-L52

causing failure:

```
src\azure-cli-testsdk\azure\cli\testsdk\scenario_tests\base.py:165: in _process_request_recording
    request = processor.process_request(request)
src\azure-cli-testsdk\azure\cli\testsdk\utilities.py:166: in process_request
    if request.body and self.PWD_REPLACEMENT in _byte_to_str(request.body):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

byte_or_str = b'PK\x03\x04\n\x00\x00\x00\x00\x00:\xbf\x82O\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00META-INF/PK\...INF/maven/Java/WordCount/pom.propertiesPK\x05\x06\x00\x00\x00\x00\x0b\x00\x0b\x00\xeb\x02\x00\x00O\x0e\x00\x00\x00\x00'

    def _byte_to_str(byte_or_str):
>       return str(byte_or_str, 'utf-8') if isinstance(byte_or_str, bytes) else byte_or_str
E       UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbf in position 11: invalid start byte

src\azure-cli-testsdk\azure\cli\testsdk\utilities.py:52: UnicodeDecodeError
```

Those removed lines came from AD Graph `GraphClientPasswordReplacer`:

https://github.com/Azure/azure-cli/blob/8fc09120c6dd40bf43722c0c53b27a3279b4214c/src/azure-cli-testsdk/azure/cli/testsdk/utilities.py#L123-L125

We don't really know what its functionality and the original "issue" were. VCRPY invokes `GraphClientPasswordReplacer` 3 times for each request and the first 2 invocations take place as a pipeline:

1. request -> replace(request) -> replace(replace(request))  # For some internal comparison
2. request -> replace(request)  # The result is saved to YAML

Perhaps those lines are used to eliminate duplicated replacement operation?

Since the request body of Microsoft Graph API [addPassword](https://docs.microsoft.com/en-us/graph/api/application-addpassword?view=graph-rest-1.0&tabs=http) will never contains a password, that doesn't matter now.

**Testing Guide**
```
pytest src/azure-cli/azure/cli/command_modules/synapse/tests/latest/test_synapse_scenario.py::SynapseScenarioTests::test_workspace_package -o log_cli=1
```
