### PR TITLE
[AKS] `az aks get-credentials`: Fix permission prompt when saving config file to symlink

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2243,12 +2243,14 @@ def merge_kubernetes_configurations(existing_file, addition_file, replace, conte
         existing['current-context'] = addition['current-context']
 
     # check that ~/.kube/config is only read- and writable by its owner
-    if platform.system() != 'Windows':
-        existing_file_perms = "{:o}".format(
-            stat.S_IMODE(os.lstat(existing_file).st_mode))
-        if not existing_file_perms.endswith('600'):
-            logger.warning('%s has permissions "%s".\nIt should be readable and writable only by its owner.',
-                           existing_file, existing_file_perms)
+    if platform.system() != "Windows" and not os.path.islink(existing_file):
+        existing_file_perms = "{:o}".format(stat.S_IMODE(os.lstat(existing_file).st_mode))
+        if not existing_file_perms.endswith("600"):
+            logger.warning(
+                '%s has permissions "%s".\nIt should be readable and writable only by its owner.',
+                existing_file,
+                existing_file_perms,
+            )
 
     with open(existing_file, 'w+') as stream:
         yaml.safe_dump(existing, stream, default_flow_style=False)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks get-credentials`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Background
> I need help on a case where when my customer uses soft link for config file, they get the below prompt :-
> 
> /home/sander_flobbe/.kube/config has permissions '777'. It should be readable and writable only by its owner.
> 
> As per my understanding, customer shouldn’t be getting this prompt, as symlink has by default permissions of 777 which can't be modified.
> 
> ### Steps to reproduce the behavior:
>
> 1)	rm -rf .kube
> 2)	mkdir .kube
> 3)	cd .kube
> 4)	touch my-config
> 5)	ln -s my-config config
> 6)	az aks get-credentials --resource-group (..) --name (..) --subscription (..)
> 
> This gives a (false) error:
> /home/sander_flobbe/.kube/config has permissions "777".
> It should be readable and writable only by its owner.
> Merged "aks6e827e784bbf2" as current context in /home/sander_flobbe/.kube/config
> 
> This behavior is reproducible with the steps shared.

In this PR, it will additionally check if the storage path is a symlink, and if so, skip the permission check.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
