### PR TITLE
[Util] az rest: Fix link to moved docs about quotation issues

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/util/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/util/_params.py
@@ -27,7 +27,7 @@ def load_arguments(self, _):
         c.argument('skip_authorization_header', action='store_true', help='Do not auto-append Authorization header')
         c.argument('body', options_list=['--body', '-b'],
                    help='Request body. Use @{file} to load from a file. For quoting issues in different terminals, '
-                        'see https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#quoting-issues')
+                        'see https://docs.microsoft.com/en-us/cli/azure/use-cli-effectively#use-quotation-marks-in-arguments')
         c.argument('output_file', help='save response payload to a file')
         c.argument('resource',
                    help='Resource url for which CLI should acquire a token from AAD in order to access '


### PR DESCRIPTION
**Related command**
az rest --help

**Description**<!--Mandatory-->
The help text contains a link to a document helping with quoting issues under different terminals. The document was moved from the GitHub repo (https://github.com/Azure/azure-cli/blob/dev/doc/use_cli_effectively.md#quoting-issues) to the MS docs (https://docs.microsoft.com/en-us/cli/azure/use-cli-effectively). The commit now changes the link to go directly to the MS docs, saving the user one click and removing a dependency to the GitHub doc.

**Testing Guide**
az rest --help
See description of "--body"

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
