### PR TITLE
[App Service] `az staticwebapp enterprise-edge`: Move command group from extension to official CLI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2605,6 +2605,26 @@ helps['staticwebapp functions show'] = """
       text: az staticwebapp functions show -n MyStaticAppName -g MyResourceGroup
 """
 
+helps['staticwebapp enterprise-edge'] = """
+    type: group
+    short-summary: Manage the Azure Front Door CDN for static webapps. For optimal experience and availability please check our documentation https://aka.ms/swaedge
+"""
+
+helps['staticwebapp enterprise-edge enable'] = """
+    type: command
+    short-summary: Enable the Azure Front Door CDN for a static webapp. Enabling enterprise-grade edge requires re-registration for the Azure Front Door Microsoft.CDN resource provider. For optimal experience and availability please check our documentation https://aka.ms/swaedge
+"""
+
+helps['staticwebapp enterprise-edge disable'] = """
+    type: command
+    short-summary: Disable the Azure Front Door CDN for a static webapp. For optimal experience and availability please check our documentation https://aka.ms/swaedge
+"""
+
+helps['staticwebapp enterprise-edge show'] = """
+    type: command
+    short-summary: Show the status (Enabled, Disabled, Enabling, Disabling) of the Azure Front Door CDN for a webapp. For optimal experience and availability please check our documentation https://aka.ms/swaedge
+"""
+
 helps['webapp deploy'] = """
     type: command
     short-summary: Deploys a provided artifact to Azure Web Apps.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1061,3 +1061,8 @@ def load_arguments(self, _):
     with self.argument_context('staticwebapp functions link') as c:
         c.argument('function_resource_id', help="Resource ID of the functionapp to link. Can be retrieved with 'az functionapp --query id'")
         c.argument('force', help="Force the function link even if the function is already linked to a static webapp. May be needed if the function was previously linked to a static webapp.")
+    # with self.argument_context('staticwebapp enterprise-edge') as c:
+    #     c.argument("resource_group_name", arg_type=resource_group_name_type)
+
+    with self.argument_context('staticwebapp enterprise-edge') as c:
+        c.argument("no_register", help="Don't try to register the Microsoft.CDN provider. Registration can be done manually with: az provider register --wait --namespace Microsoft.CDN. For more details, please review the documentation available at https://go.microsoft.com/fwlink/?linkid=2184995 .", default=False)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -483,6 +483,11 @@ def load_command_table(self, _):
         g.custom_command('unlink', 'unlink_user_function', validator=validate_staticsite_sku)
         g.custom_show_command('show', 'get_user_function', validator=validate_staticsite_sku)
 
+    with self.command_group('staticwebapp enterprise-edge', custom_command_type=staticsite_sdk) as g:
+        g.custom_command('enable', 'enable_staticwebapp_enterprise_edge')
+        g.custom_command('disable', 'disable_staticwebapp_enterprise_edge')
+        g.custom_show_command('show', 'show_staticwebapp_enterprise_edge_status')
+
     with self.command_group('logicapp') as g:
         g.custom_command('delete', 'delete_function_app', confirmation=True)
         g.custom_command('stop', 'stop_webapp')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az staticwebapp enterprise-edge enable`
`az staticwebapp enterprise-edge disable`
`az staticwebapp enterprise-edge show`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Moves the commands in the command group `az staticwebapp enterprise-edge` from the extension to the main CLI. The functionality/interface is the same, but the implementation now uses the SDK 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
