### PR TITLE
[App Service] `az appservice plan create`: Fix #22332

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -370,7 +370,7 @@ def _validate_ase_is_v3(ase):
 
 
 def _validate_ase_not_ilb(ase):
-    if ase.internal_load_balancing_mode != 0:
+    if (ase.internal_load_balancing_mode != 0) and (ase.internal_load_balancing_mode != "None"):
         raise ValidationError("Internal Load Balancer (ILB) App Service Environments not supported")
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1896,8 +1896,6 @@ def create_app_service_plan(cmd, resource_group_name, name, is_linux, hyper_v, p
 
     client = web_client_factory(cmd.cli_ctx)
     if app_service_environment:
-        if hyper_v:
-            raise ArgumentUsageError('Windows containers is not yet supported in app service environment')
         ase_list = client.app_service_environments.list()
         ase_found = False
         ase = None
@@ -1910,6 +1908,8 @@ def create_app_service_plan(cmd, resource_group_name, name, is_linux, hyper_v, p
         if not ase_found:
             err_msg = "App service environment '{}' not found in subscription.".format(app_service_environment)
             raise ResourceNotFoundError(err_msg)
+        if hyper_v and ase.kind in ('ASEV1', 'ASEV2'):
+            raise ArgumentUsageError('Windows containers are only supported on v3 App Service Environments v3 or newer')
     else:  # Non-ASE
         ase_def = None
         if location is None:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az appservice plan create`
`az webapp up`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #22332 (Based on Pramod's work [here](https://github.com/Azure/azure-cli/pull/22349)). Also updates some of the `az webapp up` logic to handle the ASE api now returning the internal load balancer flag in a different format (used to be an int; now it's a string) 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
