### PR TITLE
{Packaging} Bump msrest from 0.6.21 to 0.7.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -111,7 +111,7 @@ knack==0.9.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal==1.18.0b1
-msrest==0.6.21
+msrest==0.7.0
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
@@ -134,7 +134,6 @@ six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==1.26.7
-vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -112,7 +112,7 @@ knack==0.9.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal==1.18.0b1
-msrest==0.6.21
+msrest==0.7.0
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
@@ -135,7 +135,6 @@ six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==1.26.7
-vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -111,7 +111,7 @@ knack==0.9.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal==1.18.0b1
-msrest==0.6.21
+msrest==0.7.0
 msrestazure==0.6.4
 oauthlib==3.0.1
 packaging==21.3
@@ -135,7 +135,6 @@ six==1.14.0
 sshtunnel==0.1.5
 tabulate==0.8.9
 urllib3==1.26.7
-vsts==0.1.25
 wcwidth==0.1.7
 websocket-client==1.3.1
 xmltodict==0.12.0


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

- SDK generated by new version of autorest (not released yet) will depend on msrest 0.7.0, so CLI needs bump msrest from 0.6.21 to 0.7.0 beforehand to be compatible with those new SDK.

- Remove vsts 0.1.25 which is useless now. Another reason for removing vsts is that dependency conflict: vsts 0.1.25 requires msrest<0.7.0, >=0.6.0.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
