### PR TITLE
[Cognitive Services] Update SDK and fix an optional parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cognitiveservices/custom.py
@@ -282,7 +282,7 @@ def identity_show(client, resource_group_name, account_name):
 def deployment_begin_create_or_update(
         client, resource_group_name, account_name, deployment_name,
         model_format, model_name, model_version,
-        scale_settings_scale_type, scale_settings_capacity):
+        scale_settings_scale_type, scale_settings_capacity=None):
     """
     Create a deployment for Azure Cognitive Services account.
     """
@@ -294,7 +294,8 @@ def deployment_begin_create_or_update(
     dpy.properties.model.version = model_version
     dpy.properties.scale_settings = DeploymentScaleSettings()
     dpy.properties.scale_settings.scale_type = scale_settings_scale_type
-    dpy.properties.scale_settings.capacity = scale_settings_capacity
+    if scale_settings_capacity is not None:
+        dpy.properties.scale_settings.capacity = scale_settings_capacity
 
     return client.begin_create_or_update(resource_group_name, account_name, deployment_name, dpy, polling=False)
 

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -27,7 +27,7 @@ azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0
 azure-mgmt-botservice==0.3.0
 azure-mgmt-cdn==12.0.0
-azure-mgmt-cognitiveservices==13.1.0
+azure-mgmt-cognitiveservices==13.2.0
 azure-mgmt-compute==27.0.0
 azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.1.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -27,7 +27,7 @@ azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0
 azure-mgmt-botservice==0.3.0
 azure-mgmt-cdn==12.0.0
-azure-mgmt-cognitiveservices==13.1.0
+azure-mgmt-cognitiveservices==13.2.0
 azure-mgmt-compute==27.0.0
 azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.1.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -27,7 +27,7 @@ azure-mgmt-batchai==7.0.0b1
 azure-mgmt-billing==6.0.0
 azure-mgmt-botservice==0.3.0
 azure-mgmt-cdn==12.0.0
-azure-mgmt-cognitiveservices==13.1.0
+azure-mgmt-cognitiveservices==13.2.0
 azure-mgmt-compute==27.0.0
 azure-mgmt-consumption==2.0.0
 azure-mgmt-containerinstance==9.1.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -73,7 +73,7 @@ DEPENDENCIES = [
     'azure-mgmt-billing==6.0.0',
     'azure-mgmt-botservice~=0.3.0',
     'azure-mgmt-cdn==12.0.0',
-    'azure-mgmt-cognitiveservices~=13.1.0',
+    'azure-mgmt-cognitiveservices~=13.2.0',
     'azure-mgmt-compute~=27.0.0',
     'azure-mgmt-consumption~=2.0',
     'azure-mgmt-containerinstance~=9.1.0',


### PR DESCRIPTION
**Related command**
`az cognitiveservices account deployment create`

**Description**<!--Mandatory-->
Update SDK, which container new enum options for scale type
Fix `deployment create` command and make scale capacity optional.


**Testing Guide**
When using `az cognitiveservices account deployment create` command,  --scale-settings-scale-type now support new enums. and --scale-settings-capacity is now optional
Sample command.
`az cognitiveservices account deployment create -n {sname} -g {rg} --deployment-name dpy --model-name ada --model-version "1" --model-format OpenAI --scale-settings-scale-type "Standard"`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Cognitive Services] `az cognitiveservices account deployment create` now supports standard scale type
{Cognitive Services} Update RP SDK, which container new enum options for scale type
{Cognitive Services} Fix `deployment create` command and make scale capacity optional

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
