### PR TITLE
{Compute} `az vm application`: Fix typo in vm help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -2030,12 +2030,12 @@ examples:
 
 helps['vm application'] = """
 type: group
-short-summary: Manage appliations for VM
+short-summary: Manage applications for VM
 """
 
 helps['vm application set'] = """
 type: command
-short-summary: Set appliations for VM.
+short-summary: Set applications for VM.
 examples:
   - name: Set applications for vm
     text: az vm application set -g MyResourceGroup -n MyVm --app-version-ids /subscriptions/subid/resourceGroups/MyResourceGroup/providers/Microsoft.Compute/galleries/myGallery1/applications/MyApplication1/versions/1.0 \


### PR DESCRIPTION
**Related command**

```sh
az vm -h
```

**Description**<!--Mandatory-->

Helper text for the above command has a small typo: `application            : Manage appliations for VM.`

Instead of "appliations" it should be "appli**c**ations"

<img src="https://user-images.githubusercontent.com/6530769/173161891-4c8cb539-878e-4418-9d51-48ed16fe8267.png" width=400/>


**Testing Guide**

Run the command again with `az vm -h` and the helper text output for the `application` subgroup should be correct.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
