### PR TITLE
{CI} Migrate fabric bot from portal to config-as-code

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,12009 @@
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Add needs triage label to new issues",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isPartOfProject",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAssignedToSomeone",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isLabeled",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                },
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "reopened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-triage"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Replace needs author feedback label with needs attention label when the author comments on an issue",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs-author-feedback"
+              }
+            },
+            {
+              "name": "isOpen",
+              "parameters": {}
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label from issues",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label when an issue is commented on",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ],
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Close stale issues",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 14
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Add no recent activity label to issues",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi, we're sending this friendly reminder because we haven't heard back from you in a while. We need more information about this issue to help address it. Please be sure to give us your input within the next **7 days**. If we don't hear back from you within **14 days** of this comment the issue will be automatically closed. Thank you!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "labeled"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs-triage"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-triage"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove needs-triage label on issues once they are labeled",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-triage"
+            }
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "association": "MEMBER",
+                        "permissions": "write"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "MEMBER"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "COLLABORATOR"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "admin"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add question label to new issues ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "question"
+            }
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "no-recent-activity"
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "needs-author-feedback"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "noActivitySince",
+                  "parameters": {
+                    "days": 7
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "For issues closed due to inactivity, re-open an issue if issue author posts a reply within 7 days.",
+        "actions": [
+          {
+            "name": "reopenIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "activitySenderHasPermissions",
+              "parameters": {
+                "permissions": "none"
+              }
+            },
+            {
+              "name": "noActivitySince",
+              "parameters": {
+                "days": 7
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "For issues closed with no activity over 7 days, ask non-contributor to consider opening a new issue instead.",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thank you for your interest in this issue! Because it has been closed for a period of time, we strongly advise that you open a new issue linking to this to ensure better visibility of your comment. "
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "customer-reported"
+              }
+            },
+            {
+              "name": "labelRemoved",
+              "parameters": {
+                "label": "Service Attention"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add label after \"Service Attention\" is removed",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-team-triage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              4,
+              7,
+              10,
+              13,
+              16,
+              19,
+              22
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "MySQL"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Service Attention"
+            }
+          },
+          {
+            "name": "noAssignees",
+            "parameters": {}
+          }
+        ],
+        "taskName": "Assign service attention issues to mentionees for MySQL (requested by service team)",
+        "actions": [
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "5f074be74200c210c870e106"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "MariaDB"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "Service Attention"
+            }
+          },
+          {
+            "name": "noAssignees",
+            "parameters": {}
+          }
+        ],
+        "taskName": "Assign service attention issues to mentionees for MariaDB (requested by service team)",
+        "actions": [
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "5f074be74200c210c870e106"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduledAndTrigger",
+      "capabilityId": "IssueRouting",
+      "subCapability": "@Mention",
+      "version": "1.0",
+      "config": {
+        "labelsAndMentions": [
+          {
+            "labels": [
+              "Service Attention",
+              "AKS"
+            ],
+            "mentionees": [
+              "Azure/aks-pm"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Alerts Management"
+            ],
+            "mentionees": [
+              "liadtal",
+              "yairgil"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM"
+            ],
+            "mentionees": [
+              "josephkwchan",
+              "jennyhunter-msft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - Templates"
+            ],
+            "mentionees": [
+              "satyavel",
+              "apclouds"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - Tags"
+            ],
+            "mentionees": [
+              "rthorn17"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - Core"
+            ],
+            "mentionees": [
+              "josephkwchan",
+              "jennyhunter-msft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - Managed Applications"
+            ],
+            "mentionees": [
+              "MSEvanhi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - Service Catalog"
+            ],
+            "mentionees": [
+              "MSEvanhi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARM - RBAC"
+            ],
+            "mentionees": [
+              "LizMS",
+              "cbrooksmsft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Advisor"
+            ],
+            "mentionees": [
+              "mojayara",
+              "Prasanna-Padmanabhan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Analysis Services"
+            ],
+            "mentionees": [
+              "athipp",
+              "taiwu",
+              "minghan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "API Management"
+            ],
+            "mentionees": [
+              "adrianhall",
+              "KedarJoshi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Application Insights"
+            ],
+            "mentionees": [
+              "azmonapplicationinsights"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "App Services"
+            ],
+            "mentionees": [
+              "antcp",
+              "AzureAppServiceCLI"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "App Configuration"
+            ],
+            "mentionees": [
+              "shenmuxiaosen",
+              "avanigupta"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ARO"
+            ],
+            "mentionees": [
+              "mjudeikis",
+              "jim-minter",
+              "julienstroheker",
+              "amanohar"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Attestation"
+            ],
+            "mentionees": [
+              "anilba06"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Authorization"
+            ],
+            "mentionees": [
+              "darshanhs90",
+              "AshishGargMicrosoft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Automation"
+            ],
+            "mentionees": [
+              "jaspkaur28"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "AVS"
+            ],
+            "mentionees": [
+              "divka78",
+              "amitchat",
+              "aishu"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Azure Stack"
+            ],
+            "mentionees": [
+              "sijuman",
+              "sarathys",
+              "bganapa",
+              "rakku-ms"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Batch"
+            ],
+            "mentionees": [
+              "cRui861",
+              "paterasMSFT",
+              "gingi",
+              "dpwatrous",
+              "mksuni",
+              "bgklein",
+              "mscurrell"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "BatchAI"
+            ],
+            "mentionees": [
+              "matthchr"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Billing"
+            ],
+            "mentionees": [
+              "cabbpt"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Blueprint"
+            ],
+            "mentionees": [
+              "alex-frankel",
+              "filizt"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Bot Service"
+            ],
+            "mentionees": [
+              "sgellock"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cloud Shell"
+            ],
+            "mentionees": [
+              "maertendMSFT"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Text Analytics"
+            ],
+            "mentionees": [
+              "assafi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Form Recognizer"
+            ],
+            "mentionees": [
+              "ctstone",
+              "anrothMSFT"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Anomaly Detector"
+            ],
+            "mentionees": [
+              "yingqunpku",
+              "bowgong"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Custom Vision"
+            ],
+            "mentionees": [
+              "areddish",
+              "tburns10"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Computer Vision"
+            ],
+            "mentionees": [
+              "ryogok",
+              "TFR258",
+              "tburns10"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Face"
+            ],
+            "mentionees": [
+              "JinyuID",
+              "dipidoo",
+              "SteveMSFT"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - QnA Maker"
+            ],
+            "mentionees": [
+              "bingisbestest",
+              "nerajput1607"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Translator"
+            ],
+            "mentionees": [
+              "swmachan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Speech"
+            ],
+            "mentionees": [
+              "robch",
+              "oscholz"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - LUIS"
+            ],
+            "mentionees": [
+              "cahann",
+              "kayousef"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Content Moderator"
+            ],
+            "mentionees": [
+              "swiftarrow11"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Personalizer"
+            ],
+            "mentionees": [
+              "dwaijam"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Immersive Reader"
+            ],
+            "mentionees": [
+              "metanMSFT"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Ink Recognizer"
+            ],
+            "mentionees": [
+              "olduroja"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Bing"
+            ],
+            "mentionees": [
+              "jaggerbodas-ms",
+              "arwong"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cognitive - Mgmt"
+            ],
+            "mentionees": [
+              "yangyuan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Commerce"
+            ],
+            "mentionees": [
+              "ms-premp",
+              "qiaozha"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "avirishuv",
+              "vaibhav-agar",
+              "amjads1"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - Extensions"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "amjads1"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - Images"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "vaibhav-agar"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - Managed Disks"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "vaibhav-agar"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - RDFE"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "avirishuv"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - VM"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "avirishuv"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Compute - VMSS"
+            ],
+            "mentionees": [
+              "Drewm3",
+              "avirishuv"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Connected Kubernetes"
+            ],
+            "mentionees": [
+              "akashkeshari"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Container Instances"
+            ],
+            "mentionees": [
+              "macolso"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Container Registry"
+            ],
+            "mentionees": [
+              "toddysm",
+              "luisdlp",
+              "northtyphoon"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Container Service"
+            ],
+            "mentionees": [
+              "qike-ms",
+              "jwilder",
+              "thomas1206",
+              "seanmck"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cosmos"
+            ],
+            "mentionees": [
+              "Wmengmsft",
+              "MehaKaushik",
+              "zfoster",
+              "kushagraThapar",
+              "simorenoh",
+              "simplynaveen20",
+              "abinav2307"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Customer Insights"
+            ],
+            "mentionees": [
+              "shefymk"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Custom Providers"
+            ],
+            "mentionees": [
+              "manoharp",
+              "MSEvanhi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "CycleCloud"
+            ],
+            "mentionees": [
+              "adriankjohnson"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Bricks"
+            ],
+            "mentionees": [
+              "arindamc"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "DataBox"
+            ],
+            "mentionees": [
+              "tmvishwajit",
+              "matdickson",
+              "manuaery",
+              "madhurinms"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "DataBox Edge"
+            ],
+            "mentionees": [
+              "a-t-mason",
+              "ganzee",
+              "manuaery"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Catalog"
+            ],
+            "mentionees": [
+              "ingave"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Factory"
+            ],
+            "mentionees": [
+              "Jingshu923",
+              "zhangyd2015",
+              "Frey-Wang"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Lake"
+            ],
+            "mentionees": [
+              "sumantmehtams"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Lake Storage Gen1"
+            ],
+            "mentionees": [
+              "sumantmehtams"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Lake Storage Gen2"
+            ],
+            "mentionees": [
+              "sumantmehtams"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Lake Analytics"
+            ],
+            "mentionees": [
+              "idear1203"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Lake Store"
+            ],
+            "mentionees": [
+              "sumantmehtams"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Migration"
+            ],
+            "mentionees": [
+              "radjaram",
+              "kavitham10"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Data Share"
+            ],
+            "mentionees": [
+              "raedJarrar",
+              "jifems"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "DevOps"
+            ],
+            "mentionees": [
+              "v-anvashist",
+              "V-hmusukula"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Dev Spaces"
+            ],
+            "mentionees": [
+              "yuzorMa",
+              "johnsta",
+              "greenie-msft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Devtestlab"
+            ],
+            "mentionees": [
+              "Tanmayeekamath"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Device Provisioning Service"
+            ],
+            "mentionees": [
+              "nberdy"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Digital Twins"
+            ],
+            "mentionees": [
+              "sourabhguha",
+              "inesk-vt"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Event Grid"
+            ],
+            "mentionees": [
+              "jfggdl"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Event Hubs"
+            ],
+            "mentionees": [
+              "Saglodha"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Functions"
+            ],
+            "mentionees": [
+              "Stefanus Hinardi",
+              "Francisco-Gamino"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Graph.Microsoft"
+            ],
+            "mentionees": [
+              "dkershaw10",
+              "baywet"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Guest Configuration"
+            ],
+            "mentionees": [
+              "mgreenegit",
+              "vivlingaiah"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "HDInsight"
+            ],
+            "mentionees": [
+              "aim-for-better",
+              "idear1203",
+              "deshriva"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "HPC Cache"
+            ],
+            "mentionees": [
+              "romahamu",
+              "omzevall"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Import Export"
+            ],
+            "mentionees": [
+              "madhurinms"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "KeyVault"
+            ],
+            "mentionees": [
+              "RandalliLama",
+              "schaabs",
+              "jlichwa"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Kubernetes Configuration"
+            ],
+            "mentionees": [
+              "NarayanThiru"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Azure Data Explorer"
+            ],
+            "mentionees": [
+              "ilayrn",
+              "orhasban",
+              "zoharHenMicrosoft",
+              "sagivf",
+              "Aviv-Yaniv"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Lab Services"
+            ],
+            "mentionees": [
+              "Tanmayeekamath"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Logic App"
+            ],
+            "mentionees": [
+              "Azure/azure-logicapps-team"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "LOUIS"
+            ],
+            "mentionees": [
+              "minamnmik"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Machine Learning"
+            ],
+            "mentionees": [
+              "azureml-github"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Machine Learning Compute"
+            ],
+            "mentionees": [
+              "azureml-github"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Machine Learning Experimentation"
+            ],
+            "mentionees": [
+              "aashishb"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Managed Services"
+            ],
+            "mentionees": [
+              "Lighthouse-Azure"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "MariaDB"
+            ],
+            "mentionees": [
+              "ambhatna",
+              "savjani"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Marketplace Ordering"
+            ],
+            "mentionees": [
+              "prbansa"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Media Services"
+            ],
+            "mentionees": [
+              "akucer"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Migrate"
+            ],
+            "mentionees": [
+              "shijojoy"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Mobile Engagement"
+            ],
+            "mentionees": [
+              "kpiteira"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor"
+            ],
+            "mentionees": [
+              "SameergMS",
+              "dadunl"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - Autoscale"
+            ],
+            "mentionees": [
+              "AzMonEssential"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - ActivityLogs"
+            ],
+            "mentionees": [
+              "AzMonEssential"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - Metrics"
+            ],
+            "mentionees": [
+              "AzMonEssential"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - Diagnostic Settings"
+            ],
+            "mentionees": [
+              "AzMonEssential"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - Alerts"
+            ],
+            "mentionees": [
+              "AzmonAlerts"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - ActionGroups"
+            ],
+            "mentionees": [
+              "AzmonActionG"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - LogAnalytics"
+            ],
+            "mentionees": [
+              "AzmonLogA"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Monitor - ApplicationInsights"
+            ],
+            "mentionees": [
+              "azmonapplicationinsights"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "MySQL"
+            ],
+            "mentionees": [
+              "ambhatna",
+              "savjani"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network"
+            ],
+            "mentionees": [
+              "aznetsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Application Gateway"
+            ],
+            "mentionees": [
+              "appgwsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - CDN"
+            ],
+            "mentionees": [
+              "t-bzhan",
+              "gxue"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - DDOS Protection"
+            ],
+            "mentionees": [
+              "ddossuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - ExpressRoute"
+            ],
+            "mentionees": [
+              "exrsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Firewall"
+            ],
+            "mentionees": [
+              "fwsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Front Door"
+            ],
+            "mentionees": [
+              "cdnfdsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Load Balancer"
+            ],
+            "mentionees": [
+              "slbsupportgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Virtual Network NAT"
+            ],
+            "mentionees": [
+              "vnetsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Network Watcher"
+            ],
+            "mentionees": [
+              "netwatchsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - DNS"
+            ],
+            "mentionees": [
+              "dnssuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Traffic Manager"
+            ],
+            "mentionees": [
+              "tmsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - VPN Gateway"
+            ],
+            "mentionees": [
+              "vpngwsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Notification Hub"
+            ],
+            "mentionees": [
+              "tjsomasundaram"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Operational Insights"
+            ],
+            "mentionees": [
+              "AzmonLogA"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Policy"
+            ],
+            "mentionees": [
+              "aperezcloud",
+              "kenieva"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Policy Insights"
+            ],
+            "mentionees": [
+              "kenieva"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "PostgreSQL"
+            ],
+            "mentionees": [
+              "sunilagarwal",
+              "lfittl-msft",
+              "sr-msft",
+              "niklarin"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Recovery Services Backup"
+            ],
+            "mentionees": [
+              "pvrk",
+              "adityabalaji-msft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Recovery Services Site-Recovery"
+            ],
+            "mentionees": [
+              "Sharmistha-Rai"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Redis Cache"
+            ],
+            "mentionees": [
+              "yegu-ms"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Relay"
+            ],
+            "mentionees": [
+              "jfggdl"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Reservations"
+            ],
+            "mentionees": [
+              "Rkapso"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Resource Authorization"
+            ],
+            "mentionees": [
+              "darshanhs90",
+              "AshishGargMicrosoft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Resource Graph"
+            ],
+            "mentionees": [
+              "chiragg4u"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Resource Health"
+            ],
+            "mentionees": [
+              "stephbaron"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Scheduler"
+            ],
+            "mentionees": [
+              "derek1ee"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Search"
+            ],
+            "mentionees": [
+              "brjohnstmsft",
+              "bleroy",
+              "tjacobhi",
+              "markheff",
+              "miwelsh"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Security"
+            ],
+            "mentionees": [
+              "chlahav"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Service Bus"
+            ],
+            "mentionees": [
+              "Saglodha"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Service Fabric"
+            ],
+            "mentionees": [
+              "QingChenmsft",
+              "vaishnavk",
+              "juhacket"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Schema Registry"
+            ],
+            "mentionees": [
+              "arerlend",
+              "alzimmermsft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SignalR"
+            ],
+            "mentionees": [
+              "sffamily",
+              "chenkennt"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - VM"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - Backup & Restore"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - Data Security"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - Elastic Jobs"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - Managed Instance"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SQL - Replication & Failover"
+            ],
+            "mentionees": [
+              "azureSQLGitHub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Storage"
+            ],
+            "mentionees": [
+              "xgithubtriage"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Storsimple"
+            ],
+            "mentionees": [
+              "anoobbacker",
+              "ganzee",
+              "manuaery",
+              "patelkunal"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Stream Analytics"
+            ],
+            "mentionees": [
+              "atpham256"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Subscription"
+            ],
+            "mentionees": [
+              "anuragdalmia",
+              "shilpigautam",
+              "ramaganesan-rg"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Support"
+            ],
+            "mentionees": [
+              "shahbj79",
+              "mit2nil",
+              "aygoya",
+              "ganganarayanan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Synapse"
+            ],
+            "mentionees": [
+              "wonner",
+              "zesluo"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Tables"
+            ],
+            "mentionees": [
+              "klaaslanghout"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "TimeseriesInsights"
+            ],
+            "mentionees": [
+              "Shipra1Mishra"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "vFXT"
+            ],
+            "mentionees": [
+              "zhusijia26"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Web Apps"
+            ],
+            "mentionees": [
+              "AzureAppServiceCLI",
+              "antcp"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Virtual Network"
+            ],
+            "mentionees": [
+              "vnetsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Virtual WAN"
+            ],
+            "mentionees": [
+              "vwansuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Network Virtual Appliance"
+            ],
+            "mentionees": [
+              "nvasuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Bastion"
+            ],
+            "mentionees": [
+              "bastionsuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "IoT/CLI"
+            ],
+            "mentionees": [
+              "Azure/azure-iot-cli-triage"
+            ]
+          },
+          {
+            "labels": [
+              "Azure.Spring - Cosmos"
+            ],
+            "mentionees": [
+              "kushagraThapur"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Network - Private Link"
+            ],
+            "mentionees": [
+              "privlinksuppgithub"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Azure arc enabled servers"
+            ],
+            "mentionees": [
+              "rpsqrd",
+              "edyoung"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "SecurityInsights"
+            ],
+            "mentionees": [
+              "amirkeren"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Azure Data Explorer"
+            ],
+            "mentionees": [
+              "Ilayrn",
+              "orhasban",
+              "zoharHenMicrosoft",
+              "sagivf",
+              "Aviv-Yaniv"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Communication"
+            ],
+            "mentionees": [
+              "acsdevx-msft"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management and Consumption"
+            ],
+            "mentionees": [
+              "ccmaxpcrew"
+            ]
+          },
+          {
+            "labels": [
+              "ML-AutoML",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "Aniththa"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Hyperdrive"
+            ],
+            "mentionees": [
+              "Aniththa"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Compute"
+            ],
+            "mentionees": [
+              "nishankgu"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Core UI"
+            ],
+            "mentionees": [
+              "abeomor"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Data4ML"
+            ],
+            "mentionees": [
+              "SturgeonMi"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Designer"
+            ],
+            "mentionees": [
+              "alainli0928"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Data Labeling"
+            ],
+            "mentionees": [
+              "kvijaykannan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-Inference"
+            ],
+            "mentionees": [
+              "shivanissambare"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ML-MLOps"
+            ],
+            "mentionees": [
+              "lostmygithubaccount"
+            ]
+          },
+          {
+            "labels": [
+              "ML-Pipelines",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "shbijlan"
+            ]
+          },
+          {
+            "labels": [
+              "ML-Responsible AI",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "minthigpen"
+            ]
+          },
+          {
+            "labels": [
+              "ML-Reinforcement Learning",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "keijik"
+            ]
+          },
+          {
+            "labels": [
+              "ML-Training",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "lostmygithubaccount"
+            ]
+          },
+          {
+            "labels": [
+              "ML-Workspace Management",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "rastala"
+            ]
+          },
+          {
+            "labels": [
+              "Spring Cloud",
+              "Service Attention"
+            ],
+            "mentionees": [
+              "ShichaoQiu",
+              "yuwzho",
+              "yucwan"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management-Budget"
+            ],
+            "mentionees": [
+              "ccmaxpcrew"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Consumption-Budget"
+            ],
+            "mentionees": [
+              "ccmaxpcrew"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management-Query"
+            ],
+            "mentionees": [
+              "ccmixpdevs"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Consumption-Query"
+            ],
+            "mentionees": [
+              "ccmixpdevs"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management-Billing"
+            ],
+            "mentionees": [
+              "ccmbpxpcrew"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Consumption-Billing"
+            ],
+            "mentionees": [
+              "ccmbpxpcrew"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management-UsageDetailsAndExport"
+            ],
+            "mentionees": [
+              "TiagoCrewGitHubIssues"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Consumption-UsageDetailsandExport"
+            ],
+            "mentionees": [
+              "TiagoCrewGitHubIssues"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Consumption- RIandShowBack"
+            ],
+            "mentionees": [
+              "ccmshowbackdevs"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Serial Console"
+            ],
+            "mentionees": [
+              "CraigWiand"
+            ]
+          },
+          {
+            "mentionees": [
+              "cijothomas",
+              "reyang",
+              "rajkumar-rangaraj",
+              "TimothyMothra",
+              "vishweshbankwar"
+            ],
+            "labels": [
+              "Monitor - Exporter",
+              "Service Attention"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "Cost Management-RIandShowBack"
+            ],
+            "mentionees": [
+              "ccmshowbackdevs"
+            ]
+          },
+          {
+            "labels": [
+              "Service Attention",
+              "ContainerApp"
+            ],
+            "mentionees": [
+              "calvinsID"
+            ]
+          }
+        ],
+        "replyTemplate": "Thanks for the feedback! We are routing this to the appropriate team for follow-up. cc ${mentionees}.",
+        "taskName": "Triage issues to the service team"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "write"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "MEMBER"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "COLLABORATOR"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "admin"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add customer-reported label to PRs from customers ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "customer-reported"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thank you for your contribution ${issueAuthor}! We will review the pull request and get back to you soon."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "association": "MEMBER",
+                        "permissions": "write"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "MEMBER"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasAssociation",
+                      "parameters": {
+                        "association": "COLLABORATOR"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "admin"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Add customer-reported label to issues coming from non-collaborators",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "customer-reported"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z network",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z network",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "groupId": "",
+              "milestoneName": "Backlog"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "groupId": "61ee1499ed91cf3268d76645",
+              "user": "necusjz"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ],
+        "taskName": "[Network] auto assign labels and users based on issue description. Please do not delete"
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "CXP Attention"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "Service Attention"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[CXP Pilot] CXP Attention Responder",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thank you for your feedback.  This has been routed to the support team for assistance.",
+              "label": "Storage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "CXP Attention"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "hasLabel",
+                  "parameters": {
+                    "label": "Service Attention"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[CXP Pilot] CXP Attention Responder",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Thank you for your feedback.  This has been routed to the support team for assistance."
+            }
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z \\b(vm|vmss|image|disk|snapshot)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z \\b(vm|vmss|image|disk|snapshot)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Compute] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Compute"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "61ee1769ed91cf3268d7664a"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z storage",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z storage",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Storage] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Storage"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "61ee1830ed91cf3268d7664d"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ],
+        "dangerZone": {
+          "respondToBotActions": false,
+          "acceptRespondToBotActions": true
+        }
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(network|Network|NETWORK|monitor|Monitor|MONITOR|bastion|Bastion|BASTION)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Network Monitor Bastion] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "necusjz"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "necusjz"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(Compute|compute|COMPUTE|VM)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Compute] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Compute"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ss][Tt][Oo][Rr][Aa][Gg][Ee])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Storage] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Storage"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z \\b(aks|acs|openshift)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z \\b(aks|acs|openshift)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[AKS] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "AKS"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z \\b(appservice|logicapp)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z \\b(appservice|logicapp)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[appservice] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "App Services"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z webapp",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z webapp",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[webapp] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Web Apps"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z iot",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z iot",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[iot] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "IoT"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "IoT/CLI"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z spring-cloud",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z spring-cloud",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[spring-cloud] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Spring-Cloud"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az keyvault",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az keyvault",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[keyvault] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "KeyVault"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "620c4edb6cc2ae3d5c9f321e"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z [Mm]onitor",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z [Mm]onitor",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[monitor] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Monitor"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "620c4f9c6cc2ae3d5c9f3221"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az role"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az role"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[role] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "RBAC"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "620c50606cc2ae3d5c9f3224"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z \\b(resource|group|lock|tag|deployment|policy|managementapp|account management-group)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z \\b(resource|group|lock|tag|deployment|policy|managementapp|account management-group)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[arm] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "ARM"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "620c51246cc2ae3d5c9f3227"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az sql",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az sql",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[sql] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "SQL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az acr",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az acr",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[acr] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Container Registry"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az \\b(login|account)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az \\b(login|account)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[account] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Account"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "groupId": "",
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az container"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az container"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[container] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Container Instances"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az functionapp",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az functionapp",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[functionapp] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Functions"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az apim",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az apim",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[apim] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "API Management"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az devops",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az devops",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[devops] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "DevOps"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az ad",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az ad",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "isRegex": true,
+                    "titlePattern": "\\b([Gg][Rr][Aa][Pp][Hh])\\b"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "isRegex": true,
+                    "bodyPattern": "\\b([Gg][Rr][Aa][Pp][Hh])\\b"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[graph] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Graph"
+            }
+          },
+          {
+            "name": "assignToGitHubUserGroup",
+            "parameters": {
+              "groupId": "620c56276cc2ae3d5c9f3235"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az \\b(bot|Bot|BOT)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az \\b(bot|Bot|BOT)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[bot] Test",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Test"
+            }
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az interactive"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az interactive"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[interactive] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Interactive"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "groupId": "",
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az upgrade"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az upgrade"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[upgrade] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Upgrade"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az servicebus",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az servicebus",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[servicebus] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Service Bus"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az ml",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az ml",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[machine learning] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Machine Learning"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az lab"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az lab"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[devtestlab] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Devtestlab"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az config"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az config"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[config] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Configure"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az rest"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az rest"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[rest] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az netappfiles",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az netappfiles",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[netappfiles] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "NetAppFiles"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az cosmosdb",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az cosmosdb",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[cosmosdb] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Cosmos"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az staticwebapp",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az staticwebapp",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[staticwebapp] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "staticwebapp"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(arm|Arm|ARM|resource|Resource|RESOURCE)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[arm] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "ARM"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(account|Account|ACCOUNT)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az login"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[account] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Account"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(keyvault|Keyvault|KEYVAULT)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[keyvault] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "KeyVault"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(aks|Aks|AKS|acs|Acs|ACS|openshift|Openshift|OPENSHIFT)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[aks] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "AKS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(role|Role|ROLE)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[role] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "RBAC"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Ll][Oo][Gg][Ii][Cc][Aa][Pp][Pp]",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Aa]pp ?[Ss]ervice)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[appservice] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "App Services"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(packaging|Packaging|PACKAGING)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Packaging] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Packaging"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az eventgrid",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az eventgrid",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[eventgrid] auto assign labels and users based on issue description. ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Event Grid"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ii][Oo][Tt])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[iot] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "IoT"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "IoT/CLI"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az automation"
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az automation"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[automation] auto assign labels and users based on issue description. ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Automation"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(appconfig|Appconfig|APPCONFIG|AppConfig)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[appconfig] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "App Configuration"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(acr|Acr|ACR)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[acr] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Container Registry"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(servicebus|Servicebus|SERVICEBUS|ServiceBus|serviceBus)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[servicebus] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Service Bus"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(ci|Ci|CI)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[ci] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CI"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "wangzelin007"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(core|Core|CORE)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[core] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Core"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(rdbms|Rdbms|RDBMS)\\b",
+                "isRegex": true
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "az mysql",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[rdbms] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(sql|Sql|SQL)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[sql] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "SQL"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(botservice|Botservice|BOTSERVICE|botService|BotService)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[bB]ot [sS]ervice",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[botservice] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "\\b(aladdin|Aladdin|ALADDIN)\\b",
+                "isRegex": true
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[aladdin] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az cdn",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az cdn",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[cdn] auto assign labels and users based on issue description. ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network - CDN"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Cc][Oo][Ss][Mm][Oo][Ss][Dd][Bb]",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Cc][Oo][Ss][Mm][Oo][Ss][Dd][Bb]",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[cosmosdb] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Cosmos"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az redis",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az redis",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[redis] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Redis Cache"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Rr][Ee][Dd][Ii][Ss])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Rr][Ee][Dd][Ii][Ss])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[redis] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Redis Cache"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az sf",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az sf",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Service Fabric] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Service Fabric"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ss]ervice ?[Ff]abric)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ss]ervice ?[Ff]abric)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Service Fabric] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Service Fabric"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": " jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Release] Update index.json for extension"
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[ test ]"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[ext-template] Reply to Update index.json PR",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @wangzelin007, \nPlease review the pull request."
+            }
+          }
+        ]
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az ssh",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az ssh",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[ssh] auto assign labels and users based on issue description. ",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "VM SSH"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "SSH"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az postgres",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az postgres",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[postgres] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "PostgreSQL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az synapse",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az synapse",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[synapse] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Synapse"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z eventhubs",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z eventhubs",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[EventHub] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az portal",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az portal",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[portal] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Portal"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "groupId": "",
+              "user": "jsntcy"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Pp][Oo][Rr][Tt][Aa][Ll])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Pp][Oo][Rr][Tt][Aa][Ll])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[portal] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jsntcy"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Portal"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ww][Ee][Bb][Aa][Pp][Pp])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ww][Ee][Bb][Aa][Pp][Pp])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[webapp] Auto assign labels and reviewers based on PR title/description.",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Web Apps"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Gg][Rr][Aa][Pp][Hh])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Gg][Rr][Aa][Pp][Hh])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az ad",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az ad",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[graph] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Graph"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ii][Nn][Ss][Tt][Aa][Ll][Ll])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ii][Nn][Ss][Tt][Aa][Ll][Ll])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[install] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "milestoneName": "Backlog",
+              "label": "Installation"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "Auto Assign",
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ii][Nn][Ss][Tt][Aa][Ll][Ll])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ii][Nn][Ss][Tt][Aa][Ll][Ll])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[install] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Installation"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az pipelines",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az pipelines",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[pipelines] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Pipelines",
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "DevOps"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Aa][Pp][Ii] ?[Mm]([Aa][Nn][Aa][Gg][Ee][Mm][Ee][Nn][Tt])?)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Aa][Pp][Ii] ?[Mm]([Aa][Nn][Aa][Gg][Ee][Mm][Ee][Nn][Tt])?)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[apim] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "API Management"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z identity",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z identity",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[managed identity] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Managed Identity"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "Functions",
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z identity",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z identity",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[managed identity] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Managed Identity"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]zure [Aa]ctive [Dd]irectory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]zure [Aa]ctive [Dd]irectory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(AAD)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b(AAD)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[AAD] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "AAD"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "Functions",
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]zure [Aa]ctive [Dd]irectory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]zure [Aa]ctive [Dd]irectory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(AAD)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b(AAD)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[AAD] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jiasli"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "AAD"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az network bastion",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az network bastion",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[network bastion] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network - Bastion"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ee]vent ?[Gg]rid)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ee]vent ?[Gg]rid)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[eventgrid] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Event Grid"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az desktopvirtualization",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az desktopvirtualization",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[desktopvirtualization] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Desktop Virtualization"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "Functions",
+              "user": "wangzelin007"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Dd]esktop[Vv]irtualization",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Dd]esktop[Vv]irtualization",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[desktopvirtualization] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "wangzelin007"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Desktop Virtualization"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az backup",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az backup",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Backup] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Backup"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "Functions",
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Backlog"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Bb]ackup)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Bb]ackup)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[backup] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Backup"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az containerapp",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az containerapp",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[container app] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "ContainerApp"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Cc]ontainer ?[Aa]pp)\\b ",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Cc]ontainer ?[Aa]pp)\\b ",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[container app] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jsntcy"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "ContainerApp"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az batch",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az batch",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[batch] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Batch"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Bb][Aa][Tt][Cc][Hh])\\b ",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Bb][Aa][Tt][Cc][Hh])\\b ",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[batch] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "zhoxing-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Batch"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Nn][Ee][Tt][Aa][Pp][Pp][Ff][Ii][Ll][Ee][Ss]?)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Nn][Ee][Tt][Aa][Pp][Pp][Ff][Ii][Ll][Ee][Ss]?)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[netappfiles] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "NetAppFiles"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": " jsntcy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az sql vm",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az sql vm",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[SqlVirtualMachine] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "SQL - VM"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ss]ql[Vv](irtual)?[Mm](achine)?)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ss]ql[Vv](irtual)?[Mm](achine)?)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[SqlVirtualMachine] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "SQL - VM"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z afd",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z afd",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Azure Front Door] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network - Front Door"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z [Dd]ataprotection",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z [Dd]ataprotection",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z afd",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z afd",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Azure Front Door] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "necusjz"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network - Front Door"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "necusjz"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Cc][Dd][Nn])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Cc][Dd][Nn])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[cdn] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "necusjz"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network - CDN"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "necusjz"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Network"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z ams",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z ams",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[ams] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Media Services"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z ams",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z ams",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[ams] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Media Services"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z eventhubs",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z eventhubs",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[eventhub] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Event Hubs"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z cognitiveservices",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z cognitiveservices",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Cognitive Services] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Cognitive Services"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z cognitiveservices",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z cognitiveservices",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Cognitive Services] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Cognitive Services"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jiasli"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az appconfig",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az appconfig",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[appconfig] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "App Configuration"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b([Ss][Yy][Nn][Aa][Pp][Ss][Ee])\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b([Ss][Yy][Nn][Aa][Pp][Ss][Ee])\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[synapse] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jsntcy"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Synapse"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z mysql",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z mysql",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[mysql] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "MySQL"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z logic",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z logic",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[logic app] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Logic App"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z logic",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z logic",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[logic app] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "jsntcy"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "jsntcy"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Logic App"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "wangzelin007"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "\\b(rdbms|Rdbms|RDBMS)\\b",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "\\b(rdbms|Rdbms|RDBMS)\\b",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[rdbms] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az datafactory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az datafactory",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Data Factory] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Data Factory"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "evelyn-ys"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az datafactory",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az datafactory",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Data Factory] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "evelyn-ys"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "evelyn-ys"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Data Factory"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "calvinhzy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Aa]z arcdata",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Aa]z arcdata",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[acrdata] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "arcdata"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "[Rr]eservations?",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "[Rr]eservations?",
+                    "isRegex": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Reservations] Auto assign labels and reviewers based on PR title/description. Please do not delete",
+        "actions": [
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "yonzhan"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "requestReviewer",
+            "parameters": {
+              "reviewer": "kairu-ms"
+            }
+          },
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": "kairu-ms"
+            }
+          },
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Jun 2022 (2022-07-05)"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az backup restore",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az backup restore",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[backup restore] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Recovery Services Backup"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "zhoxing-ms"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az bot",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az bot",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[botservice] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Bot Services"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "jsntcy"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "titleContains",
+                  "parameters": {
+                    "titlePattern": "az advisor",
+                    "isRegex": true
+                  }
+                },
+                {
+                  "name": "bodyContains",
+                  "parameters": {
+                    "bodyPattern": "az advisor",
+                    "isRegex": true
+                  }
+                }
+              ]
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Advisor] auto assign labels and users based on issue description. Please do not delete",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Auto-Assign"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "Advisor"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "CXP Attention",
+              "user": "wangzelin007"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "userGroups": [
+    {
+      "_id": "5f074be74200c210c870e106",
+      "groupType": "GitHub",
+      "name": "MariaDB and MySQL Contacts",
+      "githubUserNames": [
+        "ambhatna",
+        "savjani",
+        "mksuni",
+        "Bashar-MSFT"
+      ],
+      "assignmentSchemes": [
+        {
+          "target": "All",
+          "lastAssignedIndex": 25
+        }
+      ]
+    },
+    {
+      "_id": "61ee1499ed91cf3268d76645",
+      "groupType": "GitHub",
+      "name": "Azure CLI Network",
+      "githubUserNames": [
+        "kairu-ms",
+        "jsntcy"
+      ],
+      "assignmentSchemes": [
+        {
+          "target": "All",
+          "lastAssignedIndex": 48
+        }
+      ]
+    },
+    {
+      "_id": "61ee1769ed91cf3268d7664a",
+      "groupType": "GitHub",
+      "name": "Azure CLI Compute",
+      "githubUserNames": [
+        "zhoxing-ms"
+      ],
+      "assignmentSchemes": [
+        {
+          "target": "All",
+          "lastAssignedIndex": 5
+        }
+      ]
+    },
+    {
+      "_id": "61ee1830ed91cf3268d7664d",
+      "groupType": "GitHub",
+      "name": "Azure CLI Storage",
+      "githubUserNames": [
+        "evelyn-ys"
+      ],
+      "assignmentSchemes": [
+        {
+          "target": "All",
+          "lastAssignedIndex": 19
+        }
+      ]
+    },
+    {
+      "_id": "620c4edb6cc2ae3d5c9f321e",
+      "groupType": "GitHub",
+      "name": "Azure CLI Keyvault",
+      "githubUserNames": [
+        "evelyn-ys"
+      ]
+    },
+    {
+      "_id": "620c4f9c6cc2ae3d5c9f3221",
+      "groupType": "GitHub",
+      "name": "Azure CLI Monitor",
+      "githubUserNames": [
+        "kairu-ms"
+      ]
+    },
+    {
+      "_id": "620c50606cc2ae3d5c9f3224",
+      "groupType": "GitHub",
+      "name": "Azure CLI Role",
+      "githubUserNames": [
+        "jiasli"
+      ]
+    },
+    {
+      "_id": "620c51246cc2ae3d5c9f3227",
+      "groupType": "GitHub",
+      "name": "Azure CLI Arm",
+      "githubUserNames": [
+        "zhoxing-ms"
+      ]
+    },
+    {
+      "_id": "620c56276cc2ae3d5c9f3235",
+      "groupType": "GitHub",
+      "name": "Azure CLI Graph",
+      "githubUserNames": [
+        "jiasli"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
---

Why migrate fabric bot from portal to config-as-code:
- As fabric bot team are preparing to move permanently to "Config As Code", they have hidden the save button to disable the capability to update the configuration in portal.
- We need to update milestone every month, so we need migrate before 2022-07-05.

What will happen after migration?
- The fabricbot.json file in our repo that will always take precedence than config in portal.
- All update need to commit in .github/fabricbot.json.
