### PR TITLE
{CI} Fix the bug that live test does not generate the latest index.html

### DIFF
--- a/scripts/live_test/generate_index.py
+++ b/scripts/live_test/generate_index.py
@@ -50,13 +50,13 @@ def generate(container, container_url, testdata, USER_REPO, USER_BRANCH, COMMIT_
         f.write(html)
 
     # Upload to storage account
-    cmd = 'az storage blob upload -f index.html -c {} -n index.html --account-name clitestresultstac'.format(container)
+    cmd = 'az storage blob upload -f index.html -c {} -n index.html --account-name clitestresultstac --overwrite'.format(container)
     logger.warning('Running: ' + cmd)
     os.system(cmd)
 
     # Upload to latest container if it is a full live test of official repo dev branch
     if USER_REPO == 'https://github.com/Azure/azure-cli.git' and USER_BRANCH == 'dev' and USER_TARGET == '' and USER_LIVE == '--live':
-        cmd = 'az storage blob upload -f index.html -c latest -n index.html --account-name clitestresultstac'
+        cmd = 'az storage blob upload -f index.html -c latest -n index.html --account-name clitestresultstac --overwrite'
         logger.warning('Running: ' + cmd)
         os.system(cmd)
 


### PR DESCRIPTION

- live test does not generate the latest index.html file.
![image](https://user-images.githubusercontent.com/18628534/173731261-ab7717ef-a4ae-497a-a625-f6823c2d02a9.png)
  - storage has a breaking change, need add --overwrite to `az storage blob upload` command to overwrite the old index.html file.
  - The password of the azureclilivetest account needs to be updated regularly, otherwise it will expire.
![image](https://user-images.githubusercontent.com/18628534/173731508-734b970e-3f16-41b7-a051-f756956929d5.png)

