### PR TITLE
[Packaging] Release DEB package for Debian sid

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -840,6 +840,10 @@ jobs:
         # 11
         deb_system: debian
         distro: bullseye
+      Sid:
+        # sid
+        deb_system: debian
+        distro: sid
   steps:
   - task: Bash@3
     displayName: 'Build $(deb_system) $(distro) Package'


### PR DESCRIPTION
**Description**<!--Mandatory-->

Close https://github.com/Azure/azure-cli/issues/22877

Per the [query result on `debian sid`](https://github.com/Azure/azure-cli/issues?q=is%3Aissue+debian+sid), the usage of Azure CLI on [Debian sid](https://wiki.debian.org/DebianUnstable) is not small, but we don't release DEB package for Debian sid: 

https://packages.microsoft.com/repos/azure-cli/dists/

![image](https://user-images.githubusercontent.com/4003950/173755034-953d436d-5c3d-4de9-a2d7-788c4d099a42.png)

Users will then install the **unofficial**, **buggy** `azure-cli` package from https://packages.debian.org/sid/azure-cli and report issues to us (https://github.com/Azure/azure-cli/issues/19640).

This PR releases DEB packages for Debian sid by ourselves, so that users can use the official Azure CLI package.
