### PR TITLE
[netappfiles] Fix: Typo in option global-placement-rules

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/_params.py
@@ -189,7 +189,7 @@ def load_volume_groups_arguments(self, account_name_type, pool_name_type):
         c.argument('pool_name', pool_name_type)
         c.argument('volume_group_name', options_list=['--volume-group-name', '--group-name'], id_part='child_name_1',
                    help='The name of the ANF volume group')
-        c.argument('gp_rules', options_list=['--gp-rules', '--global-placement-rules]'], nargs="+",
+        c.argument('gp_rules', options_list=['--gp-rules', '--global-placement-rules'], nargs="+",
                    help='Application specific identifier of deployment rules for the volume group. Space-separated string in `key=value` format')
         c.argument('system_role', arg_type=get_enum_type(['PRIMARY', 'HA', 'DR']))
         c.argument('add_snapshot_capacity', type=int, default=50,


### PR DESCRIPTION
**Related command**
`az netappfiles volume-group create --help`

**Description**
`az netappfiles volume-group create --help` currently produces

```text
    --global-placement-rules] --gp-rules        : Application specific identifier of deployment
                                                  rules for the volume group. Space-separated string
                                                  in `key=value` format.
```

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
