### PR TITLE
[Core] `az extension add`: Improve feedback shown to users when installation is unsuccessful

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/_resolve.py
+++ b/src/azure-cli-core/azure/cli/core/extension/_resolve.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 from packaging.version import parse
+from typing import Callable, Dict, List, NamedTuple, Union
 
 from azure.cli.core.extension import ext_compat_with_cli, WHEEL_INFO_RE
 from azure.cli.core.extension._index import get_index_extensions
@@ -16,6 +17,11 @@ logger = get_logger(__name__)
 class NoExtensionCandidatesError(Exception):
     pass
 
+class _ExtensionFilter(NamedTuple):
+    # A function that filters a list of extensions
+    filter: Callable[[List[dict]], List[dict]]
+    # Message of exception raised if a filter leaves no candidates
+    on_empty_results_message: Union[str, Callable[[List[dict]], str]]
 
 def _is_not_platform_specific(item):
     parsed_filename = WHEEL_INFO_RE(item['filename'])
@@ -54,39 +60,93 @@ def _is_greater_than_cur_version(cur_version):
         return False
     return filter_func
 
+def _get_latest_version(candidates: List[dict]) -> List[dict]:
+    return [max(candidates, key=lambda c: parse(c['metadata']['version']))]
+
+
+def _get_version_compatibility_feedback(candidates: List[dict]) -> str:
+    from .operations import check_version_compatibility
+
+    try:
+        check_version_compatibility(_get_latest_version(candidates)[0].get("metadata"))
+        return ""
+    except CLIError as e:
+        return e.args[0]
+
 
 def resolve_from_index(extension_name, cur_version=None, index_url=None, target_version=None, cli_ctx=None):
-    """
-    Gets the download Url and digest for the matching extension
+    """Gets the download Url and digest for the matching extension
 
-    :param cur_version: threshold verssion to filter out extensions.
+    Args:
+        extension_name (str): Name of
+        cur_version (str, optional): Threshold version to filter out extensions. Defaults to None.
+        index_url (str, optional):  Defaults to None.
+        target_version (str, optional): Version of extension to install. Defaults to latest version.
+        cli_ctx (, optional): CLI Context. Defaults to None.
+
+    Raises:
+        NoExtensionCandidatesError when an extension:
+            * Doesn't exist
+            * Has no versions compatible with the current platform
+            * Has no versions more recent than currently installed version
+            * Has no versions that are compatible with the version of azure cli
+
+    Returns:
+        tuple: (Download Url, SHA digest)
     """
     candidates = get_index_extensions(index_url=index_url, cli_ctx=cli_ctx).get(extension_name, [])
 
     if not candidates:
-        raise NoExtensionCandidatesError("No extension found with name '{}'".format(extension_name))
+        raise NoExtensionCandidatesError(f"No extension found with name '{extension_name}'")
 
-    filters = [_is_not_platform_specific, _is_compatible_with_cli_version]
-    if not target_version:
-        filters.append(_is_greater_than_cur_version(cur_version))
+    # Helper to curry predicate functions
+    list_filter = lambda f: lambda cs: list(filter(f, cs))
 
-    for f in filters:
-        logger.debug("Candidates %s", [c['filename'] for c in candidates])
-        candidates = list(filter(f, candidates))
-    if not candidates:
-        raise NoExtensionCandidatesError("No suitable extensions found.")
-
-    candidates_sorted = sorted(candidates, key=lambda c: parse(c['metadata']['version']), reverse=True)
-    logger.debug("Candidates %s", [c['filename'] for c in candidates_sorted])
+    candidate_filters = [
+        _ExtensionFilter(
+            filter=list_filter(_is_not_platform_specific),
+            on_empty_results_message=f"No suitable extensions found for '{extension_name}'."
+        )
+    ]
 
     if target_version:
-        try:
-            chosen = [c for c in candidates_sorted if c['metadata']['version'] == target_version][0]
-        except IndexError:
-            raise NoExtensionCandidatesError('Extension with version {} not found'.format(target_version))
+        candidate_filters += [
+            _ExtensionFilter(
+                filter=list_filter(lambda c: c['metadata']['version'] == target_version),
+                on_empty_results_message=f"Version '{target_version}' not found for extension '{extension_name}'"
+            )
+        ]
     else:
-        logger.debug("Choosing the latest of the remaining candidates.")
-        chosen = candidates_sorted[0]
+        candidate_filters += [
+            _ExtensionFilter(
+                filter= list_filter(_is_greater_than_cur_version(cur_version)),
+                on_empty_results_message=f"Latest version of '{extension_name}' is already installed."
+            )
+        ]
+
+    candidate_filters += [
+        _ExtensionFilter(
+            filter= list_filter(_is_compatible_with_cli_version),
+            on_empty_results_message=_get_version_compatibility_feedback
+        ),
+        _ExtensionFilter(
+            filter=_get_latest_version,
+            on_empty_results_message=f"No suitable extensions found for '{extension_name}'."
+        )
+    ]
+
+    for candidate_filter, on_empty_results_message in candidate_filters:
+        logger.debug("Candidates %s", [c['filename'] for c in candidates])
+        filtered_candidates = candidate_filter(candidates)
+
+        if not filtered_candidates and (on_empty_results_message is not None):
+            if not isinstance(on_empty_results_message, str):
+                on_empty_results_message = on_empty_results_message(candidates)
+            raise NoExtensionCandidatesError(on_empty_results_message)
+
+        candidates = filtered_candidates
+
+    chosen = candidates[0]
 
     logger.debug("Chosen %s", chosen)
     download_url, digest = chosen.get('downloadUrl'), chosen.get('sha256Digest')

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -330,11 +330,7 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
             source, ext_sha256 = resolve_from_index(extension_name, index_url=index_url, target_version=version, cli_ctx=cmd_cli_ctx)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
-
-            if version:
-                err = "No matching extensions for '{} ({})'. Use --debug for more information.".format(extension_name, version)
-            else:
-                err = "No matching extensions for '{}'. Use --debug for more information.".format(extension_name)
+            err = "{}\n\nUse --debug for more information".format(err.args[0])
             raise CLIError(err)
     ext_name, ext_version = _get_extension_info_from_source(source)
     set_extension_management_detail(extension_name if extension_name else ext_name, ext_version)
@@ -397,7 +393,7 @@ def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_in
             set_extension_management_detail(extension_name, ext_version)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
-            msg = "Extension {} with version {} not found.".format(extension_name, version) if version else "No updates available for '{}'. Use --debug for more information.".format(extension_name)
+            msg = "{}\n\nUse --debug for more information".format(err.args[0])
             logger.warning(msg)
             return
         # Copy current version of extension to tmp directory in case we need to restore it after a failed install.

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/__init__.py
@@ -8,6 +8,7 @@ import unittest
 import tempfile
 import shutil
 from unittest import mock
+from azure.cli.core.extension import EXT_METADATA_MAXCLICOREVERSION, EXT_METADATA_MINCLICOREVERSION
 
 
 def get_test_data_file(filename):
@@ -35,10 +36,11 @@ class IndexPatch:
         self.patcher.stop()
 
 
-def mock_ext(filename, version=None, download_url=None, digest=None, project_url=None):
+def mock_ext(filename, version=None, download_url=None, digest=None, project_url=None, name=None, min_cli_version=None, max_cli_version=None):
     d = {
         'filename': filename,
         'metadata': {
+            'name': name,
             'version': version,
             'extensions': {
                 'python.details': {
@@ -46,7 +48,9 @@ def mock_ext(filename, version=None, download_url=None, digest=None, project_url
                         'Home': project_url or 'https://github.com/azure/some-extension'
                     }
                 }
-            }
+            },
+            EXT_METADATA_MINCLICOREVERSION: min_cli_version,
+            EXT_METADATA_MAXCLICOREVERSION: max_cli_version,
         },
         'downloadUrl': download_url or 'http://contoso.com/{}'.format(filename),
         'sha256Digest': digest


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az extension add`
`az extension add --upgrade`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This pull request updates the feedback shown to users when azure cli is unable to install a requested extension, notably making it easier for extension authors to communicate that users may need to upgrade azure cli to use their extension.

Closes #21078

Specifically

 * The user is now informed if there exists newer version of an extension that is **_incompatible_** with their version of azure cli and given recommendations to rectify the issue if there are no compatible versions available. This can occur when running:
   * `az extension add --name ext_name --upgrade` 
     &nbsp;
      <img width="628" alt="extension_add_upgrade_incompatible" src="https://user-images.githubusercontent.com/101366538/174659121-d9784406-568a-48ac-8cc3-c61defd28879.png">

   * `az extension add --name ext_name`
     &nbsp;
     <img width="634" alt="extension_add_incompatible" src="https://user-images.githubusercontent.com/101366538/174659144-8cb54e0c-1423-4059-98fc-e874870cd21d.png">

 * When running `az extension add --upgrade --name ext_name`, the user is now informed when they already have the latest version of the extension in question
   &nbsp;
   <img width="461" alt="extension_upgrade_already_latest" src="https://user-images.githubusercontent.com/101366538/174659062-e96f18f5-e078-4b75-bf38-cd60563fae76.png">
 * When using `--version` to specify a target version, the message shown to users was slightly changed if that version could not be found.
    &nbsp;
    <img width="525" alt="extension_add_version_not_found" src="https://user-images.githubusercontent.com/101366538/174658947-a4c6a0e7-9205-4ea7-ba81-21f373da4c6d.png">





**Testing Guide**

Unittests were added to `src/azure-cli-core/azure/cli/core/extension/tests/latest/test_resolve.py`


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
