### PR TITLE
{ACR} Add timestamp in error messages and debug logs when sending HTTP requests

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -30,6 +30,7 @@ from azure.cli.core.commands.client_factory import get_subscription_id
 from ._client_factory import cf_acr_registries
 from ._constants import get_managed_sku
 from ._utils import get_registry_by_name, ResourceNotFound
+from ._format import add_timestamp
 
 
 logger = get_logger(__name__)
@@ -84,7 +85,10 @@ def _handle_challenge_phase(login_server,
 
     login_server = login_server.rstrip('/')
 
-    challenge = requests.get('https://' + login_server + '/v2/', verify=(not should_disable_connection_verify()))
+    request_url = 'https://' + login_server + '/v2/'
+    logger.debug(add_timestamp("Sending a HTTP Get request to {}".format(request_url)))
+    challenge = requests.get(request_url, verify=(not should_disable_connection_verify()))
+
     if challenge.status_code != 401 or 'WWW-Authenticate' not in challenge.headers:
         from ._errors import CONNECTIVITY_CHALLENGE_ERROR
         if is_diagnostics_context:
@@ -138,6 +142,7 @@ def _get_aad_token_after_challenge(cli_ctx,
         'access_token': creds[1]
     }
 
+    logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
     response = requests.post(authhost, urlencode(content), headers=headers,
                              verify=(not should_disable_connection_verify()))
 
@@ -168,6 +173,8 @@ def _get_aad_token_after_challenge(cli_ctx,
         'scope': scope,
         'refresh_token': refresh_token
     }
+
+    logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
     response = requests.post(authhost, urlencode(content), headers=headers,
                              verify=(not should_disable_connection_verify()))
 
@@ -267,6 +274,7 @@ def _get_token_with_username_and_password(login_server,
         'scope': scope
     }
 
+    logger.debug(add_timestamp("Sending a HTTP Post request to {}".format(authhost)))
     response = requests.post(authhost, urlencode(content), headers=headers,
                              verify=(not should_disable_connection_verify()))
 
@@ -330,6 +338,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
     # Validate the login server is reachable
     url = 'https://' + login_server + '/v2/'
     try:
+        logger.debug(add_timestamp("Sending a HTTP Get request to {}".format(url)))
         challenge = requests.get(url, verify=(not should_disable_connection_verify()))
         if challenge.status_code == 403:
             raise CLIError("Looks like you don't have access to registry '{}'. "
@@ -535,6 +544,7 @@ def request_data_from_registry(http_method,
         try:
             if file_payload:
                 with open(file_payload, 'rb') as data_payload:
+                    logger.debug(add_timestamp("Sending a HTTP {} request to {}".format(http_method, url)))
                     response = requests.request(
                         method=http_method,
                         url=url,
@@ -545,6 +555,7 @@ def request_data_from_registry(http_method,
                         verify=(not should_disable_connection_verify())
                     )
             else:
+                logger.debug(add_timestamp("Sending a HTTP {} request to {}".format(http_method, url)))
                 response = requests.request(
                     method=http_method,
                     url=url,
@@ -612,7 +623,7 @@ def parse_error_message(error_message, response):
 
     try:
         correlation_id = response.headers['x-ms-correlation-request-id']
-        return '{} Correlation ID: {}.'.format(error_message, correlation_id)
+        return add_timestamp('{} Correlation ID: {}.'.format(error_message, correlation_id))
     except (KeyError, TypeError, AttributeError):
         return error_message
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -5,6 +5,8 @@
 
 # pylint: disable=line-too-long
 
+from ._format import add_timestamp
+
 
 class ErrorClass:
     error_title = ""
@@ -16,9 +18,9 @@ class ErrorClass:
 
     def get_error_message(self, additional_message=None):
         if additional_message:
-            return "An error occurred: {}\n{}\n{}".format(self.error_title, self.error_message, additional_message)
+            return add_timestamp("An error occurred: {}\n{}\n{}".format(self.error_title, self.error_message, additional_message))
 
-        return "An error occurred: {}\n{}".format(self.error_title, self.error_message)
+        return add_timestamp("An error occurred: {}\n{}".format(self.error_title, self.error_message))
 
     def set_error_message(self, message):
         return ErrorClass(self.error_title, message)

--- a/src/azure-cli/azure/cli/command_modules/acr/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_format.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 from collections import OrderedDict
+from datetime import datetime
 from knack.log import get_logger
 
 
@@ -520,3 +521,7 @@ def _get_duration(start_time, finish_time):
     except ValueError:
         logger.debug("Unable to get duration with start_time '%s' and finish_time '%s'", start_time, finish_time)
         return ' '
+
+
+def add_timestamp(message):
+    return "{} {}".format(datetime.utcnow(), message)

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -11,6 +11,7 @@ from ._docker_utils import _get_aad_token
 from .helm import get_helm_command
 from ._utils import get_registry_by_name, resolve_identity_client_id
 from ._errors import ErrorClass
+from ._format import add_timestamp
 
 logger = get_logger(__name__)
 
@@ -229,7 +230,9 @@ def _get_registry_status(login_server, registry_name, ignore_errors):
     from azure.cli.core.util import should_disable_connection_verify
 
     try:
-        challenge = requests.get('https://' + login_server + '/v2/', verify=(not should_disable_connection_verify()))
+        request_url = 'https://' + login_server + '/v2/'
+        logger.debug(add_timestamp("Sending a HTTP GET request to {}".format(request_url)))
+        challenge = requests.get(request_url, verify=(not should_disable_connection_verify()))
     except SSLError:
         from ._errors import CONNECTIVITY_SSL_ERROR
         _handle_error(CONNECTIVITY_SSL_ERROR.format_error_message(login_server), ignore_errors)


### PR DESCRIPTION

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
All the changes are within the ACR module and only have impact when the debug flag is turned on.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
- Adding timestamps in debug logs when sending HTTP requests or encountering errors in ACR module, which would help investigate customer issues.  
- The changes would have effects on two places. Firstly, the timestamp would be shown in front of ACR error messages.  Secondly, when the debug flag is turned on and sending HTTP requests in ACR module, it will add a log line with the timestamp, request type and the URL.





---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
