### PR TITLE
[ARM] Fix #22930: `az bicep generate-params`: Add support for bicep generate-params command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2776,6 +2776,22 @@ type: command
 short-summary: List out all available versions of Bicep CLI.
 """
 
+helps['bicep generate-params'] = """
+type: command
+short-summary: Generate parameters file for a Bicep file.
+examples:
+  - name: Generate parameters file for a Bicep file.
+    text: az bicep generate-params --file {bicep_file}
+  - name: Generate parameters file for a Bicep file and print all output to stdout.
+    text: az bicep generate-params --file {bicep_file} --stdout
+  - name: Generate parameters file for a Bicep file and save the result to the specified directory.
+    text: az bicep generate-params --file {bicep_file} --outdir {out_dir}
+  - name: Generate parameters file for a Bicep file and save the result to the specified file.
+    text: az bicep generate-params --file {bicep_file} --outfile {out_file}
+  - name: Generate parameters file for a Bicep file without restoring external modules.
+    text: az bicep generate-params --file {bicep_file} --no-restore
+"""
+
 helps['resourcemanagement'] = """
 type: group
 short-summary: resourcemanagement CLI command group.

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -677,6 +677,18 @@ def load_arguments(self, _):
     with self.argument_context('bicep upgrade') as c:
         c.argument('target_platform', arg_type=bicep_target_platform_type)
 
+    with self.argument_context('bicep generate-params') as c:
+        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
+                                                    type=file_type, help="The path to the Bicep file to generate the parameters file from in the file system."))
+        c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
+                                                      help="When set, saves the output at the specified directory."))
+        c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
+                                                       help="When set, saves the output as the specified file path."))
+        c.argument('stdout', arg_type=CLIArgumentType(options_list=['--stdout'], action='store_true',
+                                                      help="When set, prints all output to stdout instead of corresponding files."))
+        c.argument('no_restore', arg_type=CLIArgumentType(options_list=['--no-restore'], action='store_true',
+                                                          help="When set, generates the parameters file without restoring external modules."))
+
     with self.argument_context('resourcemanagement private-link create') as c:
         c.argument('resource_group', arg_type=resource_group_name_type,
                    help='The name of the resource group.')

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -97,6 +97,12 @@ def load_arguments(self, _):
     ui_form_definition_file_type = CLIArgumentType(options_list=['--ui-form-definition'], completer=FilesCompleter(), type=file_type,
                                                    help="A path to a uiFormDefinition file in the file system")
 
+    bicep_file_type = CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(), type=file_type)
+    bicep_force_type = CLIArgumentType(options_list=['--force'], action='store_true')
+    bicep_no_restore_type = CLIArgumentType(options_list=['--no-restore'], action='store_true')
+    bicep_outdir_type = CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(), help="When set, saves the output at the specified directory.")
+    bicep_outfile_type = CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(), help="When set, saves the output as the specified file path.")
+    bicep_stdout_type = CLIArgumentType(options_list=['--stdout'], action='store_true', help="When set, prints all output to stdout instead of corresponding files.")
     bicep_target_platform_type = CLIArgumentType(options_list=['--target-platform', '-t'],
                                                  arg_type=get_enum_type(
                                                      ["win-x64", "linux-musl-x64", "linux-x64", "osx-x64"]),
@@ -641,32 +647,22 @@ def load_arguments(self, _):
         c.argument('resource_group', arg_type=resource_group_name_type)
 
     with self.argument_context('bicep build') as c:
-        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                    type=file_type, help="The path to the Bicep file to build in the file system."))
-        c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
-                                                      help="When set, saves the output at the specified directory."))
-        c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
-                                                       help="When set, saves the output as the specified file path."))
-        c.argument('stdout', arg_type=CLIArgumentType(options_list=['--stdout'], action='store_true',
-                                                      help="When set, prints all output to stdout instead of corresponding files."))
-        c.argument('no_restore', arg_type=CLIArgumentType(options_list=['--no-restore'], action='store_true',
-                                                          help="When set, builds the bicep file without restoring external modules."))
+        c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep file to build in the file system.")
+        c.argument('outdir', arg_type=bicep_outdir_type)
+        c.argument('outfile', arg_type=bicep_outfile_type)
+        c.argument('stdout', arg_type=bicep_stdout_type)
+        c.argument('no_restore', arg_type=bicep_no_restore_type, help="When set, builds the bicep file without restoring external modules.")
 
     with self.argument_context('bicep decompile') as c:
-        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                    type=file_type, help="The path to the ARM template to decompile in the file system."))
-        c.argument('force', arg_type=CLIArgumentType(options_list=['--force'], action='store_true',
-                                                     help="Allows overwriting the output file if it exists."))
+        c.argument('file', arg_type=bicep_file_type, help="The path to the ARM template to decompile in the file system.")
+        c.argument('force', arg_type=bicep_force_type, help="Allows overwriting the output file if it exists.")
 
     with self.argument_context('bicep restore') as c:
-        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                    type=file_type, help="The path to the Bicep file to restore external modules for."))
-        c.argument('force', arg_type=CLIArgumentType(options_list=['--force'], action='store_true',
-                                                     help="Allows overwriting the cached external modules."))
+        c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep file to restore external modules for.")
+        c.argument('force', arg_type=bicep_force_type, help="Allows overwriting the cached external modules.")
 
     with self.argument_context('bicep publish') as c:
-        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                    type=file_type, help="The path to the Bicep module file to publish in the file system."))
+        c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to publish in the file system.")
         c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'],
                                                       help="The target location where the Bicep module will be published."))
 
@@ -678,16 +674,11 @@ def load_arguments(self, _):
         c.argument('target_platform', arg_type=bicep_target_platform_type)
 
     with self.argument_context('bicep generate-params') as c:
-        c.argument('file', arg_type=CLIArgumentType(options_list=['--file', '-f'], completer=FilesCompleter(),
-                                                    type=file_type, help="The path to the Bicep file to generate the parameters file from in the file system."))
-        c.argument('outdir', arg_type=CLIArgumentType(options_list=['--outdir'], completer=DirectoriesCompleter(),
-                                                      help="When set, saves the output at the specified directory."))
-        c.argument('outfile', arg_type=CLIArgumentType(options_list=['--outfile'], completer=FilesCompleter(),
-                                                       help="When set, saves the output as the specified file path."))
-        c.argument('stdout', arg_type=CLIArgumentType(options_list=['--stdout'], action='store_true',
-                                                      help="When set, prints all output to stdout instead of corresponding files."))
-        c.argument('no_restore', arg_type=CLIArgumentType(options_list=['--no-restore'], action='store_true',
-                                                          help="When set, generates the parameters file without restoring external modules."))
+        c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep file to generate the parameters file from in the file system.")
+        c.argument('outdir', arg_type=bicep_outdir_type)
+        c.argument('outfile', arg_type=bicep_outfile_type)
+        c.argument('stdout', arg_type=bicep_stdout_type)
+        c.argument('no_restore', arg_type=bicep_no_restore_type, help="When set, generates the parameters file without restoring external modules.")
 
     with self.argument_context('resourcemanagement private-link create') as c:
         c.argument('resource_group', arg_type=resource_group_name_type,

--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -545,6 +545,7 @@ def load_command_table(self, _):
         g.custom_command('publish', 'publish_bicep_file')
         g.custom_command('version', 'show_bicep_cli_version')
         g.custom_command('list-versions', 'list_bicep_cli_versions')
+        g.custom_command('generate-params', 'generate_params_file')
 
     with self.command_group('resourcemanagement private-link', resource_resourcemanagementprivatelink_sdk, resource_type=ResourceType.MGMT_RESOURCE_PRIVATELINKS) as g:
         g.custom_command('create', 'create_resourcemanager_privatelink')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3726,6 +3726,7 @@ def show_bicep_cli_version(cmd):
 def list_bicep_cli_versions(cmd):
     return get_bicep_available_release_tags()
 
+
 def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None):
     ensure_bicep_installation()
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3726,6 +3726,28 @@ def show_bicep_cli_version(cmd):
 def list_bicep_cli_versions(cmd):
     return get_bicep_available_release_tags()
 
+def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None):
+    ensure_bicep_installation()
+
+    minimum_supported_version = "0.7.4"
+    if bicep_version_greater_than_or_equal_to(minimum_supported_version):
+        args = ["generate-params", file]
+        if no_restore:
+            args += ["--no-restore"]
+        if outdir:
+            args += ["--outdir", outdir]
+        if outfile:
+            args += ["--outfile", outfile]
+        if stdout:
+            args += ["--stdout"]
+
+        output = run_bicep_command(args)
+
+        if stdout:
+            print(output)
+    else:
+        logger.error("az bicep generate-params could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
+
 
 def create_resourcemanager_privatelink(
         cmd, resource_group, name, location):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/sample_params.bicep
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/sample_params.bicep
@@ -1,0 +1,7 @@
+param demoString string
+param demoInt int
+param demoBool bool
+param demoObject object
+param demoArray array
+
+param location string = resourceGroup().location

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -3981,6 +3981,21 @@ class BicepBuildTest(LiveScenarioTest):
         if os.path.exists(decompile_path):
             os.remove(decompile_path)
 
+class BicepGenerateParamsTest(LiveScenarioTest):
+
+    def test_bicep_generate_params(self):
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        tf = os.path.join(curr_dir, 'sample_params.bicep').replace('\\', '\\\\')
+        params_path = os.path.join(curr_dir, 'sample_params.parameters.json').replace('\\', '\\\\')
+        self.kwargs.update({
+            'tf': tf,
+            'params_path': params_path,
+        })
+
+        self.cmd('az bicep generate-params -f {tf} --outfile {params_path}')
+
+        if os.path.exists(params_path):
+            os.remove(params_path)
 
 class BicepInstallationTest(LiveScenarioTest):
     def setup(self):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az bicep generate-params --file {bicep_file}
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The Bicep CLI introduced a [`generate-params`](https://github.com/Azure/bicep/pull/6601) command in [v0.7.4](https://github.com/Azure/bicep/releases/tag/v0.7.4)
This PR adds support for the same.

Resolves #22930 

**Testing Guide**
<!--Example commands with explanations.-->

Using the following bicep file, naming it `sample_params.bicep`

```bicep
param demoString string
param demoInt int
param demoBool bool
param demoObject object
param demoArray array

param location string = resourceGroup().location
```

The following command should work without any error
```sh
az bicep generate-params --file sample_params.bicep # An output.paramters.json file should be created
az bicep generate-params --file sample_params.bicep --outdir . # An output.paramters.json file should be created
az bicep generate-params --file sample_params.bicep --outfile sample_params # An sample_params.paramters.json file should be created
az bicep generate-params --file sample_params.bicep --no-restore # An output.paramters.json file should be created
az bicep generate-params --file sample_params.bicep --stdout # No file should be created
```

All of these commands would result in this JSON, in the file or stdout, based on the command
```json
{
  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
  "contentVersion": "1.0.0.0",
  "parameters": {
    "demoString": {
      "value": ""
    },
    "demoInt": {
      "value": 0
    },
    "demoBool": {
      "value": false
    },
    "demoObject": {
      "value": {}
    },
    "demoArray": {
      "value": []
    }
  }
}
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
