### PR TITLE
[IoT] `az iot hub/dps certificate list`: Add table transform to certificate list commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -82,7 +82,13 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
     with self.command_group('iot dps certificate',
                             client_factory=iot_service_provisioning_factory,
                             transform=_dps_certificate_response_transform) as g:
-        g.custom_command('list', 'iot_dps_certificate_list')
+        g.custom_command(
+            'list','iot_dps_certificate_list',
+            table_transformer=(
+                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,"
+                "Subject:properties.subject,Thumbprint:properties.thumbprint,IsVerified:properties.isVerified}"
+            )
+        )
         g.custom_show_command('show', 'iot_dps_certificate_get')
         g.custom_command('create', 'iot_dps_certificate_create')
         g.custom_command('delete', 'iot_dps_certificate_delete')
@@ -100,7 +106,13 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
 
     # iot hub certificate commands
     with self.command_group('iot hub certificate', client_factory=iot_hub_service_factory) as g:
-        g.custom_command('list', 'iot_hub_certificate_list')
+        g.custom_command(
+            'list', 'iot_hub_certificate_list',
+            table_transformer=(
+                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,"
+                "Subject:properties.subject,Thumbprint:properties.thumbprint,IsVerified:properties.isVerified}"
+            )
+        )
         g.custom_show_command('show', 'iot_hub_certificate_get')
         g.custom_command('create', 'iot_hub_certificate_create')
         g.custom_command('delete', 'iot_hub_certificate_delete')

--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -85,7 +85,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.custom_command(
             'list', 'iot_dps_certificate_list',
             table_transformer=(
-                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,"
+                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,Expiry:properties.expiry,"
                 "Subject:properties.subject,Thumbprint:properties.thumbprint,IsVerified:properties.isVerified}"
             )
         )
@@ -109,7 +109,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
         g.custom_command(
             'list', 'iot_hub_certificate_list',
             table_transformer=(
-                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,"
+                "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,Expiry:properties.expiry,"
                 "Subject:properties.subject,Thumbprint:properties.thumbprint,IsVerified:properties.isVerified}"
             )
         )

--- a/src/azure-cli/azure/cli/command_modules/iot/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/commands.py
@@ -83,7 +83,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-statements
                             client_factory=iot_service_provisioning_factory,
                             transform=_dps_certificate_response_transform) as g:
         g.custom_command(
-            'list','iot_dps_certificate_list',
+            'list', 'iot_dps_certificate_list',
             table_transformer=(
                 "value[*].{Name:name,ResourceGroup:resourceGroup,Created:properties.created,"
                 "Subject:properties.subject,Thumbprint:properties.thumbprint,IsVerified:properties.isVerified}"


### PR DESCRIPTION
**Related command**
`az iot hub certificate list`
`az iot dps certificate list`

**Description**
Add a table transformer to the certificate list commands so a user has a better experience when the output is in the table format. Specific issue: https://github.com/Azure/azure-iot-cli-extension/issues/530 

Example usage:
`az iot dps certificate list --dps-name <myDPS> -o table`

Before:
![image](https://user-images.githubusercontent.com/73560279/174892860-a3825a2e-b835-432c-9196-7f9ee056c505.png)


After:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/73560279/174892380-848b2ea8-706b-42ad-83d0-089971d2874d.png">

**Testing Guide**
The code aside from table transforms was not changed.

**History Notes**
[IoT] `az iot hub/dps certificate list`: Add table transform to certificate list commands

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
