### PR TITLE
{Core} `aaz`: fix a bug on serialize content when using serialized_name of required property

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_operation.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_operation.py
@@ -154,8 +154,9 @@ class AAZHttpOperation(AAZOperation):
                 for _schema in [schema, schema.get_discriminator(result)]:
                     if not _schema:
                         continue
-                    for _name, _field_schema in _schema._fields.items():
+                    for _field_name, _field_schema in _schema._fields.items():
                         # verify required and not read only property
+                        _name = _field_schema._serialized_name or _field_name  # prefer using serialized name first
                         if _name in result:
                             continue
                         if _field_schema._flags.get('read_only', False):

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_operation.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_operation.py
@@ -21,16 +21,16 @@ class TestAAZHttpOperation(unittest.TestCase):
         self.assertEqual(data, {"properties": {}})
 
         schema.properties.prop1 = AAZListType(flags={"required": True})
-        schema.properties.prop2 = AAZDictType(flags={"required": True})
+        schema.properties.prop2 = AAZDictType(flags={"required": True}, serialized_name='property2')
 
         schema.properties.prop3 = AAZObjectType()
         schema.properties.prop4 = AAZObjectType(flags={"required": True, "read_only": True})
-        schema.properties.prop5 = AAZDictType(flags={"required": True, "read_only": True})
+        schema.properties.prop5 = AAZDictType(flags={"required": True, "read_only": True}, serialized_name='Prop5')
         schema.properties.prop6 = AAZListType(flags={"required": True, "read_only": True})
 
         v = schema._ValueCls(schema=schema, data=schema.process_data(None))
         data = AAZHttpOperation.serialize_content(v)
-        self.assertEqual(data, {"properties": {'prop1': [], "prop2": {}}})
+        self.assertEqual(data, {"properties": {'prop1': [], "property2": {}}})
 
         # test required Case 2
         schema = AAZObjectType(flags={"required": True})
@@ -38,7 +38,7 @@ class TestAAZHttpOperation(unittest.TestCase):
         schema.properties.prop1 = AAZListType(flags={"required": True})
         schema.properties.prop2 = AAZDictType(flags={"required": True})
         schema.properties.prop3 = AAZObjectType()
-        schema.properties.prop3.sub1 = AAZIntType()
+        schema.properties.prop3.sub1 = AAZIntType(serialized_name="subProperty1")
         schema.properties.prop4 = AAZStrType(flags={"required": True, "read_only": True})
 
         v = schema._ValueCls(schema=schema, data=schema.process_data(None))
@@ -49,7 +49,7 @@ class TestAAZHttpOperation(unittest.TestCase):
         v.properties.prop3.sub1 = 6
         self.assertTrue(v._is_patch)
         data = AAZHttpOperation.serialize_content(v)
-        self.assertEqual(data, {'properties': {'prop3': {'sub1': 6}, 'prop1': [], 'prop2': {}}})
+        self.assertEqual(data, {'properties': {'prop3': {'subProperty1': 6}, 'prop1': [], 'prop2': {}}})
 
         schema.properties.prop3.sub2 = AAZStrType(flags={"required": True})
         v = schema._ValueCls(schema=schema, data=schema.process_data(None))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
