### PR TITLE
{packaging} Update argcomplete to 2.0.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -44,7 +44,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'argcomplete~=1.8',
+    'argcomplete~=2.0',
     'azure-cli-telemetry==1.0.6.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0


### PR DESCRIPTION
**Related command**
Used by all `az` commands.


**Description**
Fedora Linux (among other distributions) has moved to `argcomplete` 2.0.0 and older versions of `argcomplete` are no longer available. I am unable to continue packaging `azure-cli` in Fedora with older versions of `argcomplete`.

I submitted a previous PR for this back in January 2022 and it was closed, but this issue has become more challenging as Fedora 37 moves to Python 3.11.

**Testing Guide**
No change in testing.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
