### PR TITLE
{testing} Test on Python 3.11

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -26,6 +26,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
@@ -46,6 +48,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
@@ -66,6 +70,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
@@ -167,6 +173,39 @@ jobs:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
         pythonVersion: '3.10'
+        profile: 'latest'
+        instance_cnt: '8'
+        instance_idx: '$(Instance_idx)'
+        fullTest: true
+
+- job: AutomationFullTestPython311ProfileLatest
+  displayName: Automation Full Test Python311 Profile Latest
+  timeoutInMinutes: 9999
+  strategy:
+    maxParallel: 8
+    matrix:
+      instance1:
+        Instance_idx: 1
+      instance2:
+        Instance_idx: 2
+      instance3:
+        Instance_idx: 3
+      instance4:
+        Instance_idx: 4
+      instance5:
+        Instance_idx: 5
+      instance6:
+        Instance_idx: 6
+      instance7:
+        Instance_idx: 7
+      instance8:
+        Instance_idx: 8
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+    - template: .azure-pipelines/templates/automation_test.yml
+      parameters:
+        pythonVersion: '3.11'
         profile: 'latest'
         instance_cnt: '8'
         instance_idx: '$(Instance_idx)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -411,6 +411,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
@@ -430,6 +432,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - template: .azure-pipelines/templates/automation_test.yml
       parameters:
@@ -452,6 +456,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -473,6 +479,8 @@ jobs:
     matrix:
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   steps:
     - task: UsePythonVersion@0
       displayName: 'Use Python $(python.version)'
@@ -877,6 +885,8 @@ jobs:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
   pool:
     vmImage: 'ubuntu-20.04'
   steps:


### PR DESCRIPTION
**Related command**
Related to all `az` commands.

**Description**
Beta versions of Python 3.11 are entering many Linux distributions for their next release and it would be good to test azure-cli with Python 3.11 to find any issues before the release. Add Python 3.11 to the testing matrix in Azure Pipelines.

**Testing Guide**
Testing with Python 3.11 should be the same as other Python versions.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
