### PR TITLE
[AKS] `az aks get-credentials`: Fix the command error when KUBECONFIG is empty

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2159,7 +2159,12 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
     # in which case we ignore the KUBECONFIG variable
     # KUBECONFIG can be colon separated. If we find that condition, use the first entry
     if "KUBECONFIG" in os.environ and path == os.path.join(os.path.expanduser('~'), '.kube', 'config'):
-        path = os.environ["KUBECONFIG"].split(":")[0]
+        kubeconfig_path = os.environ["KUBECONFIG"].split(":")[0]
+        if kubeconfig_path:
+            logger.info(f"The default path '{path}' is replaced by '{kubeconfig_path}' defined in KUBECONFIG.")
+            path = kubeconfig_path
+        else:
+            logger.warning(f"Invalid path '{kubeconfig_path}' defined in KUBECONFIG.")
 
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2161,10 +2161,10 @@ def aks_get_credentials(cmd, client, resource_group_name, name, admin=False,
     if "KUBECONFIG" in os.environ and path == os.path.join(os.path.expanduser('~'), '.kube', 'config'):
         kubeconfig_path = os.environ["KUBECONFIG"].split(":")[0]
         if kubeconfig_path:
-            logger.info(f"The default path '{path}' is replaced by '{kubeconfig_path}' defined in KUBECONFIG.")
+            logger.info("The default path '%s' is replaced by '%s' defined in KUBECONFIG.", path, kubeconfig_path)
             path = kubeconfig_path
         else:
-            logger.warning(f"Invalid path '{kubeconfig_path}' defined in KUBECONFIG.")
+            logger.warning("Invalid path '%s' defined in KUBECONFIG.", kubeconfig_path)
 
     if not credentialResults:
         raise CLIError("No Kubernetes credentials found.")


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks get-credentials`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

When KUBECONFIG is empty, keep using the default storage path (`~/.kube/config`) and output warning-level logs; otherwise, use the path in KUBECONFIG to replace the default storage path and output info-level logs. Thanks to @fseldow for reporting this bug.

![Screenshot 2022-06-24 104625](https://user-images.githubusercontent.com/81607949/175452788-5067aef8-a861-4022-a42e-ca7c1a01b065.png)
![Screenshot 2022-06-24 104852](https://user-images.githubusercontent.com/81607949/175452792-d4f86570-4cf5-4cd4-a46b-ef459cfbd88c.png)


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
