### PR TITLE
{servicebus} Fix error message raised on a malformed ISO-8601 duration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -625,7 +625,10 @@ def return_valid_duration(update_value, current_value=None):
         return current_value
 
     if iso8601pattern.match(value_toreturn):
-        time_duration = parse_duration(value_toreturn)
+        try:
+            time_duration = parse_duration(value_toreturn)
+        except:
+            raise CLIError("Unable to parse duration string %r" % value_toreturn)
 
         if isinstance(time_duration, timedelta):
             if time_duration <= timedelta(days=DURATION_DAYS, minutes=DURATION_MIN, seconds=DURATION_SECS):

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -618,6 +618,7 @@ def return_valid_duration(update_value, current_value=None):
     from datetime import timedelta
     from isodate import parse_duration
     from isodate import Duration
+    from knack.util import CLIError
     from azure.cli.command_modules.servicebus.constants import DURATION_SECS, DURATION_MIN, DURATION_DAYS
     if update_value is not None:
         value_toreturn = update_value

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -629,7 +629,7 @@ def return_valid_duration(update_value, current_value=None):
         try:
             time_duration = parse_duration(value_toreturn)
         except:
-            raise raise InvalidArgumentValueError("Unable to parse provided ISO 8601 format duration %r" % value_toreturn)
+            raise InvalidArgumentValueError("Unable to parse provided ISO 8601 format duration %r" % value_toreturn)
 
         if isinstance(time_duration, timedelta):
             if time_duration <= timedelta(days=DURATION_DAYS, minutes=DURATION_MIN, seconds=DURATION_SECS):

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -618,7 +618,7 @@ def return_valid_duration(update_value, current_value=None):
     from datetime import timedelta
     from isodate import parse_duration
     from isodate import Duration
-    from knack.util import CLIError
+    from azure.cli.core.azclierror import InvalidArgumentValueError
     from azure.cli.command_modules.servicebus.constants import DURATION_SECS, DURATION_MIN, DURATION_DAYS
     if update_value is not None:
         value_toreturn = update_value
@@ -629,7 +629,7 @@ def return_valid_duration(update_value, current_value=None):
         try:
             time_duration = parse_duration(value_toreturn)
         except:
-            raise CLIError("Unable to parse duration string %r" % value_toreturn)
+            raise raise InvalidArgumentValueError("Unable to parse provided ISO 8601 format duration %r" % value_toreturn)
 
         if isinstance(time_duration, timedelta):
             if time_duration <= timedelta(days=DURATION_DAYS, minutes=DURATION_MIN, seconds=DURATION_SECS):


### PR DESCRIPTION
…ration

Fixes https://github.com/Azure/azure-cli/issues/23013

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
