### PR TITLE
[ARM] `az bicep install`: Address issue installing bicep on non-musl default systems with musl

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -211,7 +211,7 @@ def _get_bicep_download_url(system, release_tag, target_platform=None):
     if system == "Windows":
         return download_url.format("bicep-win-x64.exe")
     if system == "Linux":
-        if os.path.exists("/lib/ld-musl-x86_64.so.1"):
+        if os.path.exists("/lib/ld-musl-x86_64.so.1") and not os.path.exists("/lib/x86_64-linux-gnu/libc.so.6"):
             return download_url.format("bicep-linux-musl-x64")
         return download_url.format("bicep-linux-x64")
     if system == "Darwin":


### PR DESCRIPTION
**Related command**
`az bicep install`

**Description**<!--Mandatory-->
Installing the bicep command on systems using glibc that also have MUSL
installed generate errors at runtime (See https://github.com/Azure/bicep/issues/5040)

This expands the MUSL detection logic to exclude systems with glibc,
which is the primary non-musl libc.

**Testing Guide**
1. Run `az bicep install` on systems with glibc and musl, note that the standard linux bicep gets installed.
2. Run `az bicep install` on systems with glibc and without musl, note that the standard linux bicep gets installed.
3. Run `az bicep install` on systems with musl and without glibc, note that the musl linux bicep gets installed.

**History Notes**
[ARM] `az bicep install`: Address issue installing bicep on non-musl default systems with musl

---

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
