### PR TITLE
{packaging} Update azure-common to 1.1.28

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -7,7 +7,7 @@ azure-batch==12.0.0
 azure-cli-core==2.37.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.37.0
-azure-common==1.1.22
+azure-common==1.1.28
 azure-core==1.24.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -7,7 +7,7 @@ azure-batch==12.0.0
 azure-cli-core==2.37.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.37.0
-azure-common==1.1.22
+azure-common==1.1.28
 azure-core==1.24.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -7,7 +7,7 @@ azure-batch==12.0.0
 azure-cli-core==2.37.0
 azure-cli-telemetry==1.0.6
 azure-cli==2.37.0
-azure-common==1.1.22
+azure-common==1.1.28
 azure-core==1.24.0
 azure-cosmos==3.2.0
 azure-data-tables==12.4.0


### PR DESCRIPTION
**Related command**
Used by many `azure-cli` commands.

**Description**
The `azure-common` package was updated to 1.1.28 about four months ago and I'd like to get it updated in Fedora Linux.

**Testing Guide**
Existing testing processes should be used.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
