### PR TITLE
{AzureBilling} fix #23097

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/billing/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/_params.py
@@ -13,7 +13,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], required=False, help='name of the invoice')
 
     with self.argument_context('billing period show') as c:
-        c.argument('billing_period_name', options_list=['--name', '-n'], help='name of the billing period')
+        c.argument('billing_period_name', options_list=['--name', '-n'], help='name of the billing period. Run the 'az billing period list' command to list the name of billing period')
 
     with self.argument_context('billing enrollment-account show') as c:
         c.argument('name', options_list=['--name', '-n'], help='name of the enrollment account')

--- a/src/azure-cli/azure/cli/command_modules/billing/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/billing/_params.py
@@ -13,7 +13,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], required=False, help='name of the invoice')
 
     with self.argument_context('billing period show') as c:
-        c.argument('billing_period_name', options_list=['--name', '-n'], help='name of the billing period. Run the 'az billing period list' command to list the name of billing period')
+        c.argument('billing_period_name', options_list=['--name', '-n'], help='name of the billing period. Run the az billing period list command to list the name of billing period')
 
     with self.argument_context('billing enrollment-account show') as c:
         c.argument('name', options_list=['--name', '-n'], help='name of the enrollment account')


### PR DESCRIPTION
fixes Azure/azure-cli#23097

In this command, there is no documentation that shows where I can get the values for the "name" parameter. So this PR mentions to run the 'az billing period list' command to list the name of billing period' and then use this name in the 'az billing period show' command.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
