### PR TITLE
[Packaging] Drop Python 3.6 support

### DIFF
--- a/doc/command_guidelines.md
+++ b/doc/command_guidelines.md
@@ -426,7 +426,7 @@ Follow the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/d
 
 ## Coding Practices
 
-- All code must support Python 3.6, 3.7 and 3.8
+- All code must support Python 3.7 ~ 3.10
 - PRs to Azure/azure-cli and Azure/azure-cli-extensions must pass CI
 - Code must pass style checks with pylint and pep8
 - (*) All commands should have tests

--- a/doc/debug/debug_in_vs_code.md
+++ b/doc/debug/debug_in_vs_code.md
@@ -4,7 +4,7 @@
 
 * Visual Studio Code [Link](http://code.visualstudio.com/)
 * Visual Studio Code Python Extension [Link](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python)
-* Python 3.6+
+* Python 3.7+
 * Set up development environment [Link](https://github.com/Azure/azure-cli/blob/master/doc/configuring_your_machine.md)
 
 ## Quick start

--- a/doc/extensions/authoring.md
+++ b/doc/extensions/authoring.md
@@ -129,9 +129,9 @@ See [Extension Metadata](metadata.md) for more information.
 
 ### Test your extension on Python 3
 
-- The Azure CLI supports Python 3.6, 3.7, 3.8 so verify that your extension does the same.
+- The Azure CLI supports Python 3.7 ~ 3.10 so verify that your extension does the same.
 - You can create virtual environments for different versions and run your extension in them.
-- e.g. `python3.6 -m venv env36` and `python3.8 -m venv env38`.
+- e.g. `python3.7 -m venv env37` and `python3.10 -m venv env310`.
 
 
 Also, see the [FAQ](faq.md).

--- a/doc/install_linux_prerequisites.md
+++ b/doc/install_linux_prerequisites.md
@@ -2,93 +2,27 @@ Linux Install Prerequisites
 ===========================
 
 Some native Linux packages are required when installing the CLI with:
-- Interactive install script
-- ``pip``
 
-Current supported Python versions are Python 3.6, 3.7, 3.8. Azure CLI packages prior to version 2.1.0 support both Python 2.7 and Python 3.
+- Interactive install script
+- `pip`
+
+Current supported Python versions are Python 3.7 ~ 3.10.
 
 The commands to run to install the dependencies for some common distributions are listed below.
 
-* Ubuntu
-  * [12.04 LTS](#ubuntu-1204-lts)
-  * [14.04 LTS](#ubuntu-1404-lts-and-bash-on-windows-build-14362)
-  * [15.10](#ubuntu-1510)
-  * [16.04 LTS](#ubuntu-1604-lts)
-  * [18.04 LTS](#ubuntu-1804-lts)
-* Debian
-  * [7](#debian-7)
-  * [8](#debian-8)
-* CentOS
-  * [6.5 - 6.7](#centos-65--66--67)
-  * [7.1 - 7.2](#centos-71--72)
-* RHEL
-  * [6.7](#redhat-rhel-67)
-  * [7.2](#redhat-rhel-72)
-* [SUSE](#suse-opensuse-132)
-* [Flatcar](#flatcar)
-
-### Ubuntu 12.04 LTS
-Python 2.7.3 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev
-```
-
-### Ubuntu 14.04 LTS and BASH on Windows (Build 14362+)
-Python 2.7.6 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev
-```
-
-### Ubuntu 15.10
-Python 2.7.10 should be already on the machine. Install Python 3.6+ if needed.
+### Ubuntu 18.04 LTS, Ubuntu 20.04 LTS, Ubuntu 22.04 LTS, Debian 9, Debian 10
 ```
 sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev build-essential
 ```
 
-### Ubuntu 16.04 LTS
+### RHEL 8, CentOS Stream 8
+Install the latest Python 3.9 available in the software repo.
 ```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev build-essential
-```
-
-### Ubuntu 18.04 LTS
-```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev build-essential
-```
-
-### Debian 7
-Python 2.7.3 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev
-```
-
-### Debian 8
-Python 2.7.9 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo apt-get update && sudo apt-get install -y libssl-dev libffi-dev python-dev build-essential
-```
-
-### CentOS 6.5 / 6.6 / 6.7
-
-Not supported with the default version of Python (2.6.6) on the machine. Install Python 3.6+ if needed.
-
-### CentOS 7.1 / 7.2
-Python 2.7.5 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo yum check-update; sudo yum install -y gcc libffi-devel python-devel openssl-devel
-```
-
-### RedHat RHEL 6.7
-
-Not supported with the default version of Python (2.6.6) on the machine. Install Python 3.6+ if needed.
-
-### RedHat RHEL 7.2
-Python 2.7.5 should be already on the machine. Install Python 3.6+ if needed.
-```
-sudo yum check-update; sudo yum install -y gcc libffi-devel python-devel openssl-devel
+sudo dnf install -y gcc libffi-devel python39-devel openssl-devel
 ```
 
 ### SUSE OpenSUSE 13.2
-Python 2.7.8 should be already on the machine. Install Python 3.6+ if needed.
+Install Python 3.7+ if needed.
 ```
 sudo zypper refresh && sudo zypper --non-interactive install gcc libffi-devel python-devel openssl-devel
 ```

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -98,9 +98,10 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'License :: OSI Approved :: MIT License',
 ]
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -35,7 +35,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -16,7 +16,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/src/azure-cli-testsdk/setup.py
+++ b/src/azure-cli-testsdk/setup.py
@@ -15,7 +15,6 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -42,7 +42,6 @@ CLASSIFIERS = [
     'Intended Audience :: System Administrators',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/19858 

Since we have dropped Python 3.6 tests (https://github.com/Azure/azure-cli/pull/20865), now we remove Python 3.6 from `classifiers` in order to officially announce the deprecation of Python 3.6 support.
