### PR TITLE
[Packaging] Drop Ubuntu 21.10 Impish Indri DEB package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -707,10 +707,6 @@ jobs:
         # 20.04
         deb_system: ubuntu
         distro: focal
-      Impish:
-        # 21.10
-        deb_system: ubuntu
-        distro: impish
       Jammy:
         # 22.04
         deb_system: ubuntu


### PR DESCRIPTION
**Related command**

According to https://wiki.ubuntu.com/Releases, **Ubuntu 21.10 Impish Indri** will reach its End of Life at July 14, 2022. Azure CLI should drop its support.
