### PR TITLE
{Core} Provide error recommendation for `validate_file_or_dict`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/tests/test_validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/tests/test_validators.py
@@ -1,0 +1,55 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+import os
+
+from azure.cli.core.commands.validators import validate_file_or_dict, JSON_RECOMMENDATION_MESSAGE
+from azure.cli.core.azclierror import InvalidArgumentValueError
+
+
+class TestValidators(unittest.TestCase):
+
+    def test_validate_file_or_dict(self):
+        json_str = '{"name": "my-resource"}'
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
+        temp_file = os.path.join(curr_dir, 'temp.json')
+
+        # Parse JSON file
+        with open(temp_file, 'w') as f:
+            f.write(json_str)
+        json_read = validate_file_or_dict(temp_file)
+        assert json_read['name'] == 'my-resource'
+        os.remove(temp_file)
+
+        # Parse in-line JSON string
+        json_read = validate_file_or_dict(json_str)
+        assert json_read['name'] == 'my-resource'
+
+        # Test error 1: Parse JSON file with error
+        with open(temp_file, 'w') as f:
+            f.write(json_str)
+            f.write('error!')
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'Failed to parse file') as ex:
+            validate_file_or_dict(temp_file)
+        assert ex.exception.recommendations[0] == JSON_RECOMMENDATION_MESSAGE
+        assert len(ex.exception.recommendations) == 1
+        os.remove(temp_file)
+
+        # Test error 2: A non-existing file, but it looks like a JSON file
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'JSON file does not exist') as ex:
+            validate_file_or_dict("not-exist.json")
+        assert ex.exception.recommendations[0] == JSON_RECOMMENDATION_MESSAGE
+        assert len(ex.exception.recommendations) == 1
+
+        # Test error 3: A non-existing file, or invalid JSON string
+        with self.assertRaisesRegex(InvalidArgumentValueError, 'Failed to parse string as JSON') as ex:
+            validate_file_or_dict("invalid-string")
+        assert ex.exception.recommendations[0] == JSON_RECOMMENDATION_MESSAGE
+        assert 'The provided JSON string may have been parsed by the shell.' in ex.exception.recommendations[1]
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/azure-cli-core/azure/cli/core/commands/validators.py
+++ b/src/azure-cli-core/azure/cli/core/commands/validators.py
@@ -115,8 +115,6 @@ def validate_parameter_set(namespace, required, forbidden, dest_to_options=None,
     included_forbidden = [x for x in forbidden if getattr(namespace, x) and
                           not hasattr(getattr(namespace, x), 'is_default')]
     if missing_required or included_forbidden:
-        from knack.util import CLIError
-
         def _dest_to_option(dest):
             try:
                 return dest_to_options[dest]


### PR DESCRIPTION
**Description**<!--Mandatory-->

This PR is created according to the feedback on `az ad app federated-credential` (https://github.com/Azure/azure-cli/pull/22727).

`validate_file_or_dict` is used to parse argument that is either a JSON file or JSON string.

If the file exists, but contains invalid JSON string:

```
> az ad app federated-credential create --id 233dd73b-72e3-424a-9367-7588d957267e --parameters 'D:\test\fic-error.json'
Failed to parse D:\test\fic-error.json with exception:
    Failed to parse JSON: {
  "audiences": [
    "api://AzureADTokenExchange"
  ],
  "description": "Updated description"
    "id": "f684b731-198c-406e-8c8d-f2dd23d93cdf",
  "issuer": "https://token.actions.githubusercontent.com/",
  "name": "Testing",
  "subject": "repo:octo-org/octo-repo:environment:Production"
}
Error detail: Expecting ',' delimiter: line 6 column 5 (char 105)
```

If a non-existing file or invalid JSON string is provided, CLI fails with 

```
> az ad app federated-credential create --id 233dd73b-72e3-424a-9367-7588d957267e --parameters 'non-existing.json'
Failed to parse JSON: non-existing.json
Error detail: Expecting value: line 1 column 1 (char 0)
The JSON may have been parsed by the shell. See https://docs.microsoft.com/cli/azure/use-cli-effectively#use-quotation-marks-in-arguments
PowerShell requires additional quoting rules. See https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md
```

The error may be misleading, because we allow passing an in-line JSON string. We first checks if the string is an existing file path. If not, we fall back to in-line JSON. There is no way for us to know if the provided string is a non-existing JSON file or invalid JSON string.

After this PR, for existing file with invalid JSON string, we show:

```
> az ad app federated-credential create --id 233dd73b-72e3-424a-9367-7588d957267e --parameters 'D:\test\fic-error.json'
Failed to parse file 'D:\test\fic-error.json' with exception:
Failed to parse string as JSON:
{
  "audiences": [
    "api://AzureADTokenExchange"
  ],
  "description": "Updated description"
    "id": "f684b731-198c-406e-8c8d-f2dd23d93cdf",
  "issuer": "https://token.actions.githubusercontent.com/",
  "name": "Testing",
  "subject": "repo:octo-org/octo-repo:environment:Production"
}
Error detail: Expecting ',' delimiter: line 6 column 5 (char 105)
Please provide a valid JSON file path or JSON string.
```

For non-existing file ending with `.json`, we show:

```
> az ad app federated-credential create --id 233dd73b-72e3-424a-9367-7588d957267e --parameters 'non-existing.json'
JSON file does not exist: 'non-existing.json'
Please provide a valid JSON file path or JSON string.
```

For non-existing file or invalid JSON string, we show:

```
> az ad app federated-credential create --id 233dd73b-72e3-424a-9367-7588d957267e --parameters 'non-existing'
Failed to parse string as JSON:
non-existing
Error detail: Expecting value: line 1 column 1 (char 0)
Please provide a valid JSON file path or JSON string.
The provided JSON string may have been parsed by the shell. See https://docs.microsoft.com/cli/azure/use-cli-effectively#use-quotation-marks-in-arguments
PowerShell requires additional quoting rules. See https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md
