### PR TITLE
[AD] `az ad app federated-credential`: Federated identity credential GA

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -26,6 +26,11 @@ class APIVersionException(Exception):
 
 
 # Sentinel value for profile
+# If resource_type is set to PROFILE_TYPE, it means the name of the profile, such as 'latest', '2020-09-01-hybrid',
+# is used for supported_api_version check. For example,
+#     with self.command_group('feature', resource_feature_sdk, client_factory=cf_features, resource_type=PROFILE_TYPE,
+#                             min_api='2019-03-02-hybrid') as g:
+# This checks if the current cloud's profile name >= '2019-03-02-hybrid'.
 PROFILE_TYPE = object()
 
 

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -331,68 +331,67 @@ helps['ad app federated-credential list'] = """
 type: command
 short-summary: List application federated identity credentials.
 examples:
-  - name: List application federated identity credentials.
-    text: az ad app federated-credential list --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+- name: List application federated identity credentials.
+  text: az ad app federated-credential list --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 """
 
-
+# The example is from
+# https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation-create-trust-github?tabs=microsoft-graph
 helps['ad app federated-credential create'] = """
 type: command
 short-summary: Create application federated identity credential.
 examples:
-  - name: Create application federated identity credential.
-    text: |
-        az ad app federated-credential create --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --parameters credential.json
-        ("credential.json" contains the following content)
-        {
-            "name": "Testing",
-            "issuer": "https://token.actions.githubusercontent.com/",
-            "subject": "repo:octo-org/octo-repo:environment:Production",
-            "description": "Testing",
-            "audiences": [
-                "api://AzureADTokenExchange"
-            ]
-        }
+- name: Create application federated identity credential.
+  text: |
+    az ad app federated-credential create --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --parameters credential.json
+    ("credential.json" contains the following content)
+    {
+        "name": "Testing",
+        "issuer": "https://token.actions.githubusercontent.com/",
+        "subject": "repo:octo-org/octo-repo:environment:Production",
+        "description": "Testing",
+        "audiences": [
+            "api://AzureADTokenExchange"
+        ]
+    }
 """
-
 
 helps['ad app federated-credential show'] = """
 type: command
 short-summary: Show application federated identity credential.
 examples:
-  - name: Show application federated identity credential.
-    text: az ad app federated-credential show --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+- name: Show application federated identity credential with id
+  text: az ad app federated-credential show --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --federated-credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+- name: Show application federated identity credential with name
+  text: az ad app federated-credential show --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --federated-credential-id Testing
 """
-
 
 helps['ad app federated-credential update'] = """
 type: command
 short-summary: Update application federated identity credential.
 examples:
-  - name: Update application federated identity credential.
-    text: |
-        az ad app federated-credential update --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --parameters credential.json
-        ("credential.json" contains the following content)
-        {
-            "name": "Testing",
-            "issuer": "https://token.actions.githubusercontent.com/",
-            "subject": "repo:octo-org/octo-repo:environment:Production",
-            "description": "Testing",
-            "audiences": [
-                "api://AzureADTokenExchange"
-            ]
-        }
+- name: Update application federated identity credential.
+  text: |
+    az ad app federated-credential update --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --federated-credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --parameters credential.json
+    ("credential.json" contains the following content)
+    {
+        "name": "Testing",
+        "issuer": "https://token.actions.githubusercontent.com/",
+        "subject": "repo:octo-org/octo-repo:environment:Production",
+        "description": "Updated description",
+        "audiences": [
+            "api://AzureADTokenExchange"
+        ]
+    }
 """
-
 
 helps['ad app federated-credential delete'] = """
 type: command
 short-summary: Delete application federated identity credential.
 examples:
-  - name: Delete application federated identity credential.
-    text: az ad app federated-credential delete --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+- name: Delete application federated identity credential.
+  text: az ad app federated-credential delete --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --federated-credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 """
-
 
 helps['ad group'] = """
 type: group

--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -370,12 +370,11 @@ helps['ad app federated-credential update'] = """
 type: command
 short-summary: Update application federated identity credential.
 examples:
-- name: Update application federated identity credential.
+- name: Update application federated identity credential. Note that 'name' property cannot be changed.
   text: |
     az ad app federated-credential update --id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --federated-credential-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --parameters credential.json
     ("credential.json" contains the following content)
     {
-        "name": "Testing",
         "issuer": "https://token.actions.githubusercontent.com/",
         "subject": "repo:octo-org/octo-repo:environment:Production",
         "description": "Updated description",

--- a/src/azure-cli/azure/cli/command_modules/role/_msgrpah/_graph_client.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_msgrpah/_graph_client.py
@@ -140,8 +140,7 @@ class GraphClient:
         # https://docs.microsoft.com/en-us/graph/api/application-list-federatedidentitycredentials
         result = self._send(
             "GET",
-            f"/applications/{application_id}/federatedIdentityCredentials" + _filter_to_query(filter),
-            api_version=GraphClient.BETA)
+            f"/applications/{application_id}/federatedIdentityCredentials" + _filter_to_query(filter))
         return result
 
     def application_federated_identity_credential_create(self, application_id, body):
@@ -149,15 +148,14 @@ class GraphClient:
         result = self._send(
             "POST",
             f"/applications/{application_id}/federatedIdentityCredentials",
-            body=body, api_version=GraphClient.BETA)
+            body=body)
         return result
 
     def application_federated_identity_credential_get(self, application_id, federated_identity_credential_id_or_name):
         # https://docs.microsoft.com/en-us/graph/api/federatedidentitycredential-get
         result = self._send(
             "GET",
-            f"/applications/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            api_version=GraphClient.BETA)
+            f"/applications/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}")
         return result
 
     def application_federated_identity_credential_update(
@@ -166,15 +164,14 @@ class GraphClient:
         result = self._send(
             "PATCH",
             f"/applications/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            body=body, api_version=GraphClient.BETA)
+            body=body)
         return result
 
     def application_federated_identity_credential_delete(self, application_id, federated_identity_credential_id_or_name):
         # https://docs.microsoft.com/en-us/graph/api/federatedidentitycredential-delete
         result = self._send(
             "DELETE",
-            f"/applications/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            api_version=GraphClient.BETA)
+            f"/applications/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}")
         return result
 
     def service_principal_list(self, filter=None):
@@ -215,47 +212,6 @@ class GraphClient:
     def service_principal_owner_list(self, id):
         # https://docs.microsoft.com/en-us/graph/api/serviceprincipal-list-owners
         result = self._send("GET", "/servicePrincipals/{id}/owners".format(id=id))
-        return result
-
-    def service_principal_federated_identity_credential_list(self, application_id, filter=None):
-        # https://docs.microsoft.com/en-us/graph/api/application-list-federatedidentitycredentials
-        result = self._send(
-            "GET",
-            f"/servicePrincipals/{application_id}/federatedIdentityCredentials" + _filter_to_query(filter),
-            api_version=GraphClient.BETA)
-        return result
-
-    def service_principal_federated_identity_credential_create(self, application_id, body):
-        # https://docs.microsoft.com/en-us/graph/api/application-post-federatedidentitycredentials
-        result = self._send(
-            "POST",
-            f"/servicePrincipals/{application_id}/federatedIdentityCredentials",
-            body=body, api_version=GraphClient.BETA)
-        return result
-
-    def service_principal_federated_identity_credential_get(self, application_id, federated_identity_credential_id_or_name):
-        # https://docs.microsoft.com/en-us/graph/api/federatedidentitycredential-get
-        result = self._send(
-            "GET",
-            f"/servicePrincipals/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            api_version=GraphClient.BETA)
-        return result
-
-    def service_principal_federated_identity_credential_update(
-            self, application_id, federated_identity_credential_id_or_name, body):
-        # https://docs.microsoft.com/en-us/graph/api/federatedidentitycredential-update
-        result = self._send(
-            "PATCH",
-            f"/servicePrincipals/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            body=body, api_version=GraphClient.BETA)
-        return result
-
-    def service_principal_federated_identity_credential_delete(self, application_id, federated_identity_credential_id_or_name):
-        # https://docs.microsoft.com/en-us/graph/api/federatedidentitycredential-delete
-        result = self._send(
-            "DELETE",
-            f"/servicePrincipals/{application_id}/federatedIdentityCredentials/{federated_identity_credential_id_or_name}",
-            api_version=GraphClient.BETA)
         return result
 
     def owned_objects_list(self):

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -17,7 +17,6 @@ from azure.cli.command_modules.role._validators import validate_group, validate_
 
 name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-
 JSON_PROPERTY_HELP = "Should be in JSON format. See examples below for details"
 
 
@@ -207,15 +206,13 @@ def load_arguments(self, _):
         c.argument('create_cert', action='store_true', arg_group='keyCredentials', help='Create a self-signed certificate to use for the credential')
         c.argument('keyvault', arg_group='keyCredentials', help='Name or ID of a KeyVault to use for creating or retrieving certificates.')
 
-    for item in ['app', 'sp']:
-        with self.argument_context(f'ad {item} federated-credential') as c:
-            # TODO: We have to decide which name to use
-            #   --credential-id is consistent with API
-            #   --key-id is consistent with passwordCredentials and keyCredentials
-            c.argument('parameters', type=validate_file_or_dict,
-                       help='Parameters for creating federated identity credential. ' + JSON_PROPERTY_HELP)
-            c.argument('credential_id_or_name', options_list=['--credential-id', '--key-id'],
-                       help='Name or ID of the federated identity credential')
+    with self.argument_context('ad app federated-credential') as c:
+        c.argument('app_identifier', options_list=['--id'],
+                   help="Application's appId, identifierUri, or id (formerly known as objectId)")
+        c.argument('federated_identity_credential_id_or_name', options_list=['--federated-credential-id'],
+                   help='ID or name of the federated identity credential')
+        c.argument('parameters', type=validate_file_or_dict,
+                   help='Parameters for creating federated identity credential. ' + JSON_PROPERTY_HELP)
 
     for item in ['ad sp credential delete', 'ad sp credential list', 'ad app credential delete', 'ad app credential list']:
         with self.argument_context(item) as c:

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -17,7 +17,7 @@ from azure.cli.command_modules.role._validators import validate_group, validate_
 
 name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-JSON_PROPERTY_HELP = "Should be in JSON format. See examples below for details"
+JSON_PROPERTY_HELP = "Should be JSON file path or in-line JSON string. See examples below for details"
 
 
 # pylint: disable=too-many-statements

--- a/src/azure-cli/azure/cli/command_modules/role/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/role/commands.py
@@ -98,7 +98,7 @@ def load_command_table(self, _):
     # We use federated-credential instead of federated-identity-credential or fic, in order to align with
     # Azure Portal.
     with self.command_group('ad app federated-credential',
-                            client_factory=get_graph_client, exception_handler=graph_err_handler, is_preview=True) as g:
+                            client_factory=get_graph_client, exception_handler=graph_err_handler) as g:
         for command in ['list', 'create', 'show', 'update', 'delete']:
             g.custom_command(command, f'app_federated_credential_{command}')
 

--- a/src/azure-cli/azure/cli/command_modules/role/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/role/commands.py
@@ -6,11 +6,8 @@
 
 from collections import OrderedDict
 
-from azure.cli.core.profiles import PROFILE_TYPE
 from azure.cli.core.commands import CliCommandType
-
 from ._client_factory import _auth_client_factory, _graph_client_factory
-
 from ._validators import process_assignment_namespace
 
 
@@ -80,8 +77,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'update_role_assignment', min_api='2020-04-01-preview')
         g.custom_command('list-changelogs', 'list_role_assignment_change_logs')
 
-    with self.command_group('ad app', client_factory=get_graph_client, resource_type=PROFILE_TYPE,
-                            exception_handler=graph_err_handler) as g:
+    with self.command_group('ad app', client_factory=get_graph_client, exception_handler=graph_err_handler) as g:
         g.custom_command('create', 'create_application')
         g.custom_command('delete', 'delete_application')
         g.custom_command('list', 'list_applications', table_transformer=get_graph_object_transformer('app'))
@@ -99,25 +95,19 @@ def load_command_table(self, _):
         g.custom_command('credential list', 'list_application_credentials')
         g.custom_command('credential delete', 'delete_application_credential')
 
-    # Register federated-credential command group under both app and sp.
     # We use federated-credential instead of federated-identity-credential or fic, in order to align with
     # Azure Portal.
-    # It seems sp doesn't work with federatedIdentityCredentials yet.
-    # for item in ['app', 'sp']:
-    for item in ['app']:
-        with self.command_group(f'ad {item} federated-credential',
-                                client_factory=get_graph_client, resource_type=PROFILE_TYPE,
-                                exception_handler=graph_err_handler, is_experimental=True) as g:
-            for command in ['list', 'create', 'show', 'update', 'delete']:
-                g.custom_command(command, f'{item}_federated_credential_{command}')
+    with self.command_group('ad app federated-credential',
+                            client_factory=get_graph_client, exception_handler=graph_err_handler, is_preview=True) as g:
+        for command in ['list', 'create', 'show', 'update', 'delete']:
+            g.custom_command(command, f'app_federated_credential_{command}')
 
     with self.command_group('ad app owner', client_factory=get_graph_client, exception_handler=graph_err_handler) as g:
         g.custom_command('list', 'list_application_owners')
         g.custom_command('add', 'add_application_owner')
         g.custom_command('remove', 'remove_application_owner')
 
-    with self.command_group('ad sp', client_factory=get_graph_client, resource_type=PROFILE_TYPE,
-                            exception_handler=graph_err_handler) as g:
+    with self.command_group('ad sp', client_factory=get_graph_client, exception_handler=graph_err_handler) as g:
         g.custom_command('create', 'create_service_principal')
         g.custom_command('delete', 'delete_service_principal')
         g.custom_command('list', 'list_service_principals', table_transformer=get_graph_object_transformer('sp'))

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -983,32 +983,30 @@ def list_permission_grants(client, identifier=None, query_filter=None, show_reso
     return result
 
 
-def app_federated_credential_list(client, identifier):
-    object_id = _resolve_application(client, identifier)
-    # This call is too simple, so it's unnecessary to extract a common method for both application and servicePrincipal
-    # and invoke it like
-    # _federated_identity_credential_list(client.application_federated_identity_credential_list, object_id)
+def app_federated_credential_list(client, app_identifier):
+    object_id = _resolve_application(client, app_identifier)
     return client.application_federated_identity_credential_list(object_id)
 
 
-def app_federated_credential_create(client, identifier, parameters):
-    object_id = _resolve_application(client, identifier)
+def app_federated_credential_create(client, app_identifier, parameters):
+    object_id = _resolve_application(client, app_identifier)
     return client.application_federated_identity_credential_create(object_id, parameters)
 
 
-def app_federated_credential_show(client, identifier, credential_id_or_name):
-    object_id = _resolve_application(client, identifier)
-    return client.application_federated_identity_credential_get(object_id, credential_id_or_name)
+def app_federated_credential_show(client, app_identifier, federated_identity_credential_id_or_name):
+    object_id = _resolve_application(client, app_identifier)
+    return client.application_federated_identity_credential_get(object_id, federated_identity_credential_id_or_name)
 
 
-def app_federated_credential_update(client, identifier, credential_id_or_name, parameters):
-    object_id = _resolve_application(client, identifier)
-    return client.application_federated_identity_credential_update(object_id, credential_id_or_name, parameters)
+def app_federated_credential_update(client, app_identifier, federated_identity_credential_id_or_name, parameters):
+    object_id = _resolve_application(client, app_identifier)
+    return client.application_federated_identity_credential_update(object_id, federated_identity_credential_id_or_name,
+                                                                   parameters)
 
 
-def app_federated_credential_delete(client, identifier, credential_id_or_name):
-    object_id = _resolve_application(client, identifier)
-    return client.application_federated_identity_credential_delete(object_id, credential_id_or_name)
+def app_federated_credential_delete(client, app_identifier, federated_identity_credential_id_or_name):
+    object_id = _resolve_application(client, app_identifier)
+    return client.application_federated_identity_credential_delete(object_id, federated_identity_credential_id_or_name)
 
 
 def create_service_principal(cmd, identifier):
@@ -1114,31 +1112,6 @@ def list_service_principal_credentials(cmd, identifier, cert=False):
     client = _graph_client_factory(cmd.cli_ctx)
     sp = show_service_principal(client, identifier)
     return _list_credentials(sp, cert)
-
-
-def sp_federated_credential_list(client, identifier):
-    object_id = _resolve_service_principal(client, identifier)
-    return client.service_principal_federated_identity_credential_list(object_id)
-
-
-def sp_federated_credential_create(client, identifier, parameters):
-    object_id = _resolve_service_principal(client, identifier)
-    return client.service_principal_federated_identity_credential_create(object_id, parameters)
-
-
-def sp_federated_credential_show(client, identifier, credential_id_or_name):
-    object_id = _resolve_service_principal(client, identifier)
-    return client.service_principal_federated_identity_credential_get(object_id, credential_id_or_name)
-
-
-def sp_federated_credential_update(client, identifier, credential_id_or_name, parameters):
-    object_id = _resolve_service_principal(client, identifier)
-    return client.service_principal_federated_identity_credential_update(object_id, credential_id_or_name, parameters)
-
-
-def sp_federated_credential_delete(client, identifier, credential_id_or_name):
-    object_id = _resolve_service_principal(client, identifier)
-    return client.service_principal_federated_identity_credential_delete(object_id, credential_id_or_name)
 
 
 def _get_app_object_id_from_sp_object_id(client, sp_object_id):

--- a/src/azure-cli/azure/cli/command_modules/role/linter_exclusions.yml
+++ b/src/azure-cli/azure/cli/command_modules/role/linter_exclusions.yml
@@ -39,4 +39,19 @@ ad user update:
         force_change_password_next_sign_in:
             rule_exclusions:
             - option_length_too_long
+ad app federated-credential show:
+    parameters:
+        federated_identity_credential_id_or_name:
+            rule_exclusions:
+            - option_length_too_long
+ad app federated-credential update:
+    parameters:
+        federated_identity_credential_id_or_name:
+            rule_exclusions:
+            - option_length_too_long
+ad app federated-credential delete:
+    parameters:
+        federated_identity_credential_id_or_name:
+            rule_exclusions:
+            - option_length_too_long
 ...

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_federated_credential.yaml
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/recordings/test_app_federated_credential.yaml
@@ -13,9 +13,9 @@ interactions:
       ParameterSetName:
       - --display-name
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=startswith(displayName,'azure-cli-test000001')
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=startswith%28displayName%2C%27azure-cli-test000001%27%29
   response:
     body:
       string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[]}'
@@ -27,11 +27,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:30 GMT
+      - Thu, 14 Jul 2022 02:19:57 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 96302f8e-ab27-4cd5-a90e-5aa09e2a0001
+      - 865f5848-33df-4883-8858-a86168fe934e
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -39,7 +39,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00000BCF"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000028EB"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -63,15 +63,15 @@ interactions:
       ParameterSetName:
       - --display-name
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: POST
     uri: https://graph.microsoft.com/v1.0/applications
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
-        "id": "4d5c0e0b-9816-4aa2-a444-395e807c6f80", "deletedDateTime": null, "appId":
-        "1a139bcd-74f9-48e2-834a-d897c7a9b4d6", "applicationTemplateId": null, "disabledByMicrosoftStatus":
-        null, "createdDateTime": "2022-06-13T09:27:32.2479019Z", "displayName": "azure-cli-test000001",
+        "id": "91daeb4b-50ab-49c4-b5ed-9c41ecf7c088", "deletedDateTime": null, "appId":
+        "78b2c98e-bb2c-4926-b765-90bcce681177", "applicationTemplateId": null, "disabledByMicrosoftStatus":
+        null, "createdDateTime": "2022-07-14T02:19:59.4499519Z", "displayName": "azure-cli-test000001",
         "description": null, "groupMembershipClaims": null, "identifierUris": [],
         "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient": null, "notes":
         null, "publisherDomain": "AzureSDKTeam.onmicrosoft.com", "serviceManagementReference":
@@ -96,13 +96,13 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:32 GMT
+      - Thu, 14 Jul 2022 02:20:00 GMT
       location:
-      - https://graph.microsoft.com/v2/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/4d5c0e0b-9816-4aa2-a444-395e807c6f80/Microsoft.DirectoryServices.Application
+      - https://graph.microsoft.com/v2/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/Microsoft.DirectoryServices.Application
       odata-version:
       - '4.0'
       request-id:
-      - 39f4b235-24f4-4f8d-8648-61905079e0e7
+      - 956314ad-e842-492c-8f9f-57970ca00053
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -110,7 +110,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00001E1F"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E0"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -130,12 +130,12 @@ interactions:
       ParameterSetName:
       - --id --parameters
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -144,11 +144,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:33 GMT
+      - Thu, 14 Jul 2022 02:20:00 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 72318deb-9535-46eb-affa-83a3a59aa9df
+      - d2fa4b1b-b85e-4657-b155-d08b6ed2950a
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -156,7 +156,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000022D5"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000011EF"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -182,12 +182,12 @@ interactions:
       ParameterSetName:
       - --id --parameters
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: POST
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials/$entity","id":"2276d18a-223c-46d9-83a6-cfaadcb4c258","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials/$entity","id":"afa0b8e1-6644-4693-948c-df7cc4fabb05","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
     headers:
       cache-control:
       - no-cache
@@ -196,13 +196,13 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:35 GMT
+      - Thu, 14 Jul 2022 02:20:04 GMT
       location:
-      - https://graph.microsoft.com/v2/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/federatedIdentityCredentials/2276d18a-223c-46d9-83a6-cfaadcb4c258
+      - https://graph.microsoft.com/v2/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/federatedIdentityCredentials/afa0b8e1-6644-4693-948c-df7cc4fabb05
       odata-version:
       - '4.0'
       request-id:
-      - c9a6b63f-ee88-401a-8b0f-d497900b7285
+      - db1a7514-7edb-47a9-a406-1d9422dd253a
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -210,7 +210,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002404"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E9"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -230,12 +230,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -244,11 +244,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:36 GMT
+      - Thu, 14 Jul 2022 02:20:05 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 68712da1-2585-4ccb-87db-051ec8a4a0ca
+      - f2859439-5175-4ebf-b590-7c7aace8abe3
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -256,7 +256,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002334"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037EA"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -276,12 +276,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials","value":[{"id":"2276d18a-223c-46d9-83a6-cfaadcb4c258","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials","value":[{"id":"afa0b8e1-6644-4693-948c-df7cc4fabb05","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}]}'
     headers:
       cache-control:
       - no-cache
@@ -290,11 +290,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:37 GMT
+      - Thu, 14 Jul 2022 02:20:07 GMT
       odata-version:
       - '4.0'
       request-id:
-      - d01c0461-c988-4fcd-9169-0e020b3c4731
+      - 8c68ed15-be04-4f68-b36e-4d20380404c0
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -302,7 +302,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000017E9"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037EC"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -320,14 +320,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -336,11 +336,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:38 GMT
+      - Thu, 14 Jul 2022 02:20:07 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 1160542b-0ef2-4c85-b672-f3d67c7f0861
+      - a600e8ef-e4ca-4a6e-abd8-1955ca171ea6
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -348,7 +348,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002404"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E3"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -366,14 +366,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials/2276d18a-223c-46d9-83a6-cfaadcb4c258
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials/afa0b8e1-6644-4693-948c-df7cc4fabb05
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials/$entity","id":"2276d18a-223c-46d9-83a6-cfaadcb4c258","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials/$entity","id":"afa0b8e1-6644-4693-948c-df7cc4fabb05","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
     headers:
       cache-control:
       - no-cache
@@ -382,11 +382,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:39 GMT
+      - Thu, 14 Jul 2022 02:20:08 GMT
       odata-version:
       - '4.0'
       request-id:
-      - d51a2ac4-24e9-46b7-b747-e2b4fd8d18e9
+      - 4557d136-7db1-49e3-8d95-cde95e46d476
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -394,7 +394,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002335"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00001307"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -412,14 +412,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -428,11 +428,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:40 GMT
+      - Thu, 14 Jul 2022 02:20:10 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 3f39d30e-a849-4e9f-8cd5-3ddc53ae0a23
+      - 40e4535c-de4a-47ba-8abf-15f3d579f6ef
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -440,7 +440,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000022D4"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E9"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -458,14 +458,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials/Testing
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials/Testing
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials/$entity","id":"2276d18a-223c-46d9-83a6-cfaadcb4c258","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials/$entity","id":"afa0b8e1-6644-4693-948c-df7cc4fabb05","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Production","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
     headers:
       cache-control:
       - no-cache
@@ -474,11 +474,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:40 GMT
+      - Thu, 14 Jul 2022 02:20:10 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 35f43230-8164-489f-84fe-41ccff454cc4
+      - 85e3da2b-225a-4add-843e-781c20630e20
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -486,7 +486,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002336"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00002526"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -504,14 +504,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id --parameters
+      - --id --federated-credential-id --parameters
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -520,11 +520,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:41 GMT
+      - Thu, 14 Jul 2022 02:20:11 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 32076d9c-fa53-4392-8dba-09417dc89546
+      - 32ac1392-2b9a-4ef2-a41c-1830a9644e41
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -532,7 +532,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000023F9"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00002EBE"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -554,11 +554,11 @@ interactions:
       Content-Type:
       - application/json
       ParameterSetName:
-      - --id --credential-id --parameters
+      - --id --federated-credential-id --parameters
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: PATCH
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials/2276d18a-223c-46d9-83a6-cfaadcb4c258
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials/afa0b8e1-6644-4693-948c-df7cc4fabb05
   response:
     body:
       string: ''
@@ -566,13 +566,13 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Mon, 13 Jun 2022 09:27:43 GMT
+      - Thu, 14 Jul 2022 02:20:13 GMT
       request-id:
-      - d9418acf-5912-4f09-9d26-6bf66e2f0c86
+      - 8e64561f-29aa-49fd-9816-1d2c0cf7ee0d
       strict-transport-security:
       - max-age=31536000
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000018C7"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000028EB"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -590,14 +590,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -606,11 +606,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:44 GMT
+      - Thu, 14 Jul 2022 02:20:13 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 44520a5d-8022-437f-bb04-b2547a0198b9
+      - b6052318-f8cd-4ea1-b9ea-cfbfe774e57c
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -618,7 +618,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00000BC4"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E4"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -636,14 +636,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials/2276d18a-223c-46d9-83a6-cfaadcb4c258
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials/afa0b8e1-6644-4693-948c-df7cc4fabb05
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials/$entity","id":"2276d18a-223c-46d9-83a6-cfaadcb4c258","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Staging","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials/$entity","id":"afa0b8e1-6644-4693-948c-df7cc4fabb05","name":"Testing","issuer":"https://token.actions.githubusercontent.com/","subject":"repo:octo-org/octo-repo:environment:Staging","description":"Testing","audiences":["api://AzureADTokenExchange"]}'
     headers:
       cache-control:
       - no-cache
@@ -652,11 +652,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:45 GMT
+      - Thu, 14 Jul 2022 02:20:14 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 53f1e19c-b776-4798-98cd-b11befd9491c
+      - e0d2b23f-89ac-42a5-838a-c45b04302974
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -664,7 +664,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00000BCF"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00002016"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -682,14 +682,14 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -698,11 +698,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:46 GMT
+      - Thu, 14 Jul 2022 02:20:15 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 2e866f28-e98a-4cf4-a250-46a003752dd7
+      - 09b83101-269a-4ea8-a062-f92ed3371796
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -710,7 +710,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002401"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E2"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -730,11 +730,11 @@ interactions:
       Content-Length:
       - '0'
       ParameterSetName:
-      - --id --credential-id
+      - --id --federated-credential-id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: DELETE
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials/2276d18a-223c-46d9-83a6-cfaadcb4c258
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials/afa0b8e1-6644-4693-948c-df7cc4fabb05
   response:
     body:
       string: ''
@@ -742,13 +742,13 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Mon, 13 Jun 2022 09:27:47 GMT
+      - Thu, 14 Jul 2022 02:20:16 GMT
       request-id:
-      - 895b3f4d-a164-4274-a0f4-662322d6e5f7
+      - bdca33ab-823c-44d9-b72b-e782cb1dbcd1
       strict-transport-security:
       - max-age=31536000
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000017E9"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF0000252C"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -768,12 +768,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -782,11 +782,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:48 GMT
+      - Thu, 14 Jul 2022 02:20:17 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 6999710b-6568-4a95-8c2a-0fe1344ff879
+      - 9b97fc5e-5474-4e48-96c0-670ad55f57e2
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -794,7 +794,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00002334"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00002016"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -814,12 +814,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/beta/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80/federatedIdentityCredentials
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088/federatedIdentityCredentials
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/beta/$metadata#applications(''4d5c0e0b-9816-4aa2-a444-395e807c6f80'')/federatedIdentityCredentials","value":[]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications(''91daeb4b-50ab-49c4-b5ed-9c41ecf7c088'')/federatedIdentityCredentials","value":[]}'
     headers:
       cache-control:
       - no-cache
@@ -828,11 +828,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:49 GMT
+      - Thu, 14 Jul 2022 02:20:18 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 541c2ab6-f8ca-4408-bcf3-08fae13f79f6
+      - c4a8e7a7-ce14-4c3a-acf4-ca440621268a
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -840,7 +840,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00001643"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF0000252C"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -860,12 +860,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -874,11 +874,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:50 GMT
+      - Thu, 14 Jul 2022 02:20:18 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 69328b4b-64cd-4911-a5ab-c5e03aa6fd28
+      - 818b4ce4-81ac-4d86-9ddd-5fe4f91e08d7
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -886,7 +886,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000022D5"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037ED"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -906,12 +906,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications/$entity","id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications/$entity","id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}'
     headers:
       cache-control:
       - no-cache
@@ -920,11 +920,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:51 GMT
+      - Thu, 14 Jul 2022 02:20:19 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 88ae8bb3-8a27-404c-9fdd-3f5186e35495
+      - 77907d3d-a918-411a-9ce6-68c482341bc9
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -932,7 +932,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000017E9"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF00001307"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -952,12 +952,12 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: GET
-    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20'1a139bcd-74f9-48e2-834a-d897c7a9b4d6'
+    uri: https://graph.microsoft.com/v1.0/applications?$filter=appId%20eq%20%2778b2c98e-bb2c-4926-b765-90bcce681177%27
   response:
     body:
-      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"4d5c0e0b-9816-4aa2-a444-395e807c6f80","deletedDateTime":null,"appId":"1a139bcd-74f9-48e2-834a-d897c7a9b4d6","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-06-13T09:27:32Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#applications","value":[{"id":"91daeb4b-50ab-49c4-b5ed-9c41ecf7c088","deletedDateTime":null,"appId":"78b2c98e-bb2c-4926-b765-90bcce681177","applicationTemplateId":null,"disabledByMicrosoftStatus":null,"createdDateTime":"2022-07-14T02:19:59Z","displayName":"azure-cli-test000001","description":null,"groupMembershipClaims":null,"identifierUris":[],"isDeviceOnlyAuthSupported":null,"isFallbackPublicClient":null,"notes":null,"publisherDomain":"AzureSDKTeam.onmicrosoft.com","serviceManagementReference":null,"signInAudience":"AzureADandPersonalMicrosoftAccount","tags":[],"tokenEncryptionKeyId":null,"defaultRedirectUri":null,"certification":null,"optionalClaims":null,"addIns":[],"api":{"acceptMappedClaims":null,"knownClientApplications":[],"requestedAccessTokenVersion":2,"oauth2PermissionScopes":[],"preAuthorizedApplications":[]},"appRoles":[],"info":{"logoUrl":null,"marketingUrl":null,"privacyStatementUrl":null,"supportUrl":null,"termsOfServiceUrl":null},"keyCredentials":[],"parentalControlSettings":{"countriesBlockedForMinors":[],"legalAgeGroupRule":"Allow"},"passwordCredentials":[],"publicClient":{"redirectUris":[]},"requiredResourceAccess":[],"verifiedPublisher":{"displayName":null,"verifiedPublisherId":null,"addedDateTime":null},"web":{"homePageUrl":null,"logoutUrl":null,"redirectUris":[],"implicitGrantSettings":{"enableAccessTokenIssuance":false,"enableIdTokenIssuance":false}},"spa":{"redirectUris":[]}}]}'
     headers:
       cache-control:
       - no-cache
@@ -966,11 +966,11 @@ interactions:
       content-type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       date:
-      - Mon, 13 Jun 2022 09:27:51 GMT
+      - Thu, 14 Jul 2022 02:20:20 GMT
       odata-version:
       - '4.0'
       request-id:
-      - 77090461-f7ac-49d1-b0f7-a7220640e741
+      - 38f5d113-448e-4065-9134-b7aaea265463
       strict-transport-security:
       - max-age=31536000
       transfer-encoding:
@@ -978,7 +978,7 @@ interactions:
       vary:
       - Accept-Encoding
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF00001E1F"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E8"}}'
       x-ms-resource-unit:
       - '2'
     status:
@@ -1000,9 +1000,9 @@ interactions:
       ParameterSetName:
       - --id
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: DELETE
-    uri: https://graph.microsoft.com/v1.0/applications/4d5c0e0b-9816-4aa2-a444-395e807c6f80
+    uri: https://graph.microsoft.com/v1.0/applications/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088
   response:
     body:
       string: ''
@@ -1010,13 +1010,13 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Mon, 13 Jun 2022 09:27:52 GMT
+      - Thu, 14 Jul 2022 02:20:22 GMT
       request-id:
-      - d4f7d222-e910-4b66-b6cc-308b4732c9bd
+      - 5f4ae720-ddf0-4b74-aeb5-5124e3d7fc99
       strict-transport-security:
       - max-age=31536000
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000022D5"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000028EC"}}'
       x-ms-resource-unit:
       - '1'
     status:
@@ -1038,9 +1038,9 @@ interactions:
       ParameterSetName:
       - --method --url
       User-Agent:
-      - python/3.10.4 (Windows-10-10.0.22000-SP0) AZURECLI/2.37.0
+      - python/3.10.5 (Windows-10-10.0.19044-SP0) AZURECLI/2.38.0
     method: DELETE
-    uri: https://graph.microsoft.com/v1.0/directory/deletedItems/4d5c0e0b-9816-4aa2-a444-395e807c6f80
+    uri: https://graph.microsoft.com/v1.0/directory/deletedItems/91daeb4b-50ab-49c4-b5ed-9c41ecf7c088
   response:
     body:
       string: ''
@@ -1048,13 +1048,13 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Mon, 13 Jun 2022 09:27:54 GMT
+      - Thu, 14 Jul 2022 02:20:24 GMT
       request-id:
-      - f086ee43-a4bd-4e89-9142-0960ccece6f0
+      - f2eb6f12-e1f0-41e8-a6fc-f0e2b8a0ff3f
       strict-transport-security:
       - max-age=31536000
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"001","RoleInstance":"SI2PEPF000017E9"}}'
+      - '{"ServerInfo":{"DataCenter":"Southeast Asia","Slice":"E","Ring":"5","ScaleUnit":"002","RoleInstance":"SG1PEPF000037E8"}}'
       x-ms-resource-unit:
       - '1'
     status:

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_graph.py
@@ -201,40 +201,6 @@ class GraphScenarioTestBase(ScenarioTest):
         self.cmd('ad {object_type} credential list --id {app_id}',
                  checks=self.check('[0].endDateTime', '2100-12-31T00:00:00Z'))
 
-    def _test_federated_credential(self, object_type):
-        self.kwargs['object_type'] = object_type
-        self.kwargs['parameters'] = TEST_FEDERATED_IDENTITY_CREDENTIAL
-        self.kwargs['name'] = 'Testing'
-
-        # Create credential
-        result = self.cmd("ad {object_type} federated-credential create --id {app_id} --parameters '{parameters}'",
-                          checks=[self.check('name', '{name}')]).get_output_in_json()
-        self.kwargs['credential_id'] = result['id']
-
-        # List credential
-        self.cmd("ad {object_type} federated-credential list --id {app_id}",
-                 checks=[self.check('length(@)', 1)])
-
-        # Show credential with credential ID
-        self.cmd("ad {object_type} federated-credential show --id {app_id} --credential-id {credential_id}",
-                 checks=[self.check('name', '{name}')])
-        # Show with credential name
-        self.cmd("ad {object_type} federated-credential show --id {app_id} --credential-id {name}",
-                 checks=[self.check('name', '{name}')])
-
-        # Update credential's subject
-        update_subject = "repo:octo-org/octo-repo:environment:Staging"
-        self.kwargs['update_json'] = json.dumps({'subject': update_subject})
-        self.cmd("ad {object_type} federated-credential update --id {app_id} --credential-id {credential_id} "
-                 "--parameters '{update_json}'")
-        self.cmd("ad {object_type} federated-credential show --id {app_id} --credential-id {credential_id}",
-                 checks=self.check('subject', update_subject))
-
-        # Delete credential
-        self.cmd("ad {object_type} federated-credential delete --id {app_id} --credential-id {credential_id}")
-        self.cmd("ad {object_type} federated-credential list --id {app_id}",
-                 checks=[self.check('length(@)', 0)])
-
 
 class ApplicationScenarioTest(GraphScenarioTestBase):
 
@@ -643,7 +609,37 @@ class ApplicationScenarioTest(GraphScenarioTestBase):
 
     def test_app_federated_credential(self):
         self._create_app()
-        self._test_federated_credential('app')
+        self.kwargs['parameters'] = TEST_FEDERATED_IDENTITY_CREDENTIAL
+        self.kwargs['name'] = 'Testing'
+
+        # Create credential
+        result = self.cmd("ad app federated-credential create --id {app_id} --parameters '{parameters}'",
+                          checks=[self.check('name', '{name}')]).get_output_in_json()
+        self.kwargs['credential_id'] = result['id']
+
+        # List credential
+        self.cmd("ad app federated-credential list --id {app_id}",
+                 checks=[self.check('length(@)', 1)])
+
+        # Show credential with credential ID
+        self.cmd("ad app federated-credential show --id {app_id} --federated-credential-id {credential_id}",
+                 checks=[self.check('name', '{name}')])
+        # Show with credential name
+        self.cmd("ad app federated-credential show --id {app_id} --federated-credential-id {name}",
+                 checks=[self.check('name', '{name}')])
+
+        # Update credential's subject
+        update_subject = "repo:octo-org/octo-repo:environment:Staging"
+        self.kwargs['update_json'] = json.dumps({'subject': update_subject})
+        self.cmd("ad app federated-credential update --id {app_id} --federated-credential-id {credential_id} "
+                 "--parameters '{update_json}'")
+        self.cmd("ad app federated-credential show --id {app_id} --federated-credential-id {credential_id}",
+                 checks=self.check('subject', update_subject))
+
+        # Delete credential
+        self.cmd("ad app federated-credential delete --id {app_id} --federated-credential-id {credential_id}")
+        self.cmd("ad app federated-credential list --id {app_id}",
+                 checks=[self.check('length(@)', 0)])
 
 
 class ServicePrincipalScenarioTest(GraphScenarioTestBase):


### PR DESCRIPTION
**Related command**
`az ad app federated-credential`

**Description**<!--Mandatory-->
Refine `az ad app federated-credential` (https://github.com/Azure/azure-cli/pull/22727) according to [feedback](https://microsoft-my.sharepoint.com/:w:/p/shkhalid/EYLFU4VusuRCmdxF8ptgSvcBdMigy7VWp18mTS3fgDpcog?e=G3etkM):

1. Choose `--credential-id` instead of `--key-id` (see the feedback doc for rationale)
2. Not to have `az ad sp federated-credential` cmds and wait for customer feedback. We’ve mentioned a scenario in the doc where a customer with existing sp may look to add fic and they can do so using `az ad app federated-credential create`, which will add the fic to the backing application. To be consistent across tooling (Az CLI, Az PS, Graph PS), We are trying to gain clarity from MS graph PS team to hide the FIC SP cmdlets which appear because we have a FIC SP API (only intended to support managed identities) and because those cmdlets are autogenerated. 
3. JSON parameters are ok (vs flattened arguments)
4. JSON file error message is improved by https://github.com/Azure/azure-cli/pull/23121

**2022-07-11 Update** 

1. Choose `--id` instead of `--credential-id` or `--key-id`
2. Use `--app-id` to represent the applicatin's `appId`, `identifierUri`, or `id` (formerly known as `objectId`)

This design is in sync with Azure PowerShell cmdlets, such as [`Get-AzADAppFederatedIdentityCredential`](https://docs.microsoft.com/en-us/powershell/module/az.resources/get-azadappfederatedidentitycredential?view=azps-8.1.0):

```
Get-AzADAppFederatedIdentityCredential -ApplicationObjectId 5d523cc0-8e94-4aa9-9273-c0cc14382f5c -Id f684b731-198c-406e-8c8d-f2dd23d93cdf
```

so CLI commands are like

```
az ad app federated-credential show --app-id 233dd73b-72e3-424a-9367-7588d957267e --id f684b731-198c-406e-8c8d-f2dd23d93cdf
```

**2022-07-14 Update** 

The above change is reverted. `--id` still indicates applicatin's `appId`, `identifierUri`, or `id`. Federated identity credential's ID is indicated by `--federated-credential-id`:

```
az ad app federated-credential show --id 233dd73b-72e3-424a-9367-7588d957267e --federated-credential-id f684b731-198c-406e-8c8d-f2dd23d93cdf
```