### PR TITLE
[IoT] Change certificate loading to encode to b64 strings by default

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/_utils.py
@@ -61,10 +61,7 @@ def open_certificate(certificate_path):
     if certificate_path.endswith('.pem') or certificate_path.endswith('.cer'):
         with open(certificate_path, "rb") as cert_file:
             certificate = cert_file.read()
-        try:
-            certificate = certificate.decode("utf-8")
-        except UnicodeError:
-            certificate = base64.b64encode(certificate).decode("utf-8")
+        certificate = base64.b64encode(certificate).decode("utf-8")
     else:
         raise ValueError("Certificate file type must be either '.pem' or '.cer'.")
     # Remove trailing white space from the certificate content

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/_test_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/_test_utils.py
@@ -50,12 +50,24 @@ def _create_test_cert(cert_file, key_file, subject, valid_days, serial_number):
         f.write(key_dump)
 
 
-def _delete_test_cert(cert_file, key_file, verification_file):
-    if exists(cert_file) and exists(key_file):
-        os.remove(cert_file)
-        os.remove(key_file)
-    if exists(verification_file):
-        os.remove(verification_file)
+def _create_fake_chain_cert(cert_file, chain_file):
+    # get the contents of a certificate
+    certificate = ""
+    with open(cert_file, "rb") as c:
+        certificate = c.read()
+        certificate = certificate.decode("utf-8")
+
+    # write it twice to a file to create a chain cert
+    with open(chain_file, "wt", encoding="utf-8") as f:
+        f.write(certificate)
+        f.write("\n")
+        f.write(certificate)
+
+
+def _delete_test_cert(cert_files):
+    for cert_file in cert_files:
+        if exists(cert_file):
+            os.remove(cert_file)
 
 
 def _create_verification_cert(cert_file, key_file, verification_file, nonce, valid_days, serial_number):

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recordings/test_certificate_lifecycle.yaml
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recordings/test_certificate_lifecycle.yaml
@@ -13,12 +13,12 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000002?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-05-04T00:06:37Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002","name":"clitest.rg000002","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-07-07T22:09:53Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:06:39 GMT
+      - Thu, 07 Jul 2022 22:09:55 GMT
       expires:
       - '-1'
       pragma:
@@ -66,7 +66,7 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003?api-version=2021-07-02
   response:
@@ -74,7 +74,7 @@ interactions:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003","name":"iot-hub-for-cert-test000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","resourcegroup":"clitest.rg000002","properties":{"state":"Activating","provisioningState":"Accepted","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4},"operationsMonitoringEvents":{"retentionTimeInDays":1,"partitionCount":4}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","allowedFqdnList":[]},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
       cache-control:
       - no-cache
       content-length:
@@ -82,7 +82,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:06:45 GMT
+      - Thu, 07 Jul 2022 22:09:59 GMT
       expires:
       - '-1'
       pragma:
@@ -112,9 +112,9 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -126,7 +126,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:07:15 GMT
+      - Thu, 07 Jul 2022 22:10:29 GMT
       expires:
       - '-1'
       pragma:
@@ -158,9 +158,9 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -172,7 +172,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:07:45 GMT
+      - Thu, 07 Jul 2022 22:10:59 GMT
       expires:
       - '-1'
       pragma:
@@ -204,9 +204,9 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -218,7 +218,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:08:15 GMT
+      - Thu, 07 Jul 2022 22:11:30 GMT
       expires:
       - '-1'
       pragma:
@@ -250,9 +250,9 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
   response:
     body:
       string: '{"status":"Running"}'
@@ -264,7 +264,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:08:46 GMT
+      - Thu, 07 Jul 2022 22:12:00 GMT
       expires:
       - '-1'
       pragma:
@@ -296,9 +296,9 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfZmY4OGI2NzktNmZmZi00ZGVmLWIxY2EtZjFiYzM3YzQ3MDZiO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/locations/westus/operationResults/aWQ9b3NfaWhfNGE0MzAyNTUtYzViMC00YWU5LWJmY2UtNjAwOWJjOTM0ZDVlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-07-02&operationSource=other&asyncinfo
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -310,7 +310,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:16 GMT
+      - Thu, 07 Jul 2022 22:12:30 GMT
       expires:
       - '-1'
       pragma:
@@ -342,22 +342,22 @@ interactions:
       ParameterSetName:
       - -n -g --sku
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003?api-version=2021-07-02
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003","name":"iot-hub-for-cert-test000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","resourcegroup":"clitest.rg000002","etag":"AAAADGed3e4=","properties":{"locations":[{"location":"West
-        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-cert-test000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-cert-testvj3j","endpoint":"sb://iothub-ns-iot-hub-fo-18894834-8b4100f4ff.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","allowedFqdnList":[]},"sku":{"name":"S1","tier":"Standard","capacity":1},"identity":{"type":"None"},"systemData":{"createdAt":"2022-05-04T00:06:44.43Z"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003","name":"iot-hub-for-cert-test000003","type":"Microsoft.Devices/IotHubs","location":"westus","tags":{},"subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","resourcegroup":"clitest.rg000002","etag":"AAAADGvXw7k=","properties":{"locations":[{"location":"West
+        US","role":"primary"},{"location":"East US","role":"secondary"}],"state":"Active","provisioningState":"Succeeded","ipFilterRules":[],"hostName":"iot-hub-for-cert-test000003.azure-devices.net","eventHubEndpoints":{"events":{"retentionTimeInDays":1,"partitionCount":4,"partitionIds":["0","1","2","3"],"path":"iot-hub-for-cert-testxodu","endpoint":"sb://iothub-ns-iot-hub-fo-20100823-08b5e22506.servicebus.windows.net/"}},"routing":{"endpoints":{"serviceBusQueues":[],"serviceBusTopics":[],"eventHubs":[],"storageContainers":[]},"routes":[],"fallbackRoute":{"name":"$fallback","source":"DeviceMessages","condition":"true","endpointNames":["events"],"isEnabled":true}},"storageEndpoints":{"$default":{"sasTtlAsIso8601":"PT1H","connectionString":"","containerName":""}},"messagingEndpoints":{"fileNotifications":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"enableFileUploadNotifications":false,"cloudToDevice":{"maxDeliveryCount":10,"defaultTtlAsIso8601":"PT1H","feedback":{"lockDurationAsIso8601":"PT5S","ttlAsIso8601":"PT1H","maxDeliveryCount":10}},"features":"None","allowedFqdnList":[],"rootCertificate":{}},"sku":{"name":"S1","tier":"Standard","capacity":1},"identity":{"type":"None"},"systemData":{"createdAt":"2022-07-07T22:09:59.2433333Z"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1667'
+      - '1693'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:16 GMT
+      - Thu, 07 Jul 2022 22:12:30 GMT
       expires:
       - '-1'
       pragma:
@@ -389,7 +389,7 @@ interactions:
       ParameterSetName:
       - --hub-name -g -n -p
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates?api-version=2021-07-02
   response:
@@ -403,7 +403,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:17 GMT
+      - Thu, 07 Jul 2022 22:12:31 GMT
       expires:
       - '-1'
       pragma:
@@ -422,7 +422,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}}'
+    body: '{"properties": {"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}}'
     headers:
       Accept:
       - application/json
@@ -439,14 +439,14 @@ interactions:
       ParameterSetName:
       - --hub-name -g -n -p
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004?api-version=2021-07-02
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sat, 07 May 2022
-        00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:19 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDIzNDgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDJmMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sun, 10 Jul 2022
+        22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:33 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4MWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUxMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -455,7 +455,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:18 GMT
+      - Thu, 07 Jul 2022 22:12:32 GMT
       expires:
       - '-1'
       pragma:
@@ -489,14 +489,14 @@ interactions:
       ParameterSetName:
       - --hub-name -g -n -p --verified
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates?api-version=2021-07-02
   response:
     body:
-      string: '{"value":[{"properties":{"subject":"TESTCERT000001","expiry":"Sat,
-        07 May 2022 00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:19 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDIzNDgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDJmMDAwMCI="}]}'
+      string: '{"value":[{"properties":{"subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:33 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4MWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUxMDAwMCI="}]}'
     headers:
       cache-control:
       - no-cache
@@ -505,7 +505,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:19 GMT
+      - Thu, 07 Jul 2022 22:12:33 GMT
       expires:
       - '-1'
       pragma:
@@ -524,7 +524,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"isVerified": true, "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}}'
+    body: '{"properties": {"isVerified": true, "certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}}'
     headers:
       Accept:
       - application/json
@@ -541,14 +541,14 @@ interactions:
       ParameterSetName:
       - --hub-name -g -n -p --verified
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005?api-version=2021-07-02
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sat, 07 May 2022
-        00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:21 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005","name":"verified-certificate-000005","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDI1ZTgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDMxMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sun, 10 Jul 2022
+        22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:35 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005","name":"verified-certificate-000005","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4NGVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUzMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -557,7 +557,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:20 GMT
+      - Thu, 07 Jul 2022 22:12:34 GMT
       expires:
       - '-1'
       pragma:
@@ -591,16 +591,16 @@ interactions:
       ParameterSetName:
       - --hub-name -g
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates?api-version=2021-07-02
   response:
     body:
-      string: '{"value":[{"properties":{"subject":"TESTCERT000001","expiry":"Sat,
-        07 May 2022 00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:19 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDIzNDgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDJmMDAwMCI="},{"properties":{"subject":"TESTCERT000001","expiry":"Sat,
-        07 May 2022 00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:21 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005","name":"verified-certificate-000005","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDI1ZTgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDMxMDAwMCI="}]}'
+      string: '{"value":[{"properties":{"subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:33 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4MWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUxMDAwMCI="},{"properties":{"subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:35 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005","name":"verified-certificate-000005","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4NGVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUzMDAwMCI="}]}'
     headers:
       cache-control:
       - no-cache
@@ -609,7 +609,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:21 GMT
+      - Thu, 07 Jul 2022 22:12:35 GMT
       expires:
       - '-1'
       pragma:
@@ -641,14 +641,14 @@ interactions:
       ParameterSetName:
       - --hub-name -g -n
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004?api-version=2021-07-02
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sat, 07 May 2022
-        00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:19 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDIzNDgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDJmMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sun, 10 Jul 2022
+        22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:33 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4MWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUxMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -657,7 +657,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:22 GMT
+      - Thu, 07 Jul 2022 22:12:37 GMT
       expires:
       - '-1'
       pragma:
@@ -689,18 +689,18 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - ImNmMDIzNDgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDJmMDAwMCI=
+      - IjFhMDA4MWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUxMDAwMCI=
       ParameterSetName:
       - --hub-name -g -n --etag
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004/generateVerificationCode?api-version=2021-07-02
   response:
     body:
-      string: '{"properties":{"verificationCode":"0845B4D4D47C6F543D516D182CDEF369CD3CC34FB04F212A","subject":"TESTCERT000001","expiry":"Sat,
-        07 May 2022 00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:23 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDI4YzgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDMzMDAwMCI="}'
+      string: '{"properties":{"verificationCode":"C7E4A2762A309F5B7B72179AF7BDD55C95BAD3683B75CDA7","subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:38 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4NmVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU2MDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -709,7 +709,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:23 GMT
+      - Thu, 07 Jul 2022 22:12:37 GMT
       expires:
       - '-1'
       pragma:
@@ -730,7 +730,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDM2pDQ0FjYWdBd0lCQWdJSVVVUlJtbHJQR1RJd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURreU5Gb1hEVEl5DQpNRFV3TnpBd01Ea3lORm93T3pFNU1EY0dBMVVFQXd3d01EZzBOVUkwUkRSRU5EZEROa1kxTkRORU5URTJSREU0DQpNa05FUlVZek5qbERSRE5EUXpNMFJrSXdORVl5TVRKQk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBDQpNSUlCQ2dLQ0FRRUF3SWpBNVhPekJrUWRGc051UFFGUHdsNVh4L0FXbmxBcnJlb0x1a2ZjNzFuOGhOZ09UeU9EDQpEYnRWL0N4cUZjYXBXMi9BNGVTWDlTaGFlZDFabUlFUUxUN1lpS1RITjhkMDhxWWxyVHZGZUdWSVFyZ2xwTjk3DQpKcWJXc1pKY3NwYzRYNTRoSHpnbUxPbXRxVk9xU2hSWmgwV1lIaXRoRFl6bEl2bmxUa1F1TW1XNGRSM2Y5UXNMDQorR2JZMWZNemN1S2I5MXJrWXc2c1lud1hjelVuK3NoWXRqRmhtc1hoYk85SXFETDdndjQ5aVVvSFF5YWJ1L3RLDQpjNlBTbEVYMkt6ZmRFVWtSSEY0UTcrZlpaVTZaeTgwVXhJbldMWjBhSVJIMkY2MEMrMVdweW9jcDdqWEFidExsDQpRbkdsUWRYeVU1bDAvREE5bjFIWEhtdy9OYWtvanUyZjF3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCDQpBUUJjREpZc2dRWFp6Z1Bqb1RlWVNsdGlhR1phTHIrWjV6ZGpjYWZNaGsyMGg1azkzZzJtZktWd3o3WDk2dXZhDQpmTzRLYnliVFNrTE83ZmhpRXBveC94aWFOcUc1RnhtczZubExSaDBUTVBWbVZ3V2gwYm9KcFo3NmpEampYaEFqDQo1NG5pTStyWUthRGh2UC95Rjd0aUtPMVlEeWs2NVlKbjgvcURtYWMyQzE0eWxWdTVqNDVVNXhDMmtVU1RHT0ZHDQpvYkQ5cFNGNVptR1hWOHlaS2R4V09PUFdmL1ZSM2ZiVU1naUVsa1ZIeDBVcmN1dGVEYUZvTmxSMTZNL045RjBaDQpEWUVuVU54NzY3ZlQySzBQVVdkWEF6eFNJd2U5TkZoK080RXI0NDl0Z2JwbE41VmQ3Qit5dHlqZjUzRW9xNnNPDQo0VWY2NG5UTUVjR3o0UXBrRFpVcTk3bjgNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NCg=="}'
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDM2pDQ0FjYWdBd0lCQWdJSUNaaFFmRlludGN3d0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TVRJek9Gb1hEVEl5DQpNRGN4TURJeU1USXpPRm93T3pFNU1EY0dBMVVFQXd3d1F6ZEZORUV5TnpZeVFUTXdPVVkxUWpkQ056SXhOemxCDQpSamRDUkVRMU5VTTVOVUpCUkRNMk9ETkNOelZEUkVFM01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBDQpNSUlCQ2dLQ0FRRUFxK0MzWnBySlFuRUNnK0Q1akpXZ3ZyZ0RJelZZcEVNVlJiSnhEMmFGTnY3WEZCOGkrUjhMDQpRVXA5d0lOODVkTkxLNDJMa0hOYjZsamdkOWlNTWxPNS83T2VxKzFYY3FyVjliUzd6WUphclZZTEpKdUo0eDR1DQphdlhlOGx2eUxuWEJ4S0RaRVdyTksyWlVOUVMxZlZkYkZxTzh3NXFDZ1ZqQmRTajRtTVQ2cWpKNHpQcU9nMWJYDQppWmZ6RkJCVHhXU1JGRWNYdFFOaDJIbW5odXI3MTNodWRsSUpacU1kZGo4dEZGVTh5SVZIanVIeDRRaHRocFBnDQp5VVVwZXBRNThsTHNMR1NNRHhUSHVmVjBuM0UxaEgydVVZYi8zVlgybncrUWV5aUhOc2NTa09mbFJzMklMWWZvDQplTzdic0IrZDlWTHJIN1diS2JWeURQdVh4cXVwVkdBWk53SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCDQpBUUFZQzh1SGlLRWlqWm9kTHhRbG53bnpNY1BxYklwRjdiZ1grb0lpQjdCQTVZRE5TQW9pWVhnMjAwbHFSRFhFDQpMbXdQOHg2RjdlZUVvV3NWOE5wakN0cE9YNWo2ak9PZVFLUmdYYUd0NTdEN2FoMGFiUUF0QjF2S2lYSVVEZk9RDQpSUUhqR2c4emtqeE50dnJ6OE5DRXRpRFNPSkZQUDZDNW9GeWs4S3REeXdKTHI4MkpSaVRKd3k3d1NMNHB0aHhwDQoxRWJtQ1dJQWJ5LzNicDJWNGRlSThYTDdhT2p5WVVueHF5V3JsZmNsc21qZ0NxOGQzUGtFdW0rZVRUU2N1UzAwDQppbUhmTjMyMkRVQklBU1lYdXBPNUtOS0xGWTkxalYrdUJnUHQ1bDRiYkNYSG10Z0hJSTZ1NUFZUU9Fc0dpOElSDQpyb1pZM0w5S2dlRDdNTlY3Y0RXYzhXVkMNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NCg=="}'
     headers:
       Accept:
       - application/json
@@ -745,18 +745,18 @@ interactions:
       Content-Type:
       - application/json
       If-Match:
-      - ImNmMDI4YzgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDMzMDAwMCI=
+      - IjFhMDA4NmVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU2MDAwMCI=
       ParameterSetName:
       - --hub-name -g -n -p --etag
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004/verify?api-version=2021-07-02
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sat, 07 May 2022
-        00:06:37 GMT","thumbprint":"C0B00B842B807074A09F05F280C51E82945C9711","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Wed, 04 May 2022 00:09:25 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSVdPc1g3d1JDUVNNd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFF6WlhsdWEzQXpjV052YjJ0bU1tNTNNQjRYRFRJeU1EVXdOREF3TURZek4xb1hEVEl5DQpNRFV3TnpBd01EWXpOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxRelpYbHVhM0F6Y1dOdmIydG1NbTUzDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNpeXNpMHU0aEs5TmIvb2VGTjBnDQpOQ2JscWo3RUFwcVpSbG5ESjhSOTFyWDJFOVpIVEpWV1pCR1g2RlVsaVJFbndJRThHazRtVXZSaVB3aGJQWXE3DQpEZjI5MVY0VVRVUWxURkJERzRxVm5vY3o1eUNzd2pNVzFlQmVISElnNEkvbndpYTBqQmxkV2N3alBCR0ZnNlNRDQpHWEQ5S3RRWmNnelkwLy9FVkdPdlRybVlGU0dxUGwrQnZUN0dRMTRpQXAwK3VZNTJHZ1FTMU41STFtMFo3aSsvDQpGUXJ5RU9BRVJGcjNwUVFGTjBlaTFOVEpsTm82NDNxanZGK3VteGpIM2tNWndoU2s4TkRaWGQyVnBuM3dSS0liDQpTbnM1cUIwWDQ5a0pNKzFBVWRDR21MRGp3aHh6Sis2T05YN1hXWDl1cnk3M1ZFNjFEbWFwMTF3Y3JxUEg3Rk1VDQpXUUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQm1aRUZUZnlXcURGdnJwMElPTVJmaXBxOU43YkRCDQpFY3FTUjZ1aVN1L250cHVOOTZxZ01MNnl4My9aeTNKU0dNdHdzdWZucU1WTWo3dUIzZHdxSXppaXZxTTNsN09UDQptdldrM0h4bjNIUmxrb1M0N0pLVnQrdHp1dENneFJwVDZqbXNJaVY1SkovTXlGQVRhY2dHVmhVUmlLUXdObEY0DQpIc01NOE9vMFNTbUhiMVl4YTFROENvMWQxSm51VXV2aVZKeU52dE1KU1F5NHh4UzBOZnVYdU1FbU9ZU3ZBTzNxDQpqb2Z4YTVFTHByZE13L0JQMUVkOExHUGZVb0ZSOTNyU0Q2V1JQRlM4VEJqRGtqMUdQanZYSjBVUmx6a0lEU0krDQplU2NhZjdZWXFGOTNhWW1uSm84TFVqS1kraFVzTzRXR0RDS3VPRDhiLzY3czhTSmdWVzZGQnkrSg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"ImNmMDJhNzgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDM1MDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sun, 10 Jul 2022
+        22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:39 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4OWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU3MDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -765,7 +765,111 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 04 May 2022 00:09:24 GMT
+      - Thu, 07 Jul 2022 22:12:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot hub certificate create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --hub-name -g -n -p
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates?api-version=2021-07-02
+  response:
+    body:
+      string: '{"value":[{"properties":{"subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:39 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004","name":"certificate-000004","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4OWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU3MDAwMCI="},{"properties":{"subject":"TESTCERT000001","expiry":"Sun,
+        10 Jul 2022 22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:35 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWNjUWpBZE8zcUljd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQW5waHppZWlsMkFQNkVMR3RWeXJYDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQp1OXpvRjN2U2dxME5pSXNKU3JQQWNKUVVZTXBjNkdCdEpKMUs5SW5qOEwrc3hVam9tZ29LKzcxOXNiL29ScmZtDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQp2UUlEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQk5HNVlvN1NsNnpBRmxJWUo4QWpJTng5bkU1a01nDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQp0NWZsOU1JcndvR09iSHVCTjFoM1lmNVUwZWhkcTNjUDZ6K216WGY3R1diSXJFeHdKbVR4V2RDanMrQnVoMW1ZDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005","name":"verified-certificate-000005","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4NGVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUzMDAwMCI="}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3967'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 07 Jul 2022 22:12:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQ0KTUlJQ3hqQ0NBYTZnQXdJQkFnSUljY1FqQWRPM3FJY3dEUVlKS29aSWh2Y05BUUVMQlFBd0l6RWhNQjhHQTFVRQ0NCkF3d1lWRVZUVkVORlVsUm1iVzEzWW10MWVXbHRjVFEyWkd4ME1CNFhEVEl5TURjd056SXlNRGsxTTFvWERUSXkNDQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQ0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFucGh6aWVpbDJBUDZFTEd0VnlyWA0NCmV2V0lZK1B1ckdUVXJxRGtYS2NhY2tlY0xtTXFnbytjWk9ZbWxhWU8zS082aXo4NUQ3aUNRUzRDMXhvaVMrc3gNDQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQ0KdTl6b0YzdlNncTBOaUlzSlNyUEFjSlFVWU1wYzZHQnRKSjFLOUluajhMK3N4VWpvbWdvSys3MTlzYi9vUnJmbQ0NCjlqcXFxalllOFF4aFpYUkh1TFE1emwwY2ZtSHlxNWI3MVBBcGEzNzMrYmptMkcvbzY2TTd6M09LYXEzUnRpaHANDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQ0KdlFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJORzVZbzdTbDZ6QUZsSVlKOEFqSU54OW5FNWtNZw0NClhsalIzS2dHYlJDY1lXcGZWTHF3UmdaaVdMdGlsSmpGM2d6S2hNeWFjeG41cjB6WlA3Z20rWit5Q3kyNmcxOUMNDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQ0KdDVmbDlNSXJ3b0dPYkh1Qk4xaDNZZjVVMGVoZHEzY1A2eittelhmN0dXYklyRXh3Sm1UeFdkQ2pzK0J1aDFtWQ0NCnlDMzNxRzArQ3EyMkJ1RUZVOGlseUVTSWlhT2xPR3U3MGhmYjhMVlNxMm54aW9DdGRobFp1TjlQVzBxTjVLaFQNDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NDQoNCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQ0NCk1JSUN4akNDQWE2Z0F3SUJBZ0lJY2NRakFkTzNxSWN3RFFZSktvWklodmNOQVFFTEJRQXdJekVoTUI4R0ExVUUNDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQ0KTURjeE1ESXlNRGsxTTFvd0l6RWhNQjhHQTFVRUF3d1lWRVZUVkVORlVsUm1iVzEzWW10MWVXbHRjVFEyWkd4MA0NCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBbnBoemllaWwyQVA2RUxHdFZ5clgNDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQ0KWWZpdXZDUzZVcE9kSDlJa0poMlVlVjZoanBTQnZhVTdZRmFsQk5KZFl1UENDYy9nRFRKQzN3a3pDcVBWdnpQUg0NCnU5em9GM3ZTZ3EwTmlJc0pTclBBY0pRVVlNcGM2R0J0SkoxSzlJbmo4TCtzeFVqb21nb0srNzE5c2Ivb1JyZm0NDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQ0KNFJYckUxbW93TEEwNjZ6OW5YUlZTNENUMmlCUUkyRWFmb3ZyY0I4V3BBOVBxVzR0VExyYjNhcDA4aDRJUUlESg0NCnZRSURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTkc1WW83U2w2ekFGbElZSjhBaklOeDluRTVrTWcNDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQ0Kbm1RdDBSekZHYzRJS0NvaXRSY1FzelVQRDlWYW1qMG16eURWaWx0aHZDYWVtZnUwTnlRdjFlM0pVOCs5YzlKdg0NCnQ1Zmw5TUlyd29HT2JIdUJOMWgzWWY1VTBlaGRxM2NQNnorbXpYZjdHV2JJckV4d0ptVHhXZENqcytCdWgxbVkNDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQ0KbE9XTFFtdzJUVE53NUNrSHNwMElEVzE2TXhpL0N1U2NqU1VBMGZ6QmZpVVJnM0RBQlBDRmUyYlkNDQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQ0K"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot hub certificate create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2851'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --hub-name -g -n -p
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000006?api-version=2021-07-02
+  response:
+    body:
+      string: '{"properties":{"subject":"TESTCERT000001","expiry":"Sun, 10 Jul 2022
+        22:09:53 GMT","thumbprint":"DB3C8A09D32E35412DFED32E246624749A75353E","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:12:41 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQ0KTUlJQ3hqQ0NBYTZnQXdJQkFnSUljY1FqQWRPM3FJY3dEUVlKS29aSWh2Y05BUUVMQlFBd0l6RWhNQjhHQTFVRQ0NCkF3d1lWRVZUVkVORlVsUm1iVzEzWW10MWVXbHRjVFEyWkd4ME1CNFhEVEl5TURjd056SXlNRGsxTTFvWERUSXkNDQpNRGN4TURJeU1EazFNMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSbWJXMTNZbXQxZVdsdGNUUTJaR3gwDQ0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFucGh6aWVpbDJBUDZFTEd0VnlyWA0NCmV2V0lZK1B1ckdUVXJxRGtYS2NhY2tlY0xtTXFnbytjWk9ZbWxhWU8zS082aXo4NUQ3aUNRUzRDMXhvaVMrc3gNDQpZZml1dkNTNlVwT2RIOUlrSmgyVWVWNmhqcFNCdmFVN1lGYWxCTkpkWXVQQ0NjL2dEVEpDM3drekNxUFZ2elBSDQ0KdTl6b0YzdlNncTBOaUlzSlNyUEFjSlFVWU1wYzZHQnRKSjFLOUluajhMK3N4VWpvbWdvSys3MTlzYi9vUnJmbQ0NCjlqcXFxalllOFF4aFpYUkh1TFE1emwwY2ZtSHlxNWI3MVBBcGEzNzMrYmptMkcvbzY2TTd6M09LYXEzUnRpaHANDQo0UlhyRTFtb3dMQTA2Nno5blhSVlM0Q1QyaUJRSTJFYWZvdnJjQjhXcEE5UHFXNHRUTHJiM2FwMDhoNElRSURKDQ0KdlFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUJORzVZbzdTbDZ6QUZsSVlKOEFqSU54OW5FNWtNZw0NClhsalIzS2dHYlJDY1lXcGZWTHF3UmdaaVdMdGlsSmpGM2d6S2hNeWFjeG41cjB6WlA3Z20rWit5Q3kyNmcxOUMNDQpubVF0MFJ6RkdjNElLQ29pdFJjUXN6VVBEOVZhbWowbXp5RFZpbHRodkNhZW1mdTBOeVF2MWUzSlU4KzljOUp2DQ0KdDVmbDlNSXJ3b0dPYkh1Qk4xaDNZZjVVMGVoZHEzY1A2eittelhmN0dXYklyRXh3Sm1UeFdkQ2pzK0J1aDFtWQ0NCnlDMzNxRzArQ3EyMkJ1RUZVOGlseUVTSWlhT2xPR3U3MGhmYjhMVlNxMm54aW9DdGRobFp1TjlQVzBxTjVLaFQNDQpsT1dMUW13MlRUTnc1Q2tIc3AwSURXMTZNeGkvQ3VTY2pTVUEwZnpCZmlVUmczREFCUENGZTJiWQ0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NDQoNCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQ0NCk1JSUN4akNDQWE2Z0F3SUJBZ0lJY2NRakFkTzNxSWN3RFFZSktvWklodmNOQVFFTEJRQXdJekVoTUI4R0ExVUUNDQpBd3dZVkVWVFZFTkZVbFJtYlcxM1ltdDFlV2x0Y1RRMlpHeDBNQjRYRFRJeU1EY3dOekl5TURrMU0xb1hEVEl5DQ0KTURjeE1ESXlNRGsxTTFvd0l6RWhNQjhHQTFVRUF3d1lWRVZUVkVORlVsUm1iVzEzWW10MWVXbHRjVFEyWkd4MA0NCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBbnBoemllaWwyQVA2RUxHdFZ5clgNDQpldldJWStQdXJHVFVycURrWEtjYWNrZWNMbU1xZ28rY1pPWW1sYVlPM0tPNml6ODVEN2lDUVM0QzF4b2lTK3N4DQ0KWWZpdXZDUzZVcE9kSDlJa0poMlVlVjZoanBTQnZhVTdZRmFsQk5KZFl1UENDYy9nRFRKQzN3a3pDcVBWdnpQUg0NCnU5em9GM3ZTZ3EwTmlJc0pTclBBY0pRVVlNcGM2R0J0SkoxSzlJbmo4TCtzeFVqb21nb0srNzE5c2Ivb1JyZm0NDQo5anFxcWpZZThReGhaWFJIdUxRNXpsMGNmbUh5cTViNzFQQXBhMzczK2JqbTJHL282Nk03ejNPS2FxM1J0aWhwDQ0KNFJYckUxbW93TEEwNjZ6OW5YUlZTNENUMmlCUUkyRWFmb3ZyY0I4V3BBOVBxVzR0VExyYjNhcDA4aDRJUUlESg0NCnZRSURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCTkc1WW83U2w2ekFGbElZSjhBaklOeDluRTVrTWcNDQpYbGpSM0tnR2JSQ2NZV3BmVkxxd1JnWmlXTHRpbEpqRjNnektoTXlhY3huNXIwelpQN2dtK1oreUN5MjZnMTlDDQ0Kbm1RdDBSekZHYzRJS0NvaXRSY1FzelVQRDlWYW1qMG16eURWaWx0aHZDYWVtZnUwTnlRdjFlM0pVOCs5YzlKdg0NCnQ1Zmw5TUlyd29HT2JIdUJOMWgzWWY1VTBlaGRxM2NQNnorbXpYZjdHV2JJckV4d0ptVHhXZENqcytCdWgxbVkNDQp5QzMzcUcwK0NxMjJCdUVGVThpbHlFU0lpYU9sT0d1NzBoZmI4TFZTcTJueGlvQ3RkaGxadU45UFcwcU41S2hUDQ0KbE9XTFFtdzJUVE53NUNrSHNwMElEVzE2TXhpL0N1U2NqU1VBMGZ6QmZpVVJnM0RBQlBDRmUyYlkNDQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000006","name":"certificate-000006","type":"Microsoft.Devices/IotHubs/Certificates","etag":"IjFhMDA4YWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU5MDAwMCI="}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3401'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 07 Jul 2022 22:12:40 GMT
       expires:
       - '-1'
       pragma:
@@ -799,11 +903,11 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - ImNmMDJhNzgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDM1MDAwMCI=
+      - IjFhMDA4OWVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTU3MDAwMCI=
       ParameterSetName:
       - --hub-name -g -n --etag
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000004?api-version=2021-07-02
   response:
@@ -815,7 +919,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 00:09:25 GMT
+      - Thu, 07 Jul 2022 22:12:42 GMT
       expires:
       - '-1'
       pragma:
@@ -845,11 +949,11 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - ImNmMDI1ZTgyLTAwMDAtMDcwMC0wMDAwLTYyNzFjNDMxMDAwMCI=
+      - IjFhMDA4NGVkLTAwMDAtMDcwMC0wMDAwLTYyYzc1YTUzMDAwMCI=
       ParameterSetName:
       - --hub-name -g -n --etag
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/verified-certificate-000005?api-version=2021-07-02
   response:
@@ -861,7 +965,53 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 04 May 2022 00:09:28 GMT
+      - Thu, 07 Jul 2022 22:12:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot hub certificate delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      If-Match:
+      - '*'
+      ParameterSetName:
+      - --hub-name -g -n --etag
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-iothub/2.2.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002/providers/Microsoft.Devices/IotHubs/iot-hub-for-cert-test000003/certificates/certificate-000006?api-version=2021-07-02
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 07 Jul 2022 22:12:44 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recordings/test_dps_certificate_lifecycle.yaml
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recordings/test_dps_certificate_lifecycle.yaml
@@ -17,7 +17,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Devices/checkProvisioningServiceNameAvailability?api-version=2021-10-15
@@ -32,7 +32,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:49:26 GMT
+      - Thu, 07 Jul 2022 22:08:43 GMT
       expires:
       - '-1'
       pragma:
@@ -66,12 +66,12 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-azure-mgmt-resource/20.0.0 Python/3.8.3 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.3 (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-05-03T17:49:25Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-07-07T22:08:40Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:49:26 GMT
+      - Thu, 07 Jul 2022 22:08:43 GMT
       expires:
       - '-1'
       pragma:
@@ -113,7 +113,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002?api-version=2021-10-15
@@ -122,7 +122,7 @@ interactions:
       string: '{"name":"dps000002","location":"westus","properties":{"state":"Activating","provisioningState":"Accepted","allocationPolicy":"Hashed","idScope":null},"resourcegroup":"clitest.rg000001","type":"Microsoft.Devices/provisioningServices","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002","subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","tags":{},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfMjhiMjc3NTUtZDU2YS00NzI4LWFiNDctODZkZjY0ZDdkNmZkO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfNGM3ZjZjMGItYjdlMS00Nzg3LThlODctNTc1MzM4NDI4ODJlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
       cache-control:
       - no-cache
       content-length:
@@ -130,7 +130,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:49:30 GMT
+      - Thu, 07 Jul 2022 22:08:46 GMT
       expires:
       - '-1'
       pragma:
@@ -160,10 +160,10 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfMjhiMjc3NTUtZDU2YS00NzI4LWFiNDctODZkZjY0ZDdkNmZkO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfNGM3ZjZjMGItYjdlMS00Nzg3LThlODctNTc1MzM4NDI4ODJlO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -175,7 +175,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:00 GMT
+      - Thu, 07 Jul 2022 22:09:16 GMT
       expires:
       - '-1'
       pragma:
@@ -207,13 +207,13 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002?api-version=2021-10-15
   response:
     body:
-      string: '{"etag":"AAAAAA/P24M=","name":"dps000002","location":"westus","properties":{"state":"Active","provisioningState":"Succeeded","iotHubs":[],"allocationPolicy":"Hashed","serviceOperationsHostName":"dps000002.azure-devices-provisioning.net","deviceProvisioningHostName":"global.azure-devices-provisioning.net","idScope":"0ne005CB7A6"},"resourcegroup":"clitest.rg000001","type":"Microsoft.Devices/provisioningServices","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002","subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","tags":{},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
+      string: '{"etag":"AAAAABFIFYM=","name":"dps000002","location":"westus","properties":{"state":"Active","provisioningState":"Succeeded","iotHubs":[],"allocationPolicy":"Hashed","serviceOperationsHostName":"dps000002.azure-devices-provisioning.net","deviceProvisioningHostName":"global.azure-devices-provisioning.net","idScope":"0ne0068CBEA"},"resourcegroup":"clitest.rg000001","type":"Microsoft.Devices/provisioningServices","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002","subscriptionid":"a386d5ea-ea90-441a-8263-d816368c84a1","tags":{},"sku":{"name":"S1","tier":"Standard","capacity":1}}'
     headers:
       cache-control:
       - no-cache
@@ -222,7 +222,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:00 GMT
+      - Thu, 07 Jul 2022 22:09:16 GMT
       expires:
       - '-1'
       pragma:
@@ -254,7 +254,7 @@ interactions:
       ParameterSetName:
       - --dps-name -g --name -p
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates?api-version=2021-10-15
@@ -269,7 +269,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:01 GMT
+      - Thu, 07 Jul 2022 22:09:18 GMT
       expires:
       - '-1'
       pragma:
@@ -288,7 +288,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlESFRDQ0FnV2dBd0lCQWdJSVo3L1hBUmdxQm9rd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJ3TlRKblpUWjNNek4wTTNkaWJXNWtNQjRYRFRJeU1EVXdNakUzTlRBd01Wb1hEVEl5DQpNRFV3TmpFM05UQXdNVm93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSd05USm5aVFozTXpOME0zZGliVzVrDQpNSUlCSVRBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE0QU1JSUJDUUtDQVFBd0FTYzJZTW5DdEVTa0l4WjZ2N1RVDQozL01rWTFZb3Vtd3o2eDM5N01sMVl6Z2dZZmpvVis3cGxsQzlQRWhVSFVNYUJGNHZTazhFUzR1OXB2bkFBeUZzDQpNcXdkZ2pDai9CUE1adTBoL0N2anhod0dZTnd3aVpFOGV0Vmd4TEt1VGQzQ0xQVWU3REpoYnZYazR1TnNrbmpBDQpjZXFNK1FEYmoxRlFCSE13QXlFYnVSakRKTjZwQXY1VGc5RVEvek5tTHNrZERMY3d3R0RzVWRmOElER1ZpYkVqDQpFdWlyK29WbnZ1TWJod09HbkNJamVObjg3dnI4S2V5Nm1tcGtYVnVhNUxHQkRHL0cza2hHd2FvdjVSY1ExUmJPDQp5QUNJQ2haM3V3U1BaOHhoYkRIcndnSjRnQnhqaGowZU9lNy9JVHBkVlo4Y095RDdxNjRFb3UyYm4yWk9RZ0RSDQpBZ01CQUFHalZqQlVNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUV3SFFZRFZSME9CQllFRk5vNW8rNWVhMHNODQpNbFcvNzVWZ0dKQ3YyQWNKTUI4R0ExVWRJd1FZTUJhQUZObzVvKzVlYTBzTk1sVy83NVZnR0pDdjJBY0pNQTBHDQpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQVptaUJpMVFmRDJab0Q4V29SY0VNRUxUbTI2OFFkaDlKMTgwWXlqakJ3DQpJMnRQeXpSUGNXczlVd1ZuSUhJK21rUHBFTUxxeEplM0E3a3owRnEzeXU5bVR2Z1NobStaYjBPNnhEWjdCQTVNDQpnamZ5Z0xqOXc4YWJNd2JQcnFJWU9NMEVKenR6dXA5cDQwZ1E4b1NmY3owcm9FYS9SZVdTN2oxMVoxeXo0VnN4DQpFbEtRekFpdkRMRWFPZ3RLQ0M4OTI1Lzg1RFltbHJyNGF0SjRWaXQ4T2w2N3NBeWNlR1paZ2U5bWxrODU0UkZxDQphSVRTbm5COUVmaFFpaHIzU2lRS2xuVHpGdnEza2picENUejhqa2FSb3U3a0JtQW9icmZld2l0d1lNTTRKdmlhDQpSMTloeW1EUit6M3JBRUpyT2FVN2g1SmgwV3ZuM2MvLzRjVnc5M3NlSTFmLw0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}'
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWZESUErK2dqYUtFd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreE4xb1hEVEl5DQpNRGN4TURJeU1Ea3hOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSamJHRnphSEowZEdabGJYUm9ZV05xDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXhZTVJQeGJVbk9tQmp2WCtFeG1kDQpFNlZ5NjRrQlFHeXZPejRKSmt6bHB5NTJhbytvS1c3a0FCRzljZFBZREtzd0FTY1ZzME5SUi9NM2FHdEZOK0hRDQpialhMaU4yT0F3R0ZSSmdObDFKaGxDUXpGTUNnaXBIczRkVzhQd21lcnlLMTJ0ekJOaTBuWUxKN1BlQXowdWpPDQpHOFBCZmF0dTBmeWVxNi9lc1FoUGI5ZFcwNkRhWGF6NTdVdXhYbXZCL2RISDQ0VFcvYVZFSm0zeDRocHZLU2VWDQpQZnFwRkFZMEdaNUYxdVR5MmcwVG5OTCsyamtBMXNKYW1iTFBJQ0NNbXhPOExLZmxpYjdqeHNRb3BhV1R5VnV0DQphSEZXenR0V29wWURkSzdqMlNIdUNnNDFIQlF3QkZQdTI3WFY1aDlia3BMT0JlQisxTElCdWFmc2UvcC8xcVplDQord0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUFuQ2pKTzllQnNLVXBPNXJTOUU2T2oxdHFua0hmDQpVc1FtVk1kZmx2b0Ivem5YckRvQVFHTnh6ajIrK3JnZHhDWngxQm4vSzRremJqaWNBNHlsUElsREQ1L3ZWalgrDQpPb3JSNDh5Szk5aGtQcWlvaWZTZTUwNWZaSHNDUVFnVTM2ajlwRThkMVpGQVdlZmJteHUxcGpWTUt4T01VcjF4DQpSOWE5OUZOK0l4ZWMycUtzaENUZmxmeDlJZjVoc3ptdFE2YjBxbnhSZDVhMExnK04zZHAvUHRvbFUxVitaS0xoDQpydkRHdjh6N2s3SUVZbU9iemRCczdsSitEaWFPK1gwWGNGSzhkSmw0SmFvRFNlWWJmZHNISktaWkpDTWx5Z0pBDQpDT0lPV0pVWUhLMThsY1hMYmdTdFBBUzlaNXBtNVg0cXZVMnJuYWVKNUVEZ00yRGNJQzRjK2NDaQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}'
     headers:
       Accept:
       - application/json
@@ -299,21 +299,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1563'
+      - '1403'
       Content-Type:
       - application/json
       ParameterSetName:
       - --dps-name -g --name -p
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000005","expiry":"Fri, 06 May 2022
-        17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:03 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:19 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -322,7 +322,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:02 GMT
+      - Thu, 07 Jul 2022 22:09:18 GMT
       expires:
       - '-1'
       pragma:
@@ -356,15 +356,15 @@ interactions:
       ParameterSetName:
       - --dps-name -g --name -p --verified
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates?api-version=2021-10-15
   response:
     body:
-      string: '{"value":[{"properties":{"subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:03 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI="}]}'
+      string: '{"value":[{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:19 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI="}]}'
     headers:
       cache-control:
       - no-cache
@@ -373,7 +373,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:02 GMT
+      - Thu, 07 Jul 2022 22:09:19 GMT
       expires:
       - '-1'
       pragma:
@@ -392,7 +392,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlESFRDQ0FnV2dBd0lCQWdJSVo3L1hBUmdxQm9rd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJ3TlRKblpUWjNNek4wTTNkaWJXNWtNQjRYRFRJeU1EVXdNakUzTlRBd01Wb1hEVEl5DQpNRFV3TmpFM05UQXdNVm93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSd05USm5aVFozTXpOME0zZGliVzVrDQpNSUlCSVRBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE0QU1JSUJDUUtDQVFBd0FTYzJZTW5DdEVTa0l4WjZ2N1RVDQozL01rWTFZb3Vtd3o2eDM5N01sMVl6Z2dZZmpvVis3cGxsQzlQRWhVSFVNYUJGNHZTazhFUzR1OXB2bkFBeUZzDQpNcXdkZ2pDai9CUE1adTBoL0N2anhod0dZTnd3aVpFOGV0Vmd4TEt1VGQzQ0xQVWU3REpoYnZYazR1TnNrbmpBDQpjZXFNK1FEYmoxRlFCSE13QXlFYnVSakRKTjZwQXY1VGc5RVEvek5tTHNrZERMY3d3R0RzVWRmOElER1ZpYkVqDQpFdWlyK29WbnZ1TWJod09HbkNJamVObjg3dnI4S2V5Nm1tcGtYVnVhNUxHQkRHL0cza2hHd2FvdjVSY1ExUmJPDQp5QUNJQ2haM3V3U1BaOHhoYkRIcndnSjRnQnhqaGowZU9lNy9JVHBkVlo4Y095RDdxNjRFb3UyYm4yWk9RZ0RSDQpBZ01CQUFHalZqQlVNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUV3SFFZRFZSME9CQllFRk5vNW8rNWVhMHNODQpNbFcvNzVWZ0dKQ3YyQWNKTUI4R0ExVWRJd1FZTUJhQUZObzVvKzVlYTBzTk1sVy83NVZnR0pDdjJBY0pNQTBHDQpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQVptaUJpMVFmRDJab0Q4V29SY0VNRUxUbTI2OFFkaDlKMTgwWXlqakJ3DQpJMnRQeXpSUGNXczlVd1ZuSUhJK21rUHBFTUxxeEplM0E3a3owRnEzeXU5bVR2Z1NobStaYjBPNnhEWjdCQTVNDQpnamZ5Z0xqOXc4YWJNd2JQcnFJWU9NMEVKenR6dXA5cDQwZ1E4b1NmY3owcm9FYS9SZVdTN2oxMVoxeXo0VnN4DQpFbEtRekFpdkRMRWFPZ3RLQ0M4OTI1Lzg1RFltbHJyNGF0SjRWaXQ4T2w2N3NBeWNlR1paZ2U5bWxrODU0UkZxDQphSVRTbm5COUVmaFFpaHIzU2lRS2xuVHpGdnEza2picENUejhqa2FSb3U3a0JtQW9icmZld2l0d1lNTTRKdmlhDQpSMTloeW1EUit6M3JBRUpyT2FVN2g1SmgwV3ZuM2MvLzRjVnc5M3NlSTFmLw0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K",
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWZESUErK2dqYUtFd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreE4xb1hEVEl5DQpNRGN4TURJeU1Ea3hOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSamJHRnphSEowZEdabGJYUm9ZV05xDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXhZTVJQeGJVbk9tQmp2WCtFeG1kDQpFNlZ5NjRrQlFHeXZPejRKSmt6bHB5NTJhbytvS1c3a0FCRzljZFBZREtzd0FTY1ZzME5SUi9NM2FHdEZOK0hRDQpialhMaU4yT0F3R0ZSSmdObDFKaGxDUXpGTUNnaXBIczRkVzhQd21lcnlLMTJ0ekJOaTBuWUxKN1BlQXowdWpPDQpHOFBCZmF0dTBmeWVxNi9lc1FoUGI5ZFcwNkRhWGF6NTdVdXhYbXZCL2RISDQ0VFcvYVZFSm0zeDRocHZLU2VWDQpQZnFwRkFZMEdaNUYxdVR5MmcwVG5OTCsyamtBMXNKYW1iTFBJQ0NNbXhPOExLZmxpYjdqeHNRb3BhV1R5VnV0DQphSEZXenR0V29wWURkSzdqMlNIdUNnNDFIQlF3QkZQdTI3WFY1aDlia3BMT0JlQisxTElCdWFmc2UvcC8xcVplDQord0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUFuQ2pKTzllQnNLVXBPNXJTOUU2T2oxdHFua0hmDQpVc1FtVk1kZmx2b0Ivem5YckRvQVFHTnh6ajIrK3JnZHhDWngxQm4vSzRremJqaWNBNHlsUElsREQ1L3ZWalgrDQpPb3JSNDh5Szk5aGtQcWlvaWZTZTUwNWZaSHNDUVFnVTM2ajlwRThkMVpGQVdlZmJteHUxcGpWTUt4T01VcjF4DQpSOWE5OUZOK0l4ZWMycUtzaENUZmxmeDlJZjVoc3ptdFE2YjBxbnhSZDVhMExnK04zZHAvUHRvbFUxVitaS0xoDQpydkRHdjh6N2s3SUVZbU9iemRCczdsSitEaWFPK1gwWGNGSzhkSmw0SmFvRFNlWWJmZHNISktaWkpDTWx5Z0pBDQpDT0lPV0pVWUhLMThsY1hMYmdTdFBBUzlaNXBtNVg0cXZVMnJuYWVKNUVEZ00yRGNJQzRjK2NDaQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K",
       "isVerified": true}'
     headers:
       Accept:
@@ -404,21 +404,21 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1583'
+      - '1423'
       Content-Type:
       - application/json
       ParameterSetName:
       - --dps-name -g --name -p --verified
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000005","expiry":"Fri, 06 May 2022
-        17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:04 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2Y2VhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRjMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:20 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBjNTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTkwMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -427,7 +427,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:04 GMT
+      - Thu, 07 Jul 2022 22:09:21 GMT
       expires:
       - '-1'
       pragma:
@@ -461,17 +461,17 @@ interactions:
       ParameterSetName:
       - --dps-name -g
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates?api-version=2021-10-15
   response:
     body:
-      string: '{"value":[{"properties":{"subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:03 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI="},{"properties":{"subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:04 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2Y2VhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRjMDAwMCI="}]}'
+      string: '{"value":[{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:19 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI="},{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:20 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBjNTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTkwMDAwMCI="}]}'
     headers:
       cache-control:
       - no-cache
@@ -480,7 +480,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:05 GMT
+      - Thu, 07 Jul 2022 22:09:21 GMT
       expires:
       - '-1'
       pragma:
@@ -512,15 +512,15 @@ interactions:
       ParameterSetName:
       - --dps-name -g --name
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000005","expiry":"Fri, 06 May 2022
-        17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:03 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:19 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -529,7 +529,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:06 GMT
+      - Thu, 07 Jul 2022 22:09:22 GMT
       expires:
       - '-1'
       pragma:
@@ -561,17 +561,17 @@ interactions:
       ParameterSetName:
       - --dps-name -g --name -p --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates?api-version=2021-10-15
   response:
     body:
-      string: '{"value":[{"properties":{"subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:03 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI="},{"properties":{"subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:04 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2Y2VhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRjMDAwMCI="}]}'
+      string: '{"value":[{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:19 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI="},{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:20 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBjNTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTkwMDAwMCI="}]}'
     headers:
       cache-control:
       - no-cache
@@ -580,7 +580,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:06 GMT
+      - Thu, 07 Jul 2022 22:09:23 GMT
       expires:
       - '-1'
       pragma:
@@ -599,7 +599,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlESFRDQ0FnV2dBd0lCQWdJSVo3L1hBUmdxQm9rd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJ3TlRKblpUWjNNek4wTTNkaWJXNWtNQjRYRFRJeU1EVXdNakUzTlRBd01Wb1hEVEl5DQpNRFV3TmpFM05UQXdNVm93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSd05USm5aVFozTXpOME0zZGliVzVrDQpNSUlCSVRBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE0QU1JSUJDUUtDQVFBd0FTYzJZTW5DdEVTa0l4WjZ2N1RVDQozL01rWTFZb3Vtd3o2eDM5N01sMVl6Z2dZZmpvVis3cGxsQzlQRWhVSFVNYUJGNHZTazhFUzR1OXB2bkFBeUZzDQpNcXdkZ2pDai9CUE1adTBoL0N2anhod0dZTnd3aVpFOGV0Vmd4TEt1VGQzQ0xQVWU3REpoYnZYazR1TnNrbmpBDQpjZXFNK1FEYmoxRlFCSE13QXlFYnVSakRKTjZwQXY1VGc5RVEvek5tTHNrZERMY3d3R0RzVWRmOElER1ZpYkVqDQpFdWlyK29WbnZ1TWJod09HbkNJamVObjg3dnI4S2V5Nm1tcGtYVnVhNUxHQkRHL0cza2hHd2FvdjVSY1ExUmJPDQp5QUNJQ2haM3V3U1BaOHhoYkRIcndnSjRnQnhqaGowZU9lNy9JVHBkVlo4Y095RDdxNjRFb3UyYm4yWk9RZ0RSDQpBZ01CQUFHalZqQlVNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUV3SFFZRFZSME9CQllFRk5vNW8rNWVhMHNODQpNbFcvNzVWZ0dKQ3YyQWNKTUI4R0ExVWRJd1FZTUJhQUZObzVvKzVlYTBzTk1sVy83NVZnR0pDdjJBY0pNQTBHDQpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQVptaUJpMVFmRDJab0Q4V29SY0VNRUxUbTI2OFFkaDlKMTgwWXlqakJ3DQpJMnRQeXpSUGNXczlVd1ZuSUhJK21rUHBFTUxxeEplM0E3a3owRnEzeXU5bVR2Z1NobStaYjBPNnhEWjdCQTVNDQpnamZ5Z0xqOXc4YWJNd2JQcnFJWU9NMEVKenR6dXA5cDQwZ1E4b1NmY3owcm9FYS9SZVdTN2oxMVoxeXo0VnN4DQpFbEtRekFpdkRMRWFPZ3RLQ0M4OTI1Lzg1RFltbHJyNGF0SjRWaXQ4T2w2N3NBeWNlR1paZ2U5bWxrODU0UkZxDQphSVRTbm5COUVmaFFpaHIzU2lRS2xuVHpGdnEza2picENUejhqa2FSb3U3a0JtQW9icmZld2l0d1lNTTRKdmlhDQpSMTloeW1EUit6M3JBRUpyT2FVN2g1SmgwV3ZuM2MvLzRjVnc5M3NlSTFmLw0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}'
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWZESUErK2dqYUtFd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreE4xb1hEVEl5DQpNRGN4TURJeU1Ea3hOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSamJHRnphSEowZEdabGJYUm9ZV05xDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXhZTVJQeGJVbk9tQmp2WCtFeG1kDQpFNlZ5NjRrQlFHeXZPejRKSmt6bHB5NTJhbytvS1c3a0FCRzljZFBZREtzd0FTY1ZzME5SUi9NM2FHdEZOK0hRDQpialhMaU4yT0F3R0ZSSmdObDFKaGxDUXpGTUNnaXBIczRkVzhQd21lcnlLMTJ0ekJOaTBuWUxKN1BlQXowdWpPDQpHOFBCZmF0dTBmeWVxNi9lc1FoUGI5ZFcwNkRhWGF6NTdVdXhYbXZCL2RISDQ0VFcvYVZFSm0zeDRocHZLU2VWDQpQZnFwRkFZMEdaNUYxdVR5MmcwVG5OTCsyamtBMXNKYW1iTFBJQ0NNbXhPOExLZmxpYjdqeHNRb3BhV1R5VnV0DQphSEZXenR0V29wWURkSzdqMlNIdUNnNDFIQlF3QkZQdTI3WFY1aDlia3BMT0JlQisxTElCdWFmc2UvcC8xcVplDQord0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUFuQ2pKTzllQnNLVXBPNXJTOUU2T2oxdHFua0hmDQpVc1FtVk1kZmx2b0Ivem5YckRvQVFHTnh6ajIrK3JnZHhDWngxQm4vSzRremJqaWNBNHlsUElsREQ1L3ZWalgrDQpPb3JSNDh5Szk5aGtQcWlvaWZTZTUwNWZaSHNDUVFnVTM2ajlwRThkMVpGQVdlZmJteHUxcGpWTUt4T01VcjF4DQpSOWE5OUZOK0l4ZWMycUtzaENUZmxmeDlJZjVoc3ptdFE2YjBxbnhSZDVhMExnK04zZHAvUHRvbFUxVitaS0xoDQpydkRHdjh6N2s3SUVZbU9iemRCczdsSitEaWFPK1gwWGNGSzhkSmw0SmFvRFNlWWJmZHNISktaWkpDTWx5Z0pBDQpDT0lPV0pVWUhLMThsY1hMYmdTdFBBUzlaNXBtNVg0cXZVMnJuYWVKNUVEZ00yRGNJQzRjK2NDaQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}'
     headers:
       Accept:
       - application/json
@@ -610,23 +610,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1563'
+      - '1403'
       Content-Type:
       - application/json
       If-Match:
-      - IjA1MDA2YmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRiMDAwMCI=
+      - IjQ5MDA3MDAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OThmMDAwMCI=
       ParameterSetName:
       - --dps-name -g --name -p --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000005","expiry":"Fri, 06 May 2022
-        17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:08 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2ZGVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUwMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:25 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBkZTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk0MDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -635,7 +635,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:08 GMT
+      - Thu, 07 Jul 2022 22:09:24 GMT
       expires:
       - '-1'
       pragma:
@@ -669,28 +669,28 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - IjA1MDA2ZGVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUwMDAwMCI=
+      - IjQ5MDBkZTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk0MDAwMCI=
       ParameterSetName:
       - --dps-name -g -n --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003/generateVerificationCode?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"verificationCode":"7D07A6A51F8AF1469499A1D92074D629894BE9FA8A013E49","subject":"TESTCERT000005","expiry":"Fri,
-        06 May 2022 17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":false,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:09 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlESFRDQ0FnV2dBd0lCQWdJSVo3L1hBUmdxQm9rd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJ3TlRKblpUWjNNek4wTTNkaWJXNWtNQjRYRFRJeU1EVXdNakUzTlRBd01Wb1hEVEl5DQpNRFV3TmpFM05UQXdNVm93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSd05USm5aVFozTXpOME0zZGliVzVrDQpNSUlCSVRBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE0QU1JSUJDUUtDQVFBd0FTYzJZTW5DdEVTa0l4WjZ2N1RVDQozL01rWTFZb3Vtd3o2eDM5N01sMVl6Z2dZZmpvVis3cGxsQzlQRWhVSFVNYUJGNHZTazhFUzR1OXB2bkFBeUZzDQpNcXdkZ2pDai9CUE1adTBoL0N2anhod0dZTnd3aVpFOGV0Vmd4TEt1VGQzQ0xQVWU3REpoYnZYazR1TnNrbmpBDQpjZXFNK1FEYmoxRlFCSE13QXlFYnVSakRKTjZwQXY1VGc5RVEvek5tTHNrZERMY3d3R0RzVWRmOElER1ZpYkVqDQpFdWlyK29WbnZ1TWJod09HbkNJamVObjg3dnI4S2V5Nm1tcGtYVnVhNUxHQkRHL0cza2hHd2FvdjVSY1ExUmJPDQp5QUNJQ2haM3V3U1BaOHhoYkRIcndnSjRnQnhqaGowZU9lNy9JVHBkVlo4Y095RDdxNjRFb3UyYm4yWk9RZ0RSDQpBZ01CQUFHalZqQlVNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUV3SFFZRFZSME9CQllFRk5vNW8rNWVhMHNODQpNbFcvNzVWZ0dKQ3YyQWNKTUI4R0ExVWRJd1FZTUJhQUZObzVvKzVlYTBzTk1sVy83NVZnR0pDdjJBY0pNQTBHDQpDU3FHU0liM0RRRUJDd1VBQTRJQkFRQVptaUJpMVFmRDJab0Q4V29SY0VNRUxUbTI2OFFkaDlKMTgwWXlqakJ3DQpJMnRQeXpSUGNXczlVd1ZuSUhJK21rUHBFTUxxeEplM0E3a3owRnEzeXU5bVR2Z1NobStaYjBPNnhEWjdCQTVNDQpnamZ5Z0xqOXc4YWJNd2JQcnFJWU9NMEVKenR6dXA5cDQwZ1E4b1NmY3owcm9FYS9SZVdTN2oxMVoxeXo0VnN4DQpFbEtRekFpdkRMRWFPZ3RLQ0M4OTI1Lzg1RFltbHJyNGF0SjRWaXQ4T2w2N3NBeWNlR1paZ2U5bWxrODU0UkZxDQphSVRTbm5COUVmaFFpaHIzU2lRS2xuVHpGdnEza2picENUejhqa2FSb3U3a0JtQW9icmZld2l0d1lNTTRKdmlhDQpSMTloeW1EUit6M3JBRUpyT2FVN2g1SmgwV3ZuM2MvLzRjVnc5M3NlSTFmLw0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2ZWVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUxMDAwMCI="}'
+      string: '{"properties":{"verificationCode":"C237D1FAA0696F8365A11A4ACE2046CA4FA6597D1EF7C23C","subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:26 GMT","certificate":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDeGpDQ0FhNmdBd0lCQWdJSWZESUErK2dqYUtFd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreE4xb1hEVEl5DQpNRGN4TURJeU1Ea3hOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSamJHRnphSEowZEdabGJYUm9ZV05xDQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXhZTVJQeGJVbk9tQmp2WCtFeG1kDQpFNlZ5NjRrQlFHeXZPejRKSmt6bHB5NTJhbytvS1c3a0FCRzljZFBZREtzd0FTY1ZzME5SUi9NM2FHdEZOK0hRDQpialhMaU4yT0F3R0ZSSmdObDFKaGxDUXpGTUNnaXBIczRkVzhQd21lcnlLMTJ0ekJOaTBuWUxKN1BlQXowdWpPDQpHOFBCZmF0dTBmeWVxNi9lc1FoUGI5ZFcwNkRhWGF6NTdVdXhYbXZCL2RISDQ0VFcvYVZFSm0zeDRocHZLU2VWDQpQZnFwRkFZMEdaNUYxdVR5MmcwVG5OTCsyamtBMXNKYW1iTFBJQ0NNbXhPOExLZmxpYjdqeHNRb3BhV1R5VnV0DQphSEZXenR0V29wWURkSzdqMlNIdUNnNDFIQlF3QkZQdTI3WFY1aDlia3BMT0JlQisxTElCdWFmc2UvcC8xcVplDQord0lEQVFBQk1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUFuQ2pKTzllQnNLVXBPNXJTOUU2T2oxdHFua0hmDQpVc1FtVk1kZmx2b0Ivem5YckRvQVFHTnh6ajIrK3JnZHhDWngxQm4vSzRremJqaWNBNHlsUElsREQ1L3ZWalgrDQpPb3JSNDh5Szk5aGtQcWlvaWZTZTUwNWZaSHNDUVFnVTM2ajlwRThkMVpGQVdlZmJteHUxcGpWTUt4T01VcjF4DQpSOWE5OUZOK0l4ZWMycUtzaENUZmxmeDlJZjVoc3ptdFE2YjBxbnhSZDVhMExnK04zZHAvUHRvbFUxVitaS0xoDQpydkRHdjh6N2s3SUVZbU9iemRCczdsSitEaWFPK1gwWGNGSzhkSmw0SmFvRFNlWWJmZHNISktaWkpDTWx5Z0pBDQpDT0lPV0pVWUhLMThsY1hMYmdTdFBBUzlaNXBtNVg0cXZVMnJuYWVKNUVEZ00yRGNJQzRjK2NDaQ0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBkZjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk2MDAwMCI="}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2205'
+      - '2045'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:09 GMT
+      - Thu, 07 Jul 2022 22:09:26 GMT
       expires:
       - '-1'
       pragma:
@@ -711,7 +711,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlEQWpDQ0FlcWdBd0lCQWdJSWFHQTM5NHJWYS9Zd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJ3TlRKblpUWjNNek4wTTNkaWJXNWtNQjRYRFRJeU1EVXdNakUzTlRBeE1Gb1hEVEl5DQpNRFV3TmpFM05UQXhNRm93T3pFNU1EY0dBMVVFQXd3d04wUXdOMEUyUVRVeFJqaEJSakUwTmprME9UbEJNVVE1DQpNakEzTkVRMk1qazRPVFJDUlRsR1FUaEJNREV6UlRRNU1JSUJJVEFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUTRBDQpNSUlCQ1FLQ0FRQTJiODdRb3B6d1p3aUE0QWJvYnpyWEd4QlJoNkZtTzhaVWQxNUNRd3hCUlFYVGpTSGhwTGVUDQo0WXIvdWNvM3N2cTF0VXZnM2JZNFp3bnVIVTgvYXpIRlYxS2tIRmlaRE9JRVpSNGwvM0hNQU0wazZwTi9ReTdnDQpBV1FBQlZZVDlkKzRFTFBjTklaSXhjL1A1M1AzV24veGpBSUtUZmJrOXNRS0wvcksxc3o0M3lnWUpIMTJnaGJkDQpFNmpldEl5Y3JRWmtIWnRZMnJiTVRtVVFCOW45bmZNbkZWTGNPcmp2MDJNdWwrVVc2OG9KbXpjaVRkTnRQUXI1DQpmaG1rOGpMZ2cyR283bjRQVnduNUppeXhJdW1PRmNyWS9uRktjaFZ5UXI5UDZSNlEwZ2pFZ0xRMEtvKzNwKzdUDQpiWG82TEZWbWZ2Nks4ZmQrMzJ4ZkoyOCtTZ1BvL3F3bEFnTUJBQUdqSXpBaE1COEdBMVVkSXdRWU1CYUFGTm81DQpvKzVlYTBzTk1sVy83NVZnR0pDdjJBY0pNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFYNFhPZGhoczFYaGlpDQpRTkpGSXEwVjlPSTljaDRrZk80enV5QWtYM2N2ci9hVm9WWForZFBtVTRQSnYxb0dEUTB6TWYvNWs3cTk1bkJhDQpMTTcxOVhOaDExMjVTTVRZMzBKZzJ3Ylc3SzZRRVFURWZmZUQ2RXlNanhmMjFhNHFzc1Zxdyt5RUxpWHkzN0t0DQpBcU1LQUF3NFhabTV0bXRvbks3VG5wNHA0VWFzcW50YzVaRDFldXlBSFN5WE9uR283V1dpWk9PVGtQNisxSE55DQpDcU03RGNtTVlrcHVCMjlnTi9SV1RNVWxGTUdyTkVJRXVid1ZwMC9NTVoxVGxvcFZqZ0hCUkJpOFB6ZlBqaXNXDQp6QldvMWJUNkhqNjBIWnMyQlp1dWgrN0YvNTkzbU9lK0tWRVF1YjRydXk4L1JpS2NheUJ2QWtnUkM3R29qa3o2DQpnSFlOOTM2Zg0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ0K"}'
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDM2pDQ0FjYWdBd0lCQWdJSWZheXVMMjhGMHFZd0RRWUpLb1pJaHZjTkFRRUxCUUF3SXpFaE1COEdBMVVFDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreU5sb1hEVEl5DQpNRGN4TURJeU1Ea3lObG93T3pFNU1EY0dBMVVFQXd3d1F6SXpOMFF4UmtGQk1EWTVOa1k0TXpZMVFURXhRVFJCDQpRMFV5TURRMlEwRTBSa0UyTlRrM1JERkZSamRETWpORE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBDQpNSUlCQ2dLQ0FRRUFwejhwcmhnQmoyeE5WY0ttRnN6TGw2aFNLbmpiWGQ4eGZlRG1kamF3NjQzcGpXSVhHT0xsDQpyNmJwRFpHazk2dWhiRitsczFkZElxeTBoRFZGeHBBSjczVkVubWYzS0QxNzVkQWJsbHpIdUQyTGF0d09KR2RqDQp4d1JmbkNwSDd3VzNPZDd1MmdXL1FnSGZBR1JERXlIcUZTcXFYSHB0Z1RlZGl6b2RZSE1xWFk1c3B4UE14Vk4xDQpUU2U2b1dzUjFVUHkyL1B5YjZPSDMzcHErbFg4M0RzVURhTzlyY2tvMWQxdWV3V1grQ1ZPaWlsalRZK3hwdVVBDQpQUzNkWW1JMHgvU3VXYVdaRVQ2WURhS3A3bU5KV1pna2tkQ1RROTFRb1FzOEc1Mjc4anFQWkxqT0tHOU5wOTZFDQpqT2xpcjNmZzRjdmo4WkNVNE81ck04dVp3N1laZ29aRlpRSURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCDQpBUUJndmk4eTFzaFFYWGdWRTdDWW5PenhCc2hMZDQvdlJYTzEwVzFDN3hLckNzS3hPN1haVE4vbXE2dlBKL0xtDQpuL0FrZW5OSkhtQzNESWE0bHhlejZaeWtza1h4dU1DMHoxNmlKR1BlckljZ2NzK2tSL0pFdTg1VVh3RHNsc2JJDQp5WCtYK3kzeUNpZUdDOWxlYVZOZHhiUjBUSTdrUUd6ZXVaQUVPenM4Y05ndXlYMElaUDdsdHBvaGJHNExuL0NODQpOS0lCUjl3M2tMKzI2blA1aUNRVWtwWnl1SHhmVkFiZkNTVUV6VGw3cWZoTUxUUXpBMU9WRmhyZGFrZWZLb09XDQpRVXNKNnVWN1dkNVlKZGNQdDdxMlNFengxazREeUpKaU1JM2ZDVmpQbDhpeC9rcEFyNEhGRnRLYjUxczJIcFp3DQoyWmVLYW4wdkx4QUR3eEhya2JYZURqdnANCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NCg=="}'
     headers:
       Accept:
       - application/json
@@ -722,23 +722,23 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1515'
+      - '1451'
       Content-Type:
       - application/json
       If-Match:
-      - IjA1MDA2ZWVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUxMDAwMCI=
+      - IjQ5MDBkZjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk2MDAwMCI=
       ParameterSetName:
       - --dps-name -g -n -p --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003/verify?api-version=2021-10-15
   response:
     body:
-      string: '{"properties":{"subject":"TESTCERT000005","expiry":"Fri, 06 May 2022
-        17:50:01 GMT","thumbprint":"D0529BF2D7CAF23CC15506B2A7F0F08F27A428A0","isVerified":true,"created":"Mon,
-        01 Jan 0001 00:00:00 GMT","updated":"Tue, 03 May 2022 17:50:10 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjA1MDA2ZmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUyMDAwMCI="}'
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:27 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBlNjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk3MDAwMCI="}'
     headers:
       cache-control:
       - no-cache
@@ -747,7 +747,113 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:11 GMT
+      - Thu, 07 Jul 2022 22:09:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot dps certificate create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --dps-name -g --name -p
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+        (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates?api-version=2021-10-15
+  response:
+    body:
+      string: '{"value":[{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:27 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003","name":"certificate000003","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBlNjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk3MDAwMCI="},{"properties":{"subject":"TESTCERT000006","expiry":"Sun,
+        10 Jul 2022 22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":true,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:20 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004","name":"verified-certificate-000004","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBjNTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTkwMDAwMCI="}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 07 Jul 2022 22:09:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"certificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQ0KTUlJQ3hqQ0NBYTZnQXdJQkFnSUlmRElBKytnamFLRXdEUVlKS29aSWh2Y05BUUVMQlFBd0l6RWhNQjhHQTFVRQ0NCkF3d1lWRVZUVkVORlVsUmpiR0Z6YUhKMGRHWmxiWFJvWVdOcU1CNFhEVEl5TURjd056SXlNRGt4TjFvWERUSXkNDQpNRGN4TURJeU1Ea3hOMW93SXpFaE1COEdBMVVFQXd3WVZFVlRWRU5GVWxSamJHRnphSEowZEdabGJYUm9ZV05xDQ0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF4WU1SUHhiVW5PbUJqdlgrRXhtZA0NCkU2Vnk2NGtCUUd5dk96NEpKa3pscHk1MmFvK29LVzdrQUJHOWNkUFlES3N3QVNjVnMwTlJSL00zYUd0Rk4rSFENDQpialhMaU4yT0F3R0ZSSmdObDFKaGxDUXpGTUNnaXBIczRkVzhQd21lcnlLMTJ0ekJOaTBuWUxKN1BlQXowdWpPDQ0KRzhQQmZhdHUwZnllcTYvZXNRaFBiOWRXMDZEYVhhejU3VXV4WG12Qi9kSEg0NFRXL2FWRUptM3g0aHB2S1NlVg0NClBmcXBGQVkwR1o1RjF1VHkyZzBUbk5MKzJqa0Exc0phbWJMUElDQ01teE84TEtmbGliN2p4c1FvcGFXVHlWdXQNDQphSEZXenR0V29wWURkSzdqMlNIdUNnNDFIQlF3QkZQdTI3WFY1aDlia3BMT0JlQisxTElCdWFmc2UvcC8xcVplDQ0KK3dJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFBbkNqSk85ZUJzS1VwTzVyUzlFNk9qMXRxbmtIZg0NClVzUW1WTWRmbHZvQi96blhyRG9BUUdOeHpqMisrcmdkeENaeDFCbi9LNGt6YmppY0E0eWxQSWxERDUvdlZqWCsNDQpPb3JSNDh5Szk5aGtQcWlvaWZTZTUwNWZaSHNDUVFnVTM2ajlwRThkMVpGQVdlZmJteHUxcGpWTUt4T01VcjF4DQ0KUjlhOTlGTitJeGVjMnFLc2hDVGZsZng5SWY1aHN6bXRRNmIwcW54UmQ1YTBMZytOM2RwL1B0b2xVMVYrWktMaA0NCnJ2REd2OHo3azdJRVltT2J6ZEJzN2xKK0RpYU8rWDBYY0ZLOGRKbDRKYW9EU2VZYmZkc0hKS1paSkNNbHlnSkENDQpDT0lPV0pVWUhLMThsY1hMYmdTdFBBUzlaNXBtNVg0cXZVMnJuYWVKNUVEZ00yRGNJQzRjK2NDaQ0NCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0NDQoNCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQ0NCk1JSUN4akNDQWE2Z0F3SUJBZ0lJZkRJQSsrZ2phS0V3RFFZSktvWklodmNOQVFFTEJRQXdJekVoTUI4R0ExVUUNDQpBd3dZVkVWVFZFTkZVbFJqYkdGemFISjBkR1psYlhSb1lXTnFNQjRYRFRJeU1EY3dOekl5TURreE4xb1hEVEl5DQ0KTURjeE1ESXlNRGt4TjFvd0l6RWhNQjhHQTFVRUF3d1lWRVZUVkVORlVsUmpiR0Z6YUhKMGRHWmxiWFJvWVdOcQ0NCk1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBeFlNUlB4YlVuT21CanZYK0V4bWQNDQpFNlZ5NjRrQlFHeXZPejRKSmt6bHB5NTJhbytvS1c3a0FCRzljZFBZREtzd0FTY1ZzME5SUi9NM2FHdEZOK0hRDQ0KYmpYTGlOMk9Bd0dGUkpnTmwxSmhsQ1F6Rk1DZ2lwSHM0ZFc4UHdtZXJ5SzEydHpCTmkwbllMSjdQZUF6MHVqTw0NCkc4UEJmYXR1MGZ5ZXE2L2VzUWhQYjlkVzA2RGFYYXo1N1V1eFhtdkIvZEhINDRUVy9hVkVKbTN4NGhwdktTZVYNDQpQZnFwRkFZMEdaNUYxdVR5MmcwVG5OTCsyamtBMXNKYW1iTFBJQ0NNbXhPOExLZmxpYjdqeHNRb3BhV1R5VnV0DQ0KYUhGV3p0dFdvcFlEZEs3ajJTSHVDZzQxSEJRd0JGUHUyN1hWNWg5YmtwTE9CZUIrMUxJQnVhZnNlL3AvMXFaZQ0NCit3SURBUUFCTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBQW5DakpPOWVCc0tVcE81clM5RTZPajF0cW5rSGYNDQpVc1FtVk1kZmx2b0Ivem5YckRvQVFHTnh6ajIrK3JnZHhDWngxQm4vSzRremJqaWNBNHlsUElsREQ1L3ZWalgrDQ0KT29yUjQ4eUs5OWhrUHFpb2lmU2U1MDVmWkhzQ1FRZ1UzNmo5cEU4ZDFaRkFXZWZibXh1MXBqVk1LeE9NVXIxeA0NClI5YTk5Rk4rSXhlYzJxS3NoQ1RmbGZ4OUlmNWhzem10UTZiMHFueFJkNWEwTGcrTjNkcC9QdG9sVTFWK1pLTGgNDQpydkRHdjh6N2s3SUVZbU9iemRCczdsSitEaWFPK1gwWGNGSzhkSmw0SmFvRFNlWWJmZHNISktaWkpDTWx5Z0pBDQ0KQ09JT1dKVVlISzE4bGNYTGJnU3RQQVM5WjVwbTVYNHF2VTJybmFlSjVFRGdNMkRjSUM0YytjQ2kNDQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQ0K"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot dps certificate create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2835'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --dps-name -g --name -p
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+        (Windows-10-10.0.22000-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate-000005?api-version=2021-10-15
+  response:
+    body:
+      string: '{"properties":{"subject":"TESTCERT000006","expiry":"Sun, 10 Jul 2022
+        22:09:17 GMT","thumbprint":"A50989DEBAC33B27B6AF8E0075E46964D6BD3823","isVerified":false,"created":"Mon,
+        01 Jan 0001 00:00:00 GMT","updated":"Thu, 07 Jul 2022 22:09:29 GMT","certificate":null},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate-000005","name":"certificate-000005","type":"Microsoft.Devices/provisioningServices/Certificates","etag":"IjQ5MDBlYjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk5MDAwMCI="}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '595'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 07 Jul 2022 22:09:28 GMT
       expires:
       - '-1'
       pragma:
@@ -781,11 +887,11 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - IjA1MDA2ZmVhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjUyMDAwMCI=
+      - IjQ5MDBlNjAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTk3MDAwMCI=
       ParameterSetName:
       - --dps-name -g --name --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate000003?api-version=2021-10-15
@@ -798,7 +904,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 03 May 2022 17:50:12 GMT
+      - Thu, 07 Jul 2022 22:09:30 GMT
       expires:
       - '-1'
       pragma:
@@ -828,11 +934,11 @@ interactions:
       Content-Length:
       - '0'
       If-Match:
-      - IjA1MDA2Y2VhLTAwMDAtMDcwMC0wMDAwLTYyNzE2YjRjMDAwMCI=
+      - IjQ5MDBjNTAzLTAwMDAtMDcwMC0wMDAwLTYyYzc1OTkwMDAwMCI=
       ParameterSetName:
       - --dps-name -g --name --etag
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/verified-certificate-000004?api-version=2021-10-15
@@ -845,7 +951,54 @@ interactions:
       content-length:
       - '0'
       date:
-      - Tue, 03 May 2022 17:50:14 GMT
+      - Thu, 07 Jul 2022 22:09:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - iot dps certificate delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      If-Match:
+      - '*'
+      ParameterSetName:
+      - --dps-name -g --name --etag
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+        (Windows-10-10.0.22000-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/certificates/certificate-000005?api-version=2021-10-15
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 07 Jul 2022 22:09:34 GMT
       expires:
       - '-1'
       pragma:
@@ -877,7 +1030,7 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002?api-version=2021-10-15
@@ -886,7 +1039,7 @@ interactions:
       string: 'null'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfYTUwYjEwYzUtOTQyMC00MDE4LWJiZTQtODYwZjIyNTZhNmQyO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfMDI1MjU1NTUtNzExZS00YzQ0LWJlNDktYjFkOWViN2VkYTJmO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
       cache-control:
       - no-cache
       content-length:
@@ -894,11 +1047,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:15 GMT
+      - Thu, 07 Jul 2022 22:09:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfYTUwYjEwYzUtOTQyMC00MDE4LWJiZTQtODYwZjIyNTZhNmQyO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfMDI1MjU1NTUtNzExZS00YzQ0LWJlNDktYjFkOWViN2VkYTJmO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15
       pragma:
       - no-cache
       server:
@@ -926,10 +1079,10 @@ interactions:
       ParameterSetName:
       - -g -n
       User-Agent:
-      - AZURECLI/2.36.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
+      - AZURECLI/2.38.0 azsdk-python-mgmt-iothubprovisioningservices/1.1.0 Python/3.8.3
         (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfYTUwYjEwYzUtOTQyMC00MDE4LWJiZTQtODYwZjIyNTZhNmQyO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Devices/provisioningServices/dps000002/operationResults/aWQ9b3NfaWRfMDI1MjU1NTUtNzExZS00YzQ0LWJlNDktYjFkOWViN2VkYTJmO3JlZ2lvbj13ZXN0dXM=?api-version=2021-10-15&asyncinfo
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -941,7 +1094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 03 May 2022 17:50:31 GMT
+      - Thu, 07 Jul 2022 22:09:50 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
@@ -6,14 +6,15 @@
 
 from azure.cli.testsdk import ResourceGroupPreparer, ScenarioTest
 
-from OpenSSL import crypto, SSL
-from os.path import exists, join
-from azure.cli.command_modules.iot.tests.latest._test_utils import _create_test_cert, _delete_test_cert, _create_verification_cert
+from azure.cli.command_modules.iot.tests.latest._test_utils import (
+    _create_test_cert, _delete_test_cert, _create_verification_cert, _create_fake_chain_cert
+)
 import random
 
 VERIFICATION_FILE = "verify.cer"
 CERT_FILE = "testcert.cer"
 KEY_FILE = "testkey.pvk"
+CHAIN_FILE = "testcert-chain.pem"
 MAX_INT = 9223372036854775807
 
 
@@ -22,15 +23,17 @@ class IotHubCertificateTest(ScenarioTest):
         super(IotHubCertificateTest, self).__init__('test_certificate_lifecycle')
         self.hub_name = 'iot-hub-for-cert-test'
         _create_test_cert(CERT_FILE, KEY_FILE, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, MAX_INT))
+        _create_fake_chain_cert(CERT_FILE, CHAIN_FILE)
 
     def __del__(self):
-        _delete_test_cert(CERT_FILE, KEY_FILE, VERIFICATION_FILE)
+        _delete_test_cert([CERT_FILE, KEY_FILE, VERIFICATION_FILE, CHAIN_FILE])
 
     @ResourceGroupPreparer()
     def test_certificate_lifecycle(self, resource_group):
         hub = self._create_test_hub(resource_group)
         cert_name = self.create_random_name(prefix='certificate-', length=48)
         cert_name_verified = self.create_random_name(prefix='verified-certificate-', length=48)
+        chain_name = self.create_random_name(prefix='certificate-', length=48)
 
         # Create certificate
         self.cmd('iot hub certificate create --hub-name {0} -g {1} -n {2} -p {3}'.format(hub, resource_group, cert_name, CERT_FILE),
@@ -72,9 +75,15 @@ class IotHubCertificateTest(ScenarioTest):
                         checks=[self.check('name', cert_name),
                                 self.check('properties.isVerified', True)]).get_output_in_json()['etag']
 
+        # Create certificate from a chain - test how certificate is encoded in the service call
+        self.cmd('iot hub certificate create --hub-name {0} -g {1} -n {2} -p {3}'.format(hub, resource_group, chain_name, CHAIN_FILE),
+                 checks=[self.check('name', chain_name),
+                         self.check('properties.isVerified', False)])
+
         # Delete certificates
         self.cmd('iot hub certificate delete --hub-name {0} -g {1} -n {2} --etag {3}'.format(hub, resource_group, cert_name, etag))
         self.cmd('iot hub certificate delete --hub-name {0} -g {1} -n {2} --etag {3}'.format(hub, resource_group, cert_name_verified, etag_verified))
+        self.cmd('iot hub certificate delete --hub-name {0} -g {1} -n {2} --etag *'.format(hub, resource_group, chain_name))
 
     def _create_test_hub(self, resource_group):
         hub = self.create_random_name(prefix='iot-hub-for-cert-test', length=48)


### PR DESCRIPTION
**Related command**
`az iot dps certificate create`
`az iot hub certificate create`
`az iot dps certificate update`
`az iot hub certificate update`

**Description**
I am changing how certificates are opened to the older way of just encoding the contents to a b64 string and sending that string to the service. The service accepts more certificates this way. This is a response to a customer issue.

**Testing Guide**
Added a test case to both the iot hub and dps certificate lifecycle tests. An extra certificate, which just has the certificate body copied twice, is created to mimic a chain certificate. This chain certificate is uploaded as a test that the service can handle the certificate (if the certificate body is not encoded in a b64 string, it would fail). 

The test recordings for test_dps_certificate_lifecycle and test_certificate_lifecycle were regenerated.
![image](https://user-images.githubusercontent.com/73560279/177880768-87aa17bf-a12d-429b-b4be-293c73e8f858.png)

if not encoded as a b64 
![image](https://user-images.githubusercontent.com/73560279/177881492-c28c5987-39b2-4a07-90d2-066e46727245.png)

Also ran `azdev test iot`
![image](https://user-images.githubusercontent.com/73560279/177880965-f0d39c4e-2bec-410b-adf5-29a929d4b97b.png)

**History Notes**
[IoT] Change certificate loading to encode to b64 strings by default

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
