### PR TITLE
[Container] Fix #20280: `az container create`: Allow environment variable interpolation in container group yaml

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/container/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/container/custom.py
@@ -356,23 +356,28 @@ def _get_diagnostics_from_workspace(cli_ctx, log_analytics_workspace):
 
     return None, {}
 
+
 yaml_env_var_matcher = re.compile(r'.*\$\{([^}^{]+)\}')
+
+
 def yaml_env_var_constructor(loader, node):
-  ''' Extract the matched value, expand env variable, and replace the match '''
-  env_matcher=re.compile(r"\$\{([^}^{]+)\}")
-  value = node.value
-  match = env_matcher.findall(value)
-  if match:
-    full_value = value
-    for env_var in match:
-        full_value = full_value.replace(
-            f'${{{env_var}}}', os.environ.get(env_var, env_var)
-        )
-    return full_value
-  return value
+    ''' Extract the matched value, expand env variable, and replace the match '''
+    env_matcher = re.compile(r"\$\{([^}^{]+)\}")
+    value = node.value
+    match = env_matcher.findall(value)
+    if match:
+        full_value = value
+        for env_var in match:
+            full_value = full_value.replace(
+                f'${{{env_var}}}', os.environ.get(env_var, env_var)
+            )
+        return full_value
+    return value
+
 
 yaml.add_implicit_resolver('!env_var', yaml_env_var_matcher, None, yaml.SafeLoader)
 yaml.add_constructor('!env_var', yaml_env_var_constructor, yaml.SafeLoader)
+
 
 # pylint: disable=unsupported-assignment-operation,protected-access
 def _create_update_from_file(cli_ctx, resource_group_name, name, location, file, no_wait):


### PR DESCRIPTION
**Related command**
`az container create`

**Description**<!--Mandatory-->
Fixes #20280

Allows environment variable interpolation in container group yaml. `${MY_ENV}` is replaced with the value of `MY_ENV` environment variable if present and not changed if the environment variable is not present. It works with a prefix or a suffix as well. For example, `secret-${MY_ENV}` or `${MY_ENV}-world` or `secret-${MY_ENV}-world` will work as well.

**Testing Guide**
```bash
export $AZ_RESOURCE_GROUP=azure-cli-dev
export $AZ_LOCATION=centralindia
az group create --location $AZ_LOCATION --name $AZ_RESOURCE_GROUP
export MY_ENV=hello
cat <<EOF > aci-nginx.yml
name: aci-nginx
apiVersion: '2021-10-01'
location: centralindia
properties: 
  containers: 
  - name: nginx
    properties: 
      image: nginx
      ports: 
      - protocol: TCP
        port: 80
      environmentVariables:
      - name: TEST_VAR
        value: ${MY_ENV}
      resources:
        requests:
          memoryInGB: 0.3
          cpu: 0.2
        limits:
          memoryInGB: 0.3
          cpu: 0.2
  ipAddress:
    ports:
    - protocol: TCP
      port: 80
    type: Public
    dnsNameLabel: azure-cli-dev
  osType: Linux
EOF
python src/azure-cli/azure/cli/ container create -g $AZ_RESOURCE_GROUP -f aci-nginx.yaml
```

Check the environment variable value once the container is created
![image](https://user-images.githubusercontent.com/52544819/177917839-97f54b0f-b844-4441-a5b5-06e6c2ae7a95.png)

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Container] `az container create`: Add environment variable interpolation in container group yaml

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
