### PR TITLE
[Compute] Fix #22654: `az vm/vmss run-command`: Fix the bug that `--protected-parameters` does not achieve the desired effect

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -2479,7 +2479,7 @@ def vm_run_command_create(client,
     if protected_parameters is not None:
         auto_arg_name_num = 0
         run_command['protected_parameters'] = []
-        for p in parameters:
+        for p in protected_parameters:
             if '=' in p:
                 n, v = p.split('=', 1)
             else:
@@ -2553,7 +2553,7 @@ def vm_run_command_update(client,
     if protected_parameters is not None:
         auto_arg_name_num = 0
         run_command['protected_parameters'] = []
-        for p in parameters:
+        for p in protected_parameters:
             if '=' in p:
                 n, v = p.split('=', 1)
             else:
@@ -4039,7 +4039,7 @@ def vmss_run_command_create(client,
     if protected_parameters is not None:
         auto_arg_name_num = 0
         run_command['protected_parameters'] = []
-        for p in parameters:
+        for p in protected_parameters:
             if '=' in p:
                 n, v = p.split('=', 1)
             else:
@@ -4115,7 +4115,7 @@ def vmss_run_command_update(client,
     if protected_parameters is not None:
         auto_arg_name_num = 0
         run_command['protected_parameters'] = []
-        for p in parameters:
+        for p in protected_parameters:
             if '=' in p:
                 n, v = p.split('=', 1)
             else:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In `az vm run-command` and `az vmss run-command` groups, parameter `--protected-parameters` does not achieve the desired effect. The value provided by `--protected-parameters` is ignored and the value of `--parameters` is used repeatedly..

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] Fix #22654: `az vm run-command create/update`: Parameter `--protected-parameters` does not achieve the desired effect
[Compute] `az vmss run-command create/update`: Parameter `--protected-parameters` does not achieve the desired effect

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
