### PR TITLE
[Keyvault] `az keyvault security-domain upload`: Fix `password must be bytes-like` for `--passwords`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -2420,7 +2420,7 @@ def _security_domain_gen_share_arrays(sd_wrapping_keys, passwords, shared_keys, 
 
         with open(private_key_path, 'rb') as f:
             pem_data = f.read()
-            password = passwords[private_key_index] if private_key_index < len(passwords) else None
+            password = passwords[private_key_index].encode(encoding="utf-8") if private_key_index < len(passwords) else None
             private_key = load_pem_private_key(pem_data, password=password, backend=default_backend())
 
         with open(cert_path, 'rb') as f:

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -2420,7 +2420,9 @@ def _security_domain_gen_share_arrays(sd_wrapping_keys, passwords, shared_keys, 
 
         with open(private_key_path, 'rb') as f:
             pem_data = f.read()
-            password = passwords[private_key_index].encode(encoding="utf-8") if private_key_index < len(passwords) else None
+            password = passwords[private_key_index] if private_key_index < len(passwords) else None
+            if password and not isinstance(password, bytes):
+                password = password.encode(encoding="utf-8")
             private_key = load_pem_private_key(pem_data, password=password, backend=default_backend())
 
         with open(cert_path, 'rb') as f:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault security-domain upload`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When uploading private keys with passphrase, it will raise exception:
```
> az keyvault security-domain upload --sd-exchange-key .\sdem.pem --hsm-name testhsm0713 --sd-file .\testhsm0527-SD.json --sd-wrapping-keys .\certs\ys_pass1.key .\certs\ys_pass2.key .\certs\ys_pass3.key --passwords 12345 1234 54321
password must be bytes-like
```

This PR should fix this.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
