### PR TITLE
[Core] Support specifying `telemetry.push_interval_in_hours` to force push telemetry cache file

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -44,7 +44,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'argcomplete~=1.8',
-    'azure-cli-telemetry==1.0.6.*',
+    'azure-cli-telemetry==1.0.7.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     'humanfriendly~=10.0',

--- a/src/azure-cli-telemetry/HISTORY.rst
+++ b/src/azure-cli-telemetry/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.0.7
++++++
+* Support specifying `telemetry.push_interval_in_hours` to force push telemetry cache file
+
 1.0.6
 +++++
 * Add `__version__` in `__init__.py`

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import stat
 import tempfile
+from knack.config import CLIConfig
 
 
 class RecordsCollection:
@@ -35,8 +36,13 @@ class RecordsCollection:
         if not os.path.isdir(folder):
             return
 
-        # sort the cache files base on their last modification time.
+        # Collect all cache.x files. If it has been a long time since last sent, also collect cache file itself.
         candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder) if fn != 'cache']
+        if os.path.exists(os.path.join(folder, 'cache')) and \
+                datetime.datetime.now() - self._last_sent > datetime.timedelta(hours=self._get_threshold_config()):
+            candidates.append(('cache', os.stat(os.path.join(folder, 'cache'))))
+
+        # sort the cache files base on their last modification time.
         candidates = [(fn, file_stat) for fn, file_stat in candidates if stat.S_ISREG(file_stat.st_mode)]
         candidates.sort(key=lambda pair: pair[1].st_mtime, reverse=True)  # move the newer cache file first
 
@@ -65,6 +71,12 @@ class RecordsCollection:
                       ignore_errors=True,
                       onerror=lambda _, p, tr: self._logger.error('Fail to remove file %s', p))
         self._logger.info('Remove directory %s', tmp)
+
+    def _get_threshold_config(self):
+        config = CLIConfig(config_dir=self._config_dir)
+        threshold = config.getint('telemetry', 'push_data_threshold', fallback=24)
+        # the threshold for push telemetry can't be less than 1 hour, default value is 24 hours
+        return threshold if threshold >= 1 else 24
 
     def _read_file(self, path):
         """ Read content of a telemetry cache file and parse them into records. """

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -28,6 +28,7 @@ class RecordsCollection:
     def next_send(self):
         return self._next_send
 
+    # pylint: disable=line-too-long
     def snapshot_and_read(self):
         """ Scan the telemetry cache files and move all the rotated files to a temp directory. """
         from azure.cli.telemetry.const import TELEMETRY_CACHE_DIR
@@ -37,10 +38,8 @@ class RecordsCollection:
             return
 
         # Collect all cache.x files. If it has been a long time since last sent, also collect cache file itself.
-        candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder) if fn != 'cache']
-        if os.path.exists(os.path.join(folder, 'cache')) and \
-                datetime.datetime.now() - self._last_sent > datetime.timedelta(hours=self._get_threshold_config()):
-            candidates.append(('cache', os.stat(os.path.join(folder, 'cache'))))
+        include_cache = datetime.datetime.now() - self._last_sent > datetime.timedelta(hours=self._get_threshold_config())
+        candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder) if include_cache or fn != 'cache']
 
         # sort the cache files base on their last modification time.
         candidates = [(fn, file_stat) for fn, file_stat in candidates if stat.S_ISREG(file_stat.st_mode)]

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
@@ -35,19 +35,21 @@ class TestRecordsCollection(unittest.TestCase):
         # take snapshot and move the files
         collection.snapshot_and_read()
 
-        # all but one file, the 'cache' file, is moved.
-        self.assert_cache_files_count(1)
+        # all files are moved, including the 'cache' file.
+        self.assert_cache_files_count(0)
 
         # total records
-        self.assertEqual(1750, len([r for r in collection]))
+        self.assertEqual(1758, len([r for r in collection]))
 
     def test_create_records_collection_with_last_send(self):
-        last_send = datetime.datetime(year=2018, month=6, day=5, hour=16, minute=36, second=7)
+        last_send = datetime.datetime.now() - datetime.timedelta(hours=6)
         collection = RecordsCollection(last_send, self.work_dir)
         collection.snapshot_and_read()
 
+        # the threshold for pushing 'cache' file is 24, so 'cache' file should not be moved
         self.assert_cache_files_count(1)
-        self.assertEqual(453, len([r for r in collection]))
+        # no new records since last_send
+        self.assertEqual(0, len([r for r in collection]))
 
     def test_create_records_collection_against_missing_config_folder(self):
         collection = RecordsCollection(datetime.datetime.min, tempfile.mktemp())

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = "1.0.6"
+VERSION = "1.0.7"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.38.0
-azure-cli-telemetry==1.0.6
+azure-cli-telemetry==1.0.7
 azure-cli==2.38.0
 azure-common==1.1.22
 azure-core==1.24.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.38.0
-azure-cli-telemetry==1.0.6
+azure-cli-telemetry==1.0.7
 azure-cli==2.38.0
 azure-common==1.1.22
 azure-core==1.24.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.38.0
-azure-cli-telemetry==1.0.6
+azure-cli-telemetry==1.0.7
 azure-cli==2.38.0
 azure-common==1.1.22
 azure-core==1.24.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
CLI telemetry will only be uploaded when:
- 10 mins after last sync
- local cache file is larger than 128k and has been rotated with cache.1 cache.2 files

This could cause long time delay for pushing telemetry for customers using CLI not that frequently. It could take several days.

This PR set a threshold for cache file upload. If it has been 24 hours since last push, then cache file will be uploaded even if it's less than 128k.

The threshold can be set manually with `az config set telemetry.push_data_threshold=N`. It only takes effects when N >= 1. Default vaule for N is 24.



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
