### PR TITLE
{Role} `az ad sp create-for-rbac`: Remove curly brackets from example command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -496,9 +496,9 @@ examples:
   - name: Create without role assignment.
     text: az ad sp create-for-rbac
   - name: Create using a custom display name.
-    text: az ad sp create-for-rbac -n "MyApp"
+    text: az ad sp create-for-rbac -n MyApp
   - name: Create with a Contributor role assignments on specified scopes. To retrieve current subscription ID, run `az account show --query id --output tsv`.
-    text: az ad sp create-for-rbac -n "MyApp" --role Contributor --scopes /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup1} /subscriptions/{subscriptionId}/resourceGroups/{resourceGroup2}
+    text: az ad sp create-for-rbac -n MyApp --role Contributor --scopes /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup2
   - name: Create using a self-signed certificate.
     text: az ad sp create-for-rbac --create-cert
   - name: Create using a self-signed certificate, and store it within KeyVault.


### PR DESCRIPTION
**Related command**
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->
The example for `az ad sp create-for-rbac` specifies scope as `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup1}`. Even though curly brackets denote placeholders in the example, some users may include the curly brackets in the actual scope as `/subscriptions/{e906c0aa-f6b1-4341-8bd4-bf98681c8713}`, which causes failure (#15739, #23160, #23198):

```
KeyError: 'e906c0aa-f6b1-4341-8bd4-bf98681c8713'
```

This PR removes curly brackets to eliminate unnecessary confusion.

Question: Will `$subscription_id` also cause confusion and will some users use it as `/subscriptions/$e906c0aa-f6b1-4341-8bd4-bf98681c8713`?