### PR TITLE
[Profile] `az account list`: Add `TenantId` column to table output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/profile/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/profile/_format.py
@@ -12,6 +12,7 @@ def transform_account_list(result):
         res = OrderedDict([('Name', r['name']),
                            ('CloudName', r['cloudName']),
                            ('SubscriptionId', r['id']),
+                           ('TenantId', r['tenantId']),
                            ('State', r.get('state')),
                            ('IsDefault', r['isDefault'])])
         transformed.append(res)


### PR DESCRIPTION
**Related command**
`az account list`

**Description**<!--Mandatory-->
`TenantId` is one of the most important fields of a subscription account. By adding `TenantId` to table output, this greatly simplifies the experience to check **which token is used to access this subscription** (instead of where the subscription belongs - `homeTenantId`):

```
> az account list --output table
Name                                             CloudName    SubscriptionId                        TenantId                              State    IsDefault
-----------------------------------------------  -----------  ------------------------------------  ------------------------------------  -------  -----------
Azure CLI Tests with TTL = 2 Days                AzureCloud   1c638cf4-608f-4ee6-b680-c329e824c3a8  72f988bf-86f1-41af-91ab-2d7cd011db47  Enabled  False
AzureSDKTest                                     AzureCloud   0b1f6471-1bf0-4dda-aec3-cb9272f09590  54826b22-38d6-4fb2-bad9-b7b93a3e9c5a  Enabled  True
...
```

This is very useful in MSAL/WAM integration for making sure the correct token is acquired and used.

Additionally, perhaps we can add tenant `DisplayName` or `defaultDomain` in the future to better match the portal tenant selection behavior (https://github.com/Azure/azure-cli/issues/19276):

![image](https://user-images.githubusercontent.com/4003950/179148142-d3dbc19f-b24c-48a5-945b-bd61714f9d91.png)
