### PR TITLE
[ACR] Changes to update networkRuleSet.defaultAction to deny when public access is disabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -24,6 +24,7 @@ from .network_rule import NETWORK_RULE_NOT_SUPPORTED
 logger = get_logger(__name__)
 DEF_DIAG_SETTINGS_NAME_TEMPLATE = '{}-diagnostic-settings'
 SYSTEM_ASSIGNED_IDENTITY_ALIAS = '[system]'
+DENY_ACTION = 'Deny'
 
 
 def acr_check_name(client, registry_name):
@@ -132,10 +133,6 @@ def acr_update_custom(cmd,
     if tags is not None:
         instance.tags = tags
 
-    if default_action is not None:
-        NetworkRuleSet = cmd.get_models('NetworkRuleSet')
-        instance.network_rule_set = NetworkRuleSet(default_action=default_action)
-
     if data_endpoint_enabled is not None:
         instance.data_endpoint_enabled = data_endpoint_enabled
 
@@ -145,6 +142,9 @@ def acr_update_custom(cmd,
     if anonymous_pull_enabled is not None:
         instance.anonymous_pull_enabled = anonymous_pull_enabled
 
+    if default_action is not None:
+        _configure_default_action(cmd, instance, default_action)
+        
     _handle_network_bypass(cmd, instance, allow_trusted_services)
     _handle_export_policy(cmd, instance, allow_exports)
 
@@ -158,8 +158,12 @@ def _configure_public_network_access(cmd, registry, enabled):
         registry.public_network_access = PublicNetworkAccess.enabled
     else:
         registry.public_network_access = PublicNetworkAccess.disabled
+        _configure_default_action(cmd, registry, DENY_ACTION)
         logger.warning('Disabling the public endpoint overrides all firewall configurations.')
 
+def _configure_default_action(cmd, registry, action):
+    NetworkRuleSet = cmd.get_models('NetworkRuleSet')
+    registry.network_rule_set = NetworkRuleSet(default_action=action)
 
 def _handle_network_bypass(cmd, registry, allow_trusted_services):
     if allow_trusted_services is not None:


### PR DESCRIPTION
**Related command**
 `az acr update --public-network-enabled true -n <repository name>`
 `az acr update --public-network-enabled false -n <repository name>`

**Description**
It's a Bug fix related to [user story](https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/13920826)
Synced with the Azure core team and came up with an agreement that the _networkRuleSet.defaultAction_ should be set to _Deny_ if the public access is disabled.

**Testing Guide**
- Routed the Azure CLI to use local code for the CLI commands
- Tested the code changes by running the unit tests `azdev test acr`
- Ran the above commands and validated that the registry's `networkRuleSet.defaultAction` are getting set correctly

**History Notes**
[Link to user story](https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/13920826)

This change does not affect the customer directly because setting the networkRuleSet.defaultAction as Deny, when public network access is disabled does not change the behavior.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
