### PR TITLE
{Extension} Install library libpq-dev for extension rdbms-connect in Docker

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -249,6 +249,11 @@ def _install_deps_for_psycopg2():  # pylint: disable=too-many-statements
                 if exit_code == 0:
                     logger.debug("Install dependencies with '%s'", " ".join(zypper_install_cmd))
                     subprocess.call(zypper_install_cmd)
+        elif installer == 'DOCKER' or any(x in distname for x in ['alpine linux']):
+            apk_install_cmd = 'apk add --no-cache libpq-dev'.split()
+            logger.debug("Install dependencies with '%s'", " ".join(apk_install_cmd))
+            logger.warning('This extension depends on libpq-dev and will be installed first.')
+            subprocess.call(apk_install_cmd)
 
 
 def is_valid_sha256sum(a_file, expected_sum):


### PR DESCRIPTION
**Description**<!--Mandatory-->
This PR fixes a bug when the extension rdbms-connect can't be installed because we need the library **libpq-dev** for Alpine Linux.

**Testing Guide**
<!--Example commands with explanations.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
