### PR TITLE
[Storage] Fix #23262: `az storage blob metadata`: Add `--lease-id` back

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -942,7 +942,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
             c.register_precondition_options()
             c.extra('snapshot', help='The snapshot parameter is an opaque DateTime value that, when present, '
                                      'specifies the blob snapshot to retrieve.')
-            c.argument('lease_id', help='Required if the blob has an active lease.')
+            c.extra('lease', options_list=['--lease-id'], help='Required if the blob has an active lease.')
 
     # pylint: disable=line-too-long
     with self.argument_context('storage blob upload', resource_type=ResourceType.DATA_STORAGE_BLOB) as c:

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -925,12 +925,12 @@ def _copy_file_to_blob_container(blob_service, source_file_service, destination_
         raise CLIError(error_template.format(source_path, destination_container, ex))
 
 
-def show_blob_v2(cmd, client, lease_id=None, **kwargs):
-    blob = client.get_blob_properties(lease=lease_id, **kwargs)
+def show_blob_v2(cmd, client, **kwargs):
+    blob = client.get_blob_properties(**kwargs)
 
     page_ranges = None
     if blob.blob_type == cmd.get_models('_models#BlobType', resource_type=ResourceType.DATA_STORAGE_BLOB).PageBlob:
-        page_ranges = client.get_page_ranges(lease=lease_id, **kwargs)
+        page_ranges = client.get_page_ranges(**kwargs)
 
     blob.page_ranges = page_ranges
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_lease_operations.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_lease_operations.yaml
@@ -15,12 +15,12 @@ interactions:
       ParameterSetName:
       - -n -g --query -o
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-azure-mgmt-storage/20.0.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-azure-mgmt-storage/20.0.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Storage/storageAccounts/clitest000002/listKeys?api-version=2021-09-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2022-04-11T13:53:18.2144035Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-04-11T13:53:18.2144035Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2022-07-26T04:06:37.2885683Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-07-26T04:06:37.2885683Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -29,7 +29,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 11 Apr 2022 13:53:39 GMT
+      - Tue, 26 Jul 2022 04:06:59 GMT
       expires:
       - '-1'
       pragma:
@@ -52,16 +52,24 @@ interactions:
 - request:
     body: null
     headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
       Connection:
       - keep-alive
       Content-Length:
       - '0'
+      ParameterSetName:
+      - -n --account-name --account-key
       User-Agent:
-      - Azure-Storage/2.0.0-2.0.1 (Python CPython 3.9.6; Windows 10) AZURECLI/2.35.0
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:40 GMT
+      - Tue, 26 Jul 2022 04:06:59 GMT
       x-ms-version:
-      - '2018-11-09'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003?restype=container
   response:
@@ -71,15 +79,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:40 GMT
+      - Tue, 26 Jul 2022 04:07:00 GMT
       etag:
-      - '"0x8DA1BC2AFB8D6AE"'
+      - '"0x8DA6EBC4A506DCD"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:41 GMT
+      - Tue, 26 Jul 2022 04:07:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2018-11-09'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -103,13 +111,13 @@ interactions:
       ParameterSetName:
       - -c -n -f --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:41 GMT
+      - Tue, 26 Jul 2022 04:07:00 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
   response:
@@ -121,11 +129,11 @@ interactions:
       content-md5:
       - DfvoqkwgtS4bi/PLbL3xkw==
       date:
-      - Mon, 11 Apr 2022 13:53:42 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -133,7 +141,7 @@ interactions:
       x-ms-request-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -156,9 +164,9 @@ interactions:
       - --lease-duration -b -c --if-modified-since --proposed-lease-id --account-name
         --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       x-ms-lease-action:
       - acquire
       x-ms-lease-duration:
@@ -166,7 +174,7 @@ interactions:
       x-ms-proposed-lease-id:
       - abcdabcd-abcd-abcd-abcd-abcdabcdabcd
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=lease
   response:
@@ -176,17 +184,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:44 GMT
+      - Tue, 26 Jul 2022 04:07:03 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-lease-id:
       - abcdabcd-abcd-abcd-abcd-abcdabcdabcd
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 201
       message: Created
@@ -204,11 +212,11 @@ interactions:
       ParameterSetName:
       - -n -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:45 GMT
+      - Tue, 26 Jul 2022 04:07:03 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: HEAD
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
   response:
@@ -224,17 +232,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 11 Apr 2022 13:53:44 GMT
+      - Tue, 26 Jul 2022 04:07:04 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       x-ms-lease-duration:
       - fixed
       x-ms-lease-state:
@@ -244,7 +252,7 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -264,9 +272,9 @@ interactions:
       ParameterSetName:
       - -b -c --lease-id --proposed-lease-id --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:46 GMT
+      - Tue, 26 Jul 2022 04:07:04 GMT
       x-ms-lease-action:
       - change
       x-ms-lease-id:
@@ -274,7 +282,7 @@ interactions:
       x-ms-proposed-lease-id:
       - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=lease
   response:
@@ -284,17 +292,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:46 GMT
+      - Tue, 26 Jul 2022 04:07:05 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-lease-id:
       - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -314,15 +322,15 @@ interactions:
       ParameterSetName:
       - -b -c --lease-id --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:47 GMT
+      - Tue, 26 Jul 2022 04:07:05 GMT
       x-ms-lease-action:
       - renew
       x-ms-lease-id:
       - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=lease
   response:
@@ -332,17 +340,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:46 GMT
+      - Tue, 26 Jul 2022 04:07:07 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-lease-id:
       - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -360,11 +368,11 @@ interactions:
       ParameterSetName:
       - -n -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:48 GMT
+      - Tue, 26 Jul 2022 04:07:07 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: HEAD
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
   response:
@@ -380,17 +388,17 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 11 Apr 2022 13:53:48 GMT
+      - Tue, 26 Jul 2022 04:07:07 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4B6E99DF"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       x-ms-lease-duration:
       - fixed
       x-ms-lease-state:
@@ -400,7 +408,117 @@ interactions:
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob metadata update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -c --metadata --lease-id --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Tue, 26 Jul 2022 04:07:08 GMT
+      x-ms-lease-id:
+      - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
+      x-ms-meta-key1:
+      - value1
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=metadata
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Tue, 26 Jul 2022 04:07:09 GMT
+      etag:
+      - '"0x8DA6EBC4F942A99"'
+      last-modified:
+      - Tue, 26 Jul 2022 04:07:09 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-request-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -c --lease-id --account-name --account-key
+      User-Agent:
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Tue, 26 Jul 2022 04:07:09 GMT
+      x-ms-lease-id:
+      - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
+      x-ms-version:
+      - '2021-06-08'
+    method: HEAD
+    uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '131072'
+      content-md5:
+      - DfvoqkwgtS4bi/PLbL3xkw==
+      content-type:
+      - application/octet-stream
+      date:
+      - Tue, 26 Jul 2022 04:07:10 GMT
+      etag:
+      - '"0x8DA6EBC4F942A99"'
+      last-modified:
+      - Tue, 26 Jul 2022 04:07:09 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-type:
+      - BlockBlob
+      x-ms-creation-time:
+      - Tue, 26 Jul 2022 04:07:02 GMT
+      x-ms-lease-duration:
+      - fixed
+      x-ms-lease-state:
+      - leased
+      x-ms-lease-status:
+      - locked
+      x-ms-meta-key1:
+      - value1
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -420,15 +538,15 @@ interactions:
       ParameterSetName:
       - -b -c --lease-break-period --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:49 GMT
+      - Tue, 26 Jul 2022 04:07:10 GMT
       x-ms-lease-action:
       - break
       x-ms-lease-break-period:
       - '30'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=lease
   response:
@@ -438,17 +556,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:49 GMT
+      - Tue, 26 Jul 2022 04:07:11 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4F942A99"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-lease-time:
       - '30'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 202
       message: Accepted
@@ -466,11 +584,11 @@ interactions:
       ParameterSetName:
       - -n -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:50 GMT
+      - Tue, 26 Jul 2022 04:07:11 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: HEAD
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
   response:
@@ -486,25 +604,27 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 11 Apr 2022 13:53:49 GMT
+      - Tue, 26 Jul 2022 04:07:12 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4F942A99"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       x-ms-lease-state:
       - breaking
       x-ms-lease-status:
       - locked
+      x-ms-meta-key1:
+      - value1
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -524,15 +644,15 @@ interactions:
       ParameterSetName:
       - -b -c --lease-id --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:51 GMT
+      - Tue, 26 Jul 2022 04:07:13 GMT
       x-ms-lease-action:
       - release
       x-ms-lease-id:
       - dcbadcba-dcba-dcba-dcba-dcbadcbadcba
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: PUT
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004?comp=lease
   response:
@@ -542,15 +662,15 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 11 Apr 2022 13:53:51 GMT
+      - Tue, 26 Jul 2022 04:07:13 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4F942A99"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK
@@ -568,11 +688,11 @@ interactions:
       ParameterSetName:
       - -n -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.35.0 azsdk-python-storage-blob/12.10.0 Python/3.9.6 (Windows-10-10.0.19044-SP0)
+      - AZURECLI/2.38.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Mon, 11 Apr 2022 13:53:52 GMT
+      - Tue, 26 Jul 2022 04:07:14 GMT
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     method: HEAD
     uri: https://clitest000002.blob.core.windows.net/cont000003/blob000004
   response:
@@ -588,25 +708,27 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Mon, 11 Apr 2022 13:53:52 GMT
+      - Tue, 26 Jul 2022 04:07:15 GMT
       etag:
-      - '"0x8DA1BC2B0D96DFB"'
+      - '"0x8DA6EBC4F942A99"'
       last-modified:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Mon, 11 Apr 2022 13:53:43 GMT
+      - Tue, 26 Jul 2022 04:07:02 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
       - unlocked
+      x-ms-meta-key1:
+      - value1
       x-ms-server-encrypted:
       - 'true'
       x-ms-version:
-      - '2021-04-10'
+      - '2021-06-08'
     status:
       code: 200
       message: OK

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_scenarios.py
@@ -204,6 +204,10 @@ class StorageBlobUploadTests(StorageScenarioMixin, ScenarioTest):
             .assert_with_checks(JMESPathCheck('properties.lease.duration', 'fixed'),
                                 JMESPathCheck('properties.lease.state', 'leased'),
                                 JMESPathCheck('properties.lease.status', 'locked'))
+        self.storage_cmd('storage blob metadata update -n {} -c {} --metadata key1=value1 --lease-id {}',
+                         account_info, b, c, new_lease_id)
+        self.storage_cmd('storage blob show -n {} -c {} --lease-id {}', account_info, b, c, new_lease_id)\
+            .assert_with_checks(JMESPathCheck('metadata.key1', 'value1'))
         self.storage_cmd('storage blob lease break -b {} -c {} --lease-break-period 30',
                          account_info, b, c)
         self.storage_cmd('storage blob show -n {} -c {}', account_info, b, c) \


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob metadata show/update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #23262 
`--lease-id` was missing during track2 migration for `az storage blob metadata`


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
