### PR TITLE
{CI} Use `macOS-12`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
   displayName: 'Verify src/azure-cli/requirements.*.Darwin.txt'
   condition: succeeded()
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-12'
 
   steps:
   - task: UsePythonVersion@0
@@ -531,7 +531,7 @@ jobs:
   dependsOn: BuildHomebrewFormula
   condition: succeeded()
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Metadata'
@@ -571,7 +571,7 @@ jobs:
   # condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
   condition: false
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-12'
   steps:
   - task: DownloadPipelineArtifact@1
     displayName: 'Download Metadata'


### PR DESCRIPTION
**Description**<!--Mandatory-->
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1740378&view=results

We got warning in ADO that `macOS-10.15` is deprecated:

![image](https://user-images.githubusercontent.com/4003950/181414051-db62a4a6-7bd0-42b6-882c-8e8f89f92ac3.png)

We switch to the latest `macOS-12`.
