### PR TITLE
{CI} Temporarily remove `CredScan`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,26 +43,6 @@ jobs:
       echo "Reject pull request directly to master branch"
       exit 1
 
-- job: CredScan
-  displayName: "Credential Scan"
-  pool:
-    vmImage: "windows-2019"
-  steps:
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan@2
-    displayName: 'Run Credential Scanner'
-    inputs:
-      toolMajorVersion: V2
-      suppressionsFile: './scripts/ci/credscan/CredScanSuppressions.json'
-      toolVersionV2: '2.1.17'
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      AllTools: false
-      BinSkim: false
-      CredScan: true
-      RoslynAnalyzers: false
-      TSLint: false
-      ToolLogsNotFoundAction: 'Standard'
 
 - job: ExtractMetadata
   displayName: Extract Metadata


### PR DESCRIPTION
**Description**<!--Mandatory-->

The migrated build pipeline fails:

https://dev.azure.com/azclitools/public/_build/results?buildId=2992&view=results

![image](https://user-images.githubusercontent.com/4003950/181417038-eabff6d9-8f51-4e03-a5e7-32f4e3d7a955.png)

- A task is missing. The pipeline references a task called 'ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-credscan.CredScan'. This usually indicates the task isn't installed, and you may be able to install it from the Marketplace: https://marketplace.visualstudio.com. (Task version 2, job 'CredScan', step ''.)
- A task is missing. The pipeline references a task called 'ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis'. This usually indicates the task isn't installed, and you may be able to install it from the Marketplace: https://marketplace.visualstudio.com. (Task version 1, job 'CredScan', step ''.)

According to https://docs.microsoft.com/en-us/azure/security/develop/security-code-analysis-overview, **Microsoft Security Code Analysis** ADO extension is now deprecated.

I am not able to install this extension anymore: https://marketplace.visualstudio.com/acquisition?itemName=ms-codeanalysis.vss-microsoft-security-code-analysis-devops

![image](https://user-images.githubusercontent.com/4003950/181417150-6d136fea-f38b-45ae-945c-95c3565e799a.png)

So we temporarily remove `CredScan` until we figure out a replacement.
