### PR TITLE
Adding note about change in behaviour for az cli

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -115,6 +115,11 @@ long-summary: >-
     The output includes credentials that you must protect. Be sure that you do not include these credentials
     in your code or check the credentials into your source control. As an alternative, consider using
     [managed identities](https://aka.ms/azadsp-managed-identities) if available to avoid the need to use credentials.
+    
+    **Note:** This command resets the credentials of the Service Principal, not the App Registration.
+    As such, the credential shown in the output will be different from the credential shown in the portal under the App Registration pane.
+    Credentials of a Service Principal are not visable in the portal, only via the az cli or Microsoft Graph API.
+    To act on the credentials of the App Registration, please use the az ad app family of commands.
 examples:
   - name: Append a certificate to the application with the certificate string.
     text: az ad app credential reset --id 00000000-0000-0000-0000-000000000000 --cert "MIICoT..." --append


### PR DESCRIPTION
As per discussion with sureshja@microsoft.com, since the change of az cli from version 2.37, the az ad sp commands no longer operate on the App Registration, they operate on the Enterprise Application/Service Principal:
https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration#az-ad-sp-credential

This change in behaviour has prompted a request to change the docs to clarify the behaviour

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
