### PR TITLE
[ACR] Connected registry error help command typo

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/connected_registry.py
@@ -62,7 +62,7 @@ def acr_connected_registry_create(cmd,  # pylint: disable=too-many-locals, too-m
                                   notifications=None):
 
     if bool(sync_token_name) == bool(repositories):
-        raise CLIError("usage error: you must provide either --sync-token-name or --repository, but not both.")
+        raise CLIError("usage error: you must provide either --sync-token or --repository, but not both.")
     # Check needed since the sync token gateway actions must be at least 5 characters long.
     if len(connected_registry_name) < 5:
         raise InvalidArgumentValueError("argument error: Connected registry name must be at least 5 characters long.")


### PR DESCRIPTION
**Related command**
az acr connected-registry create

**Description**<!--Mandatory-->
Error states --sync-token-name when the flag is --sync-token

**Testing Guide**
Try to create a connected registry without using sync-token nor repository flags

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
