### PR TITLE
[Batch] Fix #23445: `az batch pool supported-images list`: Fix the `NoneType object has no attribute startswith` bug for getting supported images list

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -305,7 +305,7 @@ def validate_client_parameters(cmd, namespace):
 
     # Simple validation for account_endpoint
     if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
-                                                                     namespace.account_endpoint.startswith('http://')):
+           namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -305,7 +305,7 @@ def validate_client_parameters(cmd, namespace):
 
     # Simple validation for account_endpoint
     if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or 
-                                         namespace.account_endpoint.startswith('http://')):
+                                          namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -305,7 +305,7 @@ def validate_client_parameters(cmd, namespace):
 
     # Simple validation for account_endpoint
     if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
-           namespace.account_endpoint.startswith('http://')):
+             namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -305,7 +305,7 @@ def validate_client_parameters(cmd, namespace):
 
     # Simple validation for account_endpoint
     if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
-             namespace.account_endpoint.startswith('http://')):
+                                                                     namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -305,7 +305,7 @@ def validate_client_parameters(cmd, namespace):
 
     # Simple validation for account_endpoint
     if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
-            namespace.account_endpoint.startswith('http://')):
+                                                                     namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -304,8 +304,8 @@ def validate_client_parameters(cmd, namespace):
         namespace.account_endpoint = cmd.cli_ctx.config.get('batch', 'endpoint', None)
 
     # Simple validation for account_endpoint
-    if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or 
-                                          namespace.account_endpoint.startswith('http://')):
+    if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
+                                           namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -304,10 +304,10 @@ def validate_client_parameters(cmd, namespace):
         namespace.account_endpoint = cmd.cli_ctx.config.get('batch', 'endpoint', None)
 
     # Simple validation for account_endpoint
-    if not (namespace.account_endpoint.startswith('https://') or
+    if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
             namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
-    namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
+        namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth
     if namespace.account_name and namespace.account_endpoint and not namespace.account_key:
         if cmd.cli_ctx.config.get('batch', 'auth_mode', 'shared_key') == 'shared_key':

--- a/src/azure-cli/azure/cli/command_modules/batch/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/batch/_validators.py
@@ -304,8 +304,8 @@ def validate_client_parameters(cmd, namespace):
         namespace.account_endpoint = cmd.cli_ctx.config.get('batch', 'endpoint', None)
 
     # Simple validation for account_endpoint
-    if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or
-                                                                     namespace.account_endpoint.startswith('http://')):
+    if namespace.account_endpoint and not (namespace.account_endpoint.startswith('https://') or 
+                                         namespace.account_endpoint.startswith('http://')):
         namespace.account_endpoint = 'https://' + namespace.account_endpoint
         namespace.account_endpoint = namespace.account_endpoint.rstrip('/')
     # if account name is specified but no key, attempt to query if we use shared key auth


### PR DESCRIPTION
fixes Azure/azure-cli#23445

Getting supported images list for an Azure Batch pool fails with nondescript error 'NoneType' object has no attribute 'startswith'.

This PR fixes this error.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
