### PR TITLE
[Compute] Fix #23341: `az vm list-skus`: Fix filtering out VM sizes that are available regionally when they are restricted in all zones

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -123,6 +123,12 @@ def list_sku_info(cli_ctx, location=None):
 
 
 def is_sku_available(cmd, sku_info, zone):
+    """
+    The SKU is unavailable in the following cases:
+    1. regional restriction and the region is restricted
+    2. parameter --zone is input which indicates only showing skus with availability zones.
+       Meanwhile, zonal restriction and all zones are restricted
+    """
     is_available = True
     is_restrict_zone = False
     is_restrict_location = False
@@ -134,8 +140,6 @@ def is_sku_available(cmd, sku_info, zone):
             if cmd.supported_api_version(max_api='2017-03-30'):
                 is_available = False
                 break
-            # This SKU is only unavailable if all zones are restricted and showing skus supporting availability zones
-            # are enabled or regional restriction and the region is restricted
             if restriction.type == 'Zone' and not (
                     set(sku_info.location_info[0].zones or []) - set(restriction.restriction_info.zones or [])):
                 is_restrict_zone = True

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -122,7 +122,7 @@ def list_sku_info(cli_ctx, location=None):
     return result
 
 
-def is_sku_available(cmd, sku_info):
+def is_sku_available(cmd, sku_info, zone):
     is_available = True
     is_restrict_zone = False
     is_restrict_location = False
@@ -143,7 +143,7 @@ def is_sku_available(cmd, sku_info):
                     sku_info.location_info[0].location in (restriction.restriction_info.locations or [])):
                 is_restrict_location = True
 
-            if is_restrict_location or is_restrict_zone:
+            if is_restrict_location or (is_restrict_zone and zone):
                 is_available = False
                 break
     return is_available

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -143,7 +143,7 @@ def is_sku_available(cmd, sku_info):
                     sku_info.location_info[0].location in (restriction.restriction_info.locations or [])):
                 is_restrict_location = True
 
-            if is_restrict_location and is_restrict_zone:
+            if is_restrict_location or is_restrict_zone:
                 is_available = False
                 break
     return is_available

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -134,9 +134,8 @@ def is_sku_available(cmd, sku_info, zone):
             if cmd.supported_api_version(max_api='2017-03-30'):
                 is_available = False
                 break
-            # This SKU is not available only if zonal restriction and all zones are restricted
-            # and skus supporting availability zones are required to show
-            # or regional restriction and the region is restricted
+            # This SKU is only unavailable if all zones are restricted and showing skus supporting availability zones
+            # are enabled or regional restriction and the region is restricted
             if restriction.type == 'Zone' and not (
                     set(sku_info.location_info[0].zones or []) - set(restriction.restriction_info.zones or [])):
                 is_restrict_zone = True

--- a/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_vm_utils.py
@@ -135,7 +135,8 @@ def is_sku_available(cmd, sku_info, zone):
                 is_available = False
                 break
             # This SKU is not available only if zonal restriction and all zones are restricted
-            # and regional restriction and the region is restricted
+            # and skus supporting availability zones are required to show
+            # or regional restriction and the region is restricted
             if restriction.type == 'Zone' and not (
                     set(sku_info.location_info[0].zones or []) - set(restriction.restriction_info.zones or [])):
                 is_restrict_zone = True

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1274,7 +1274,7 @@ def list_skus(cmd, location=None, size=None, zone=None, show_all=None, resource_
     if not show_all:
         available_skus = []
         for sku_info in result:
-            if is_sku_available(cmd, sku_info):
+            if is_sku_available(cmd, sku_info, zone):
                 available_skus.append(sku_info)
         result = available_skus
     if resource_type:

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -1268,26 +1268,13 @@ def get_vm_details(cmd, resource_group_name, vm_name, include_user_data=False):
 
 
 def list_skus(cmd, location=None, size=None, zone=None, show_all=None, resource_type=None):
-    from ._vm_utils import list_sku_info
+    from ._vm_utils import list_sku_info, is_sku_available
     result = list_sku_info(cmd.cli_ctx, location)
     # pylint: disable=too-many-nested-blocks
     if not show_all:
         available_skus = []
         for sku_info in result:
-            is_available = True
-            if sku_info.restrictions:
-                for restriction in sku_info.restrictions:
-                    if restriction.reason_code == 'NotAvailableForSubscription':
-                        # The attribute location_info is not supported in versions 2017-03-30 and earlier
-                        if cmd.supported_api_version(max_api='2017-03-30'):
-                            is_available = False
-                            break
-                        # This SKU is not available only if all zones are restricted
-                        if not (set(sku_info.location_info[0].zones or []) -
-                                set(restriction.restriction_info.zones or [])):
-                            is_available = False
-                            break
-            if is_available:
+            if is_sku_available(cmd, sku_info):
                 available_skus.append(sku_info)
         result = available_skus
     if resource_type:

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -1590,24 +1590,34 @@ class ComputeListSkusScenarioTest(ScenarioTest):
         # zonal restriction but not regional restriction
         restrictions = [restriction_zone]
         np.restrictions = restrictions
-        is_available = is_sku_available(cmd, np)
+        # show skus supporting availability zones
+        is_available = is_sku_available(cmd, np, True)
         self.assertFalse(is_available)
+        # not show skus supporting availability zones
+        is_available = is_sku_available(cmd, np, None)
+        self.assertTrue(is_available)
 
         # not all zones are restricted
         restriction_info_zone.zones = [1, 2]
-        is_available = is_sku_available(cmd, np)
+        is_available = is_sku_available(cmd, np, True)
+        self.assertTrue(is_available)
+        is_available = is_sku_available(cmd, np, None)
         self.assertTrue(is_available)
 
         # regional restriction but not zonal restriction
         restrictions = [restriction_location]
         np.restrictions = restrictions
-        is_available = is_sku_available(cmd, np)
+        is_available = is_sku_available(cmd, np, True)
+        self.assertFalse(is_available)
+        is_available = is_sku_available(cmd, np, None)
         self.assertFalse(is_available)
 
         # regional restriction and zonal restriction
         restrictions = [restriction_location, restriction_zone]
         np.restrictions = restrictions
-        is_available = is_sku_available(cmd, np)
+        is_available = is_sku_available(cmd, np, True)
+        self.assertFalse(is_available)
+        is_available = is_sku_available(cmd, np, None)
         self.assertFalse(is_available)
 
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -1556,33 +1556,54 @@ class ComputeListSkusScenarioTest(ScenarioTest):
         result = self.cmd('vm list-skus -l westus --resource-type disks').get_output_in_json()
         self.assertTrue(result and len(result) == len([x for x in result if x['resourceType'] == 'disks']))
 
-    @AllowLargeResponse(size_kb=99999)
-    def test_list_compute_skus_partially_unavailable(self):
-        result = self.cmd('vm list-skus -l eastus --query "[?name==\'Standard_M64m\']"').get_output_in_json()
-        self.assertTrue(result and result[0]["restrictions"] and result[0]["restrictions"][0]["reasonCode"] == 'NotAvailableForSubscription')
+    @mock.patch('azure.cli.command_modules.vm._validators._compute_client_factory', autospec=True)
+    def test_list_compute_skus_partially_unavailable(self, client_factory_mock):
+        from azure.cli.core.mock import DummyCli
+        from azure.cli.command_modules.vm._vm_utils import is_sku_available
+        compute_client = mock.MagicMock()
 
-    @AllowLargeResponse(size_kb=99999)
-    def test_list_compute_skus_partially_unavailable2(self):
-        results = self.cmd('vm list-skus').get_output_in_json()
-        for result in results:
-            if 'restrictions' not in result:
-                continue
-            is_available = True
-            is_restrict_zone = False
-            is_restrict_location = False
-            for restriction in result['restrictions']:
-                if restriction['reasonCode'] != 'NotAvailableForSubscription':
-                    break
-                if restriction['type'] == 'Zone' \
-                        and not (set(result['locationInfo'][0]['zones'] or []) -
-                                 set(restriction['restrictionInfo']['zones'] or [])):
-                    is_restrict_zone = True
-                if restriction['type'] == 'Location' and (
-                        result['locationInfo'][0]['location'] in (restriction['restrictionInfo']['locations'] or [])):
-                    is_restrict_location = True
-                if is_restrict_zone and is_restrict_location:
-                    is_available = False
-            self.assertTrue(is_available)
+        cmd = mock.Mock()
+        cmd.supported_api_version = mock.Mock(return_value=False)
+        cmd.cli_ctx = DummyCli()
+
+        client_factory_mock.return_value = compute_client
+
+        np = mock.MagicMock()
+        location_info0 = mock.MagicMock()
+        location_info0.zones = [1, 2, 3]
+        location_info0.location = 'location'
+        location_info = [location_info0]
+        np.location_info = location_info
+        restriction_info_zone = mock.MagicMock()
+        restriction_info_zone.zones = [1, 2, 3]
+        restriction_zone = mock.MagicMock()
+        restriction_zone.reason_code = 'NotAvailableForSubscription'
+        restriction_zone.type = 'Zone'
+        restriction_zone.restriction_info = restriction_info_zone
+        restriction_info_location = mock.MagicMock()
+        restriction_info_location.locations = ['location']
+        restriction_location = mock.MagicMock()
+        restriction_location.reason_code = 'NotAvailableForSubscription'
+        restriction_location.type = 'Location'
+        restriction_location.restriction_info = restriction_info_location
+
+        # zonal restriction but not regional restriction
+        restrictions = [restriction_zone]
+        np.restrictions = restrictions
+        is_available = is_sku_available(cmd, np)
+        self.assertTrue(is_available)
+
+        # regional restriction but not zonal restriction
+        restrictions = [restriction_location]
+        np.restrictions = restrictions
+        is_available = is_sku_available(cmd, np)
+        self.assertTrue(is_available)
+
+        # regional restriction and zonal restriction
+        restrictions = [restriction_location, restriction_zone]
+        np.restrictions = restrictions
+        is_available = is_sku_available(cmd, np)
+        self.assertFalse(is_available)
 
 
 class VMExtensionScenarioTest(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -1591,13 +1591,18 @@ class ComputeListSkusScenarioTest(ScenarioTest):
         restrictions = [restriction_zone]
         np.restrictions = restrictions
         is_available = is_sku_available(cmd, np)
+        self.assertFalse(is_available)
+
+        # not all zones are restricted
+        restriction_info_zone.zones = [1, 2]
+        is_available = is_sku_available(cmd, np)
         self.assertTrue(is_available)
 
         # regional restriction but not zonal restriction
         restrictions = [restriction_location]
         np.restrictions = restrictions
         is_available = is_sku_available(cmd, np)
-        self.assertTrue(is_available)
+        self.assertFalse(is_available)
 
         # regional restriction and zonal restriction
         restrictions = [restriction_location, restriction_zone]


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In `az vm list-skus` command, fix filtering out VM sizes that are available regionally when they are restricted in all zones
Close #23341

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] Fix #23341: `az vm list-skus`: Fix filtering out VM sizes that are available regionally when they are restricted in all zones

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
