### PR TITLE
{packaging} Allow argcomplete 2.0.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -43,7 +43,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    'argcomplete~=1.8',
+    'argcomplete>=1.8.0,<3',
     'azure-cli-telemetry==1.0.7.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,6 +1,6 @@
 antlr4-python3-runtime==4.9.3
 applicationinsights==0.11.9
-argcomplete==1.11.1
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
argcomplete has released a new version, 2.0.0, because it added python 3.10 support, but also dropped python 2.x and 3.5 support. For distributions that would like to enable python 3.10 and no longer care about python 2.x, it would be good to be able to use the newer argcomplete.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
