### PR TITLE
[Network] Fix #22594: `az network bastion create`: Add no wait support for bastion create

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_help.py
@@ -7184,3 +7184,11 @@ examples:
     text: |
         az network bastion tunnel --name MyBastionHost --resource-group MyResourceGroup --target-resource-id vmResourceId --resource-port 22 --port 50022
 """
+
+helps['network bastion wait'] = """
+type: command
+short-summary: Place the CLI in a waiting state until a condition of the Azure Bastion host machine is met.
+examples:
+  - name: Place the CLI in a waiting state until the Azure Bastion host machine is created.
+    text: az network bastion wait --resource-group MyResourceGroup --name MyBastionHost --created
+"""

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -1406,13 +1406,14 @@ def load_command_table(self, _):
 
     # region Bastion
     with self.command_group('network bastion', network_bastion_hosts_sdk, is_preview=True) as g:
-        g.custom_command('create', 'create_bastion_host')
+        g.custom_command('create', 'create_bastion_host', supports_no_wait=True)
         g.show_command('show', 'get')
         g.custom_command('list', 'list_bastion_host')
         g.custom_command('ssh', 'ssh_bastion_host')
         g.custom_command('rdp', 'rdp_bastion_host')
         g.custom_command('tunnel', 'create_bastion_tunnel')
         g.command('delete', 'begin_delete')
+        g.wait_command('wait')
     # endregion
 
     # region PrivateLinkResource and PrivateEndpointConnection

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8216,9 +8216,9 @@ def create_bastion_host(cmd, resource_group_name, bastion_host_name, virtual_net
                                    sku=sku,
                                    tags=tags)
     return sdk_no_wait(no_wait, client.begin_create_or_update,
-                                resource_group_name=resource_group_name,
-                                bastion_host_name=bastion_host_name,
-                                parameters=bastion_host)
+                       resource_group_name=resource_group_name,
+                       bastion_host_name=bastion_host_name,
+                       parameters=bastion_host)
 
 
 def list_bastion_host(cmd, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8190,7 +8190,8 @@ def list_service_aliases(cmd, location, resource_group_name=None):
 
 # region bastion
 def create_bastion_host(cmd, resource_group_name, bastion_host_name, virtual_network_name,
-                        public_ip_address, location=None, subnet='AzureBastionSubnet', scale_units=None, sku=None, tags=None):
+                        public_ip_address, location=None, subnet='AzureBastionSubnet', scale_units=None, sku=None, tags=None,
+                        no_wait=False):
     client = network_client_factory(cmd.cli_ctx).bastion_hosts
     (BastionHost,
      BastionHostIPConfiguration,
@@ -8214,9 +8215,10 @@ def create_bastion_host(cmd, resource_group_name, bastion_host_name, virtual_net
                                    scale_units=scale_units,
                                    sku=sku,
                                    tags=tags)
-    return client.begin_create_or_update(resource_group_name=resource_group_name,
-                                         bastion_host_name=bastion_host_name,
-                                         parameters=bastion_host)
+    return sdk_no_wait(no_wait, client.begin_create_or_update,
+                                resource_group_name=resource_group_name,
+                                bastion_host_name=bastion_host_name,
+                                parameters=bastion_host)
 
 
 def list_bastion_host(cmd, resource_group_name=None):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az network bastion create --name {} --resource-group {} --vnet-name {} --public-ip-address {} --no-wait
az network bastion wait --name {} --resource-group {} --created
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR adds `--no-wait` support (and the corresponding `wait` command) to `az network bastion`, allowing for no wait scenarios where one does not need to wait for bastion creation to complete.

Resolves #22594

**Testing Guide**
<!--Example commands with explanations.-->

Follow [this section](https://docs.microsoft.com/en-us/azure/bastion/create-host-cli#createhost) except that the last command should also include the `--no-wait` argument. Then, the following command can be run (typically later in a script as required)

```sh
az network bastion wait --name {} --resource-group {} --created
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
