### PR TITLE
[RDBMS] `az postgres flexible-server create/update`: Add `SameZone` for HA in PostgreSQL flexible server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_flexible_server_util.py
@@ -184,7 +184,7 @@ def _postgres_parse_list_skus(result):
 
     if not result:
         raise InvalidArgumentValueError("No available SKUs in this location")
-    single_az = not result[0].zone_redundant_ha_supported
+    single_az = 'ZoneRedundant' not in result[0].supported_ha_mode
 
     tiers = result[0].supported_flexible_server_editions
     tiers_dict = {}

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -368,14 +368,7 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             help="The availability zone information of the standby server when high availability is enabled."
         )
 
-        pg_high_availability_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['Enabled', 'Disabled']),
-            options_list=['--high-availability'],
-            help='Enable or disable high availability feature. '
-                 'Default value is Disabled. High availability can only be set during flexible server create time'
-        )
-
-        mysql_high_availability_arg_type = CLIArgumentType(
+        high_availability_arg_type = CLIArgumentType(
             arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled', 'Enabled']),
             options_list=['--high-availability'],
             help='Enable (ZoneRedundant or SameZone) or disable high availability feature. '
@@ -426,7 +419,6 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('sku_name', default='Standard_D2s_v3', arg_type=sku_name_arg_type)
                 c.argument('storage_gb', default='128', arg_type=storage_gb_arg_type)
                 c.argument('version', default='13', arg_type=version_arg_type)
-                c.argument('high_availability', arg_type=pg_high_availability_arg_type, default="Disabled")
                 c.argument('backup_retention', default=7, arg_type=pg_backup_retention_arg_type)
             elif command_group == 'mysql':
                 c.argument('tier', default='Burstable', arg_type=tier_arg_type)
@@ -435,12 +427,12 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 c.argument('version', default='5.7', arg_type=version_arg_type)
                 c.argument('iops', arg_type=iops_arg_type)
                 c.argument('auto_grow', default='Enabled', arg_type=auto_grow_arg_type)
-                c.argument('high_availability', arg_type=mysql_high_availability_arg_type, default="Disabled")
                 c.argument('backup_retention', default=7, arg_type=mysql_backup_retention_arg_type)
                 c.argument('geo_redundant_backup', default='Disabled', arg_type=geo_redundant_backup_arg_type)
             c.argument('location', arg_type=get_location_type(self.cli_ctx))
             c.argument('administrator_login', default=generate_username(), arg_type=administrator_login_arg_type)
             c.argument('administrator_login_password', arg_type=administrator_login_password_arg_type)
+            c.argument('high_availability', arg_type=high_availability_arg_type, default="Disabled")
             c.argument('public_access', arg_type=public_access_arg_type)
             c.argument('vnet', arg_type=vnet_arg_type)
             c.argument('vnet_address_prefix', arg_type=vnet_address_prefix_arg_type)
@@ -494,15 +486,14 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
             c.argument('sku_name', arg_type=sku_name_arg_type)
             c.argument('storage_gb', arg_type=storage_gb_arg_type)
             c.argument('standby_availability_zone', arg_type=standby_availability_zone_arg_type)
+            c.argument('high_availability', arg_type=high_availability_arg_type)
             if command_group == 'mysql':
                 c.argument('auto_grow', arg_type=auto_grow_arg_type)
                 c.argument('replication_role', options_list=['--replication-role'],
                            help='The replication role of the server.')
                 c.argument('iops', arg_type=iops_arg_type)
-                c.argument('high_availability', arg_type=mysql_high_availability_arg_type)
                 c.argument('backup_retention', arg_type=mysql_backup_retention_arg_type)
             elif command_group == 'postgres':
-                c.argument('high_availability', arg_type=pg_high_availability_arg_type)
                 c.argument('backup_retention', arg_type=pg_backup_retention_arg_type)
 
         if command_group == 'mysql':

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -50,7 +50,11 @@ def flexible_server_create(cmd, client,
     # Generate missing parameters
     location, resource_group_name, server_name = generate_missing_parameters(cmd, location, resource_group_name,
                                                                              server_name, 'postgres')
+
     server_name = server_name.lower()
+    if high_availability and high_availability.lower() == 'enabled':
+        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
+        high_availability = 'ZoneRedundant'
 
     pg_arguments_validator(db_context,
                            server_name=server_name,
@@ -101,8 +105,6 @@ def flexible_server_create(cmd, client,
 
     sku = postgresql_flexibleservers.models.Sku(name=sku_name, tier=tier)
 
-    if high_availability.lower() == "enabled":
-        high_availability = "ZoneRedundant"
     high_availability = postgresql_flexibleservers.models.HighAvailability(mode=high_availability,
                                                                            standby_availability_zone=standby_availability_zone)
 
@@ -247,6 +249,10 @@ def flexible_server_update_custom_func(cmd, client, instance,
         cmd=cmd, azure_sdk=postgresql_flexibleservers, cf_firewall=cf_postgres_flexible_firewall_rules, cf_db=cf_postgres_flexible_db,
         cf_availability=cf_postgres_check_resource_availability, logging_name='PostgreSQL', command_group='postgres', server_client=client)
 
+    if high_availability and high_availability.lower() == 'enabled':
+        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
+        high_availability = 'ZoneRedundant'
+
     pg_arguments_validator(db_context,
                            location=location,
                            tier=tier,
@@ -298,8 +304,8 @@ def flexible_server_update_custom_func(cmd, client, instance,
     # High availability can't be updated with existing properties
     high_availability_param = postgresql_flexibleservers.models.HighAvailability()
     if high_availability:
-        if high_availability.lower() == "enabled":
-            high_availability_param.mode = "ZoneRedundant"
+        if high_availability.lower() != "disabled":
+            high_availability_param.mode = high_availability
             if standby_availability_zone:
                 high_availability_param.standby_availability_zone = standby_availability_zone
         else:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
@@ -130,7 +130,7 @@ class FlexibleServerMgmtScenarioTest(ScenarioTest):
         backup_retention = 7
         database_name = 'testdb'
         server_name = self.create_random_name(SERVER_NAME_PREFIX, SERVER_NAME_MAX_LENGTH)
-        ha_value = 'Enabled' if database_engine == 'postgres' else 'ZoneRedundant'
+        ha_value = 'ZoneRedundant'
 
         self.cmd('{} flexible-server create -g {} -n {} --backup-retention {} --sku-name {} --tier {} \
                   --storage-size {} -u {} --version {} --tags keys=3 --database-name {} --high-availability {} \
@@ -683,7 +683,7 @@ class FlexibleServerValidatorScenarioTest(ScenarioTest):
         invalid_tier = self.create_random_name('tier', RANDOM_VARIABLE_MAX_LENGTH)
         valid_tier = 'GeneralPurpose'
         invalid_backup_retention = 40
-        ha_value = 'Enabled' if database_engine == 'postgres' else 'ZoneRedundant'
+        ha_value = 'ZoneRedundant'
 
         # Create
         if database_engine == 'postgres':
@@ -803,7 +803,7 @@ class FlexibleServerValidatorScenarioTest(ScenarioTest):
                  database_engine, resource_group, server_name, invalid_backup_retention),
                  expect_failure=True)
 
-        ha_value = 'Enabled' if database_engine == 'postgres' else 'ZoneRedundant'
+        ha_value = 'ZoneRedundant'
         self.cmd('{} flexible-server update -g {} -n {} --high-availability {}'.format(
                  database_engine, resource_group, server_name, ha_value),
                  expect_failure=True)


### PR DESCRIPTION
**Related command**
- `az postgres flexible-server create -g testGroup -n testSrv --high-availability SameZone ...`
- `az postgres flexible-server update -g testGroup -n testSrv --high-availability SameZone ...`

**Description**<!--Mandatory-->
We need to add `SameZone` as a possible value for argument `--high-availability` in PostgreSQL flexible server, just as MySQL already does.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
