### PR TITLE
[AKS] Fix #23468: `az aks nodepool wait` crashes with error "'Namespace' object has no attribute 'nodepool_name'"

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -26,9 +26,14 @@ from azure.cli.command_modules.acs._consts import (
     CONST_SPOT_EVICTION_POLICY_DELETE, CONST_STABLE_UPGRADE_CHANNEL,
     CONST_AZURE_KEYVAULT_NETWORK_ACCESS_PUBLIC, CONST_AZURE_KEYVAULT_NETWORK_ACCESS_PRIVATE)
 from azure.cli.command_modules.acs._validators import (
-    validate_acr, validate_assign_identity, validate_assign_kubelet_identity,
+    validate_acr, validate_agent_pool_name, validate_assign_identity,
+    validate_assign_kubelet_identity, validate_azure_keyvault_kms_key_id,
+    validate_azure_keyvault_kms_key_vault_resource_id,
     validate_create_parameters, validate_credential_format,
-    validate_eviction_policy, validate_ip_ranges, validate_k8s_version,
+    validate_defender_config_parameter,
+    validate_defender_disable_and_enable_parameters, validate_eviction_policy,
+    validate_host_group_id, validate_ip_ranges, validate_k8s_version,
+    validate_keyvault_secrets_provider_disable_and_enable_parameters,
     validate_kubectl_version, validate_kubelogin_version,
     validate_linux_host_name, validate_list_of_integers,
     validate_load_balancer_idle_timeout,
@@ -41,11 +46,7 @@ from azure.cli.command_modules.acs._validators import (
     validate_nodes_count, validate_pod_subnet_id, validate_ppg,
     validate_priority, validate_snapshot_id, validate_snapshot_name,
     validate_spot_max_price, validate_ssh_key, validate_taints,
-    validate_vm_set_type, validate_vnet_subnet_id,
-    validate_keyvault_secrets_provider_disable_and_enable_parameters,
-    validate_defender_disable_and_enable_parameters, validate_defender_config_parameter,
-    validate_host_group_id,
-    validate_azure_keyvault_kms_key_id, validate_azure_keyvault_kms_key_vault_resource_id)
+    validate_vm_set_type, validate_vnet_subnet_id)
 from azure.cli.core.commands.parameters import (
     edge_zone_type, file_type, get_enum_type,
     get_resource_name_completion_list, get_three_state_flag, name_type,
@@ -454,7 +455,7 @@ def load_arguments(self, _):
     with self.argument_context('aks nodepool', resource_type=ResourceType.MGMT_CONTAINERSERVICE, operation_group='managed_clusters') as c:
         c.argument('cluster_name', help='The cluster name.')
         # the following argument is declared for the wait command
-        c.argument('agent_pool_name', options_list=['--nodepool-name', '--agent-pool-name'], validator=validate_nodepool_name, help='The node pool name.')
+        c.argument('agent_pool_name', options_list=['--nodepool-name', '--agent-pool-name'], validator=validate_agent_pool_name, help='The node pool name.')
 
     for sub_command in ['add', 'update', 'upgrade', 'scale', 'show', 'list', 'delete']:
         with self.argument_context('aks nodepool ' + sub_command) as c:

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -108,13 +108,25 @@ def validate_k8s_version(namespace):
                            'such as "1.7.12" or "1.7"')
 
 
+def _validate_nodepool_name(nodepool_name):
+    """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
+    if nodepool_name != "":
+        if len(nodepool_name) > 12:
+            raise InvalidArgumentValueError('--nodepool-name can contain at most 12 characters')
+        if not nodepool_name.isalnum():
+            raise InvalidArgumentValueError('--nodepool-name should contain only alphanumeric characters')
+
+
 def validate_nodepool_name(namespace):
     """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
-    if namespace.nodepool_name != "":
-        if len(namespace.nodepool_name) > 12:
-            raise CLIError('--nodepool-name can contain at most 12 characters')
-        if not namespace.nodepool_name.isalnum():
-            raise CLIError('--nodepool-name should contain only alphanumeric characters')
+    nodepool_name = namespace.nodepool_name
+    _validate_nodepool_name(nodepool_name)
+
+
+def validate_agent_pool_name(namespace):
+    """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
+    nodepool_name = namespace.agent_pool_name
+    _validate_nodepool_name(nodepool_name)
 
 
 def validate_kubectl_version(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -119,14 +119,12 @@ def _validate_nodepool_name(nodepool_name):
 
 def validate_nodepool_name(namespace):
     """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
-    nodepool_name = namespace.nodepool_name
-    _validate_nodepool_name(nodepool_name)
+    _validate_nodepool_name(namespace.nodepool_name)
 
 
 def validate_agent_pool_name(namespace):
     """Validates a nodepool name to be at most 12 characters, alphanumeric only."""
-    nodepool_name = namespace.agent_pool_name
-    _validate_nodepool_name(nodepool_name)
+    _validate_nodepool_name(namespace.agent_pool_name)
 
 
 def validate_kubectl_version(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -550,5 +550,71 @@ class TestValidateAzureKeyVaultKmsKeyVaultResourceId(unittest.TestCase):
         validators.validate_azure_keyvault_kms_key_vault_resource_id(namespace)
 
 
+class TestValidateNodepoolName(unittest.TestCase):
+    def test_invalid_nodepool_name_too_long(self):
+        namespace = SimpleNamespace(
+            **{
+                "nodepool_name": "tooLongNodepoolName",
+            }
+        )
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.validate_nodepool_name(
+                namespace
+            )
+
+    def test_invalid_agent_pool_name_too_long(self):
+        namespace = SimpleNamespace(
+            **{
+                "agent_pool_name": "tooLongNodepoolName",
+            }
+        )
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.validate_agent_pool_name(
+                namespace
+            )
+
+    def test_invalid_nodepool_name_not_alnum(self):
+        namespace = SimpleNamespace(
+            **{
+                "nodepool_name": "invalid-np*",
+            }
+        )
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.validate_nodepool_name(
+                namespace
+            )
+
+    def test_invalid_nodepool_name_not_alnum(self):
+        namespace = SimpleNamespace(
+            **{
+                "agent_pool_name": "invalid-np*",
+            }
+        )
+        with self.assertRaises(InvalidArgumentValueError):
+            validators.validate_agent_pool_name(
+                namespace
+            )
+
+    def test_valid_nodepool_name(self):
+        namespace = SimpleNamespace(
+            **{
+                "nodepool_name": "np100",
+            }
+        )
+        validators.validate_nodepool_name(
+            namespace
+        )
+
+    def test_valid_agent_pool_name(self):
+        namespace = SimpleNamespace(
+            **{
+                "agent_pool_name": "np100",
+            }
+        )
+        validators.validate_agent_pool_name(
+            namespace
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -474,10 +474,11 @@ class TestKeyVaultSecretsProviderAddon(unittest.TestCase):
         )
         validators.validate_keyvault_secrets_provider_disable_and_enable_parameters(namespace_3)
 
-class HostGroupIDNamespace:
-     def __init__(self, host_group_id):
 
-         self.host_group_id = host_group_id
+class HostGroupIDNamespace:
+    def __init__(self, host_group_id):
+        self.host_group_id = host_group_id
+
 
 class TestValidateHostGroupID(unittest.TestCase):
     def test_invalid_host_group_id(self):
@@ -494,6 +495,7 @@ class AzureKeyVaultKmsKeyIdNamespace:
 
     def __init__(self, azure_keyvault_kms_key_id):
         self.azure_keyvault_kms_key_id = azure_keyvault_kms_key_id
+
 
 class TestValidateAzureKeyVaultKmsKeyId(unittest.TestCase):
     def test_invalid_azure_keyvault_kms_key_id_without_https(self):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_validators.py
@@ -584,7 +584,7 @@ class TestValidateNodepoolName(unittest.TestCase):
                 namespace
             )
 
-    def test_invalid_nodepool_name_not_alnum(self):
+    def test_invalid_agent_pool_name_not_alnum(self):
         namespace = SimpleNamespace(
             **{
                 "agent_pool_name": "invalid-np*",


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks nodepool wait`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The implementation of the `az aks nodepool wait` command directly calls the operation provided by the SDK, and the parameter name used to identify the nodepool name is `agent_pool_name`, which is different from the parameter name `nodepool_name` in the custom implemented nodepool commands.

The fix is to add a new dedicated validator for the command. Also added some unit tests. See sibling PR [#5219](https://github.com/Azure/azure-cli-extensions/pull/5219).

Fix issue [#23468](https://github.com/Azure/azure-cli/issues/23468).

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
