### PR TITLE
{Auth} Make `MSIAuthenticationWrapper` expose `get_auxiliary_tokens`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/adal_authentication.py
@@ -98,6 +98,12 @@ class MSIAuthenticationWrapper(MSIAuthentication):
         logger.debug("MSIAuthenticationWrapper.signed_session invoked by Track 1 SDK")
         super().signed_session(session)
 
+    def get_auxiliary_tokens(self, *scopes, **kwargs):  # pylint:disable=no-self-use,unused-argument
+        """This method is added to align with CredentialAdaptor.get_auxiliary_tokens
+        Since managed identity belongs to a single tenant and currently doesn't support cross-tenant authentication,
+        simply return None."""
+        return None
+
 
 def _normalize_expires_on(expires_on):
     """

--- a/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
+++ b/src/azure-cli-core/azure/cli/core/auth/credential_adaptor.py
@@ -66,6 +66,7 @@ class CredentialAdaptor:
         return token
 
     def get_auxiliary_tokens(self, *scopes, **kwargs):
+        # To test cross-tenant authentication, see https://github.com/Azure/azure-cli/issues/16691
         if self._auxiliary_credentials:
             return [cred.get_token(*scopes, **kwargs) for cred in self._auxiliary_credentials]
         return None


### PR DESCRIPTION
**Description**<!--Mandatory-->

When command modules such as `resource` or `network` call `get_login_credentials`, it specifies `aux_subscriptions` or `aux_tenants`. The returned `CredentialAdaptor` contains internal credentials for these aux tenants. `_prepare_mgmt_client_kwargs_track2` will then call `get_auxiliary_tokens` to get aux tokens.

However, managed identity is single-tenanted and has no cross-tenant support, so `MSIAuthenticationWrapper` doesn't expose  `get_auxiliary_tokens`.

In Azure CLI Core, we have logic to prevent calling `get_auxiliary_tokens` on `MSIAuthenticationWrapper`:https://github.com/Azure/azure-cli/blob/110f7b402020f3d3ebd2bfb923ac5a01d026cdd1/src/azure-cli-core/azure/cli/core/commands/client_factory.py#L184

`AAZBearerTokenCredentialPolicy` assumes `get_auxiliary_tokens` is available for all credentials and doesn't check if `get_auxiliary_tokens` exists first:

https://github.com/Azure/azure-cli/blob/0183af7b5df0796c965c87d4bd158aad11bc1460/src/azure-cli-core/azure/cli/core/aaz/_http_policy.py#L80-L81

This PR makes `MSIAuthenticationWrapper` expose `get_auxiliary_tokens` but returns `None` to make sure `CredentialAdaptor` and `AAZBearerTokenCredentialPolicy` have the same interface.

closed https://github.com/Azure/azure-cli/issues/23493
