### PR TITLE
[Compute] `az group show`: Error message improvement for resource not found

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/commands.py
@@ -228,7 +228,7 @@ def load_command_table(self, _):
 
     with self.command_group('group', resource_group_sdk, resource_type=ResourceType.MGMT_RESOURCE_RESOURCES) as g:
         g.command('delete', 'begin_delete', supports_no_wait=True, confirmation=True)
-        g.show_command('show', 'get')
+        g.custom_show_command('show', 'get_resource_group')
         g.command('exists', 'check_existence')
         g.custom_command('list', 'list_resource_groups', table_transformer=transform_resource_group_list)
         g.custom_command('create', 'create_resource_group')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1322,9 +1322,7 @@ def get_resource_group(cmd, resource_group_name):
     try:
         rcf = _resource_client_factory(cmd.cli_ctx)
         return rcf.resource_groups.get(resource_group_name=resource_group_name)
-    except ResourceNotFoundError as e:
-        from azure.cli.core.commands.client_factory import get_subscription_id
-        from azure.cli.core.azclierror import ResourceNotFoundError
+    except ResourceNotFoundError:
         subscription_id = get_subscription_id(cmd.cli_ctx)
         raise ResourceNotFoundError("Resource group '{}' could not be found in subscription '{}'."
                                     .format(resource_group_name, subscription_id))

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1317,6 +1317,10 @@ def update_resource_group(instance, tags=None):
     return instance
 
 
+def get_resource_group(cmd, resource_group_name):
+    rcf = _resource_client_factory(cmd.cli_ctx)
+
+
 def export_group_as_template(
         cmd, resource_group_name, include_comments=False, include_parameter_default_value=False, resource_ids=None, skip_resource_name_params=False, skip_all_params=False):
     """Captures a resource group as a template.

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1318,7 +1318,16 @@ def update_resource_group(instance, tags=None):
 
 
 def get_resource_group(cmd, resource_group_name):
-    rcf = _resource_client_factory(cmd.cli_ctx)
+    from azure.core.exceptions import ResourceNotFoundError
+    try:
+        rcf = _resource_client_factory(cmd.cli_ctx)
+        return rcf.resource_groups.get(resource_group_name=resource_group_name)
+    except ResourceNotFoundError as e:
+        from azure.cli.core.commands.client_factory import get_subscription_id
+        from azure.cli.core.azclierror import ResourceNotFoundError
+        subscription_id = get_subscription_id(cmd.cli_ctx)
+        raise ResourceNotFoundError("Resource group '{}' could not be found in subscription '{}'."
+                                    .format(resource_group_name, subscription_id))
 
 
 def export_group_as_template(

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_show_not_existing_resource_group.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_show_not_existing_resource_group.yaml
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Thu, 11 Aug 2022 08:42:09 GMT
+      - Thu, 11 Aug 2022 09:48:53 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_show_not_existing_resource_group.yaml
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/recordings/test_show_not_existing_resource_group.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - group show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/not_exist_group_000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceGroupNotFound","message":"Resource group
+        ''not_exist_group_000001'' could not be found."}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '114'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 11 Aug 2022 08:42:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -104,12 +104,12 @@ class ResourceGroupScenarioTest(ScenarioTest):
 
     def test_show_not_existing_resource_group(self):
         self.kwargs.update({
-            'group': self.create_random_name('not_exist_group_', 30),
-            'subscriptionId': '0b1f6471-1bf0-4dda-aec3-cb9272f09590'
+            'group': self.create_random_name('not_exist_group_', 30)
         })
-        from azure.cli.core.azclierror import ResourceNotFoundError
+        subscriptionId = self.get_subscription_id()
+        from azure.core.exceptions import ResourceNotFoundError
         message = "Resource group '{}' could not be found in subscription '{}'." \
-            .format(self.kwargs['group'], self.kwargs['subscriptionId'])
+            .format(self.kwargs['group'], subscriptionId)
         with self.assertRaisesRegex(ResourceNotFoundError, message):
             self.cmd('group show -n {group}')
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -100,7 +100,18 @@ class ResourceGroupScenarioTest(ScenarioTest):
 
         self.cmd('group delete -n testrg -f Microsoft.Compute/virtualMachines --yes')
         self.cmd('group exists -n testrg',
-                 checks=self.check('@', False))        
+                 checks=self.check('@', False))
+
+    def test_show_not_existing_resource_group(self):
+        self.kwargs.update({
+            'group': self.create_random_name('not_exist_group_', 30),
+            'subscriptionId': '0b1f6471-1bf0-4dda-aec3-cb9272f09590'
+        })
+        from azure.cli.core.azclierror import ResourceNotFoundError
+        message = "Resource group '{}' could not be found in subscription '{}'." \
+            .format(self.kwargs['group'], self.kwargs['subscriptionId'])
+        with self.assertRaisesRegex(ResourceNotFoundError, message):
+            self.cmd('group show -n {group}')
 
 
 class ResourceGroupNoWaitScenarioTest(ScenarioTest):


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In `az group show` command, when resource cannot found, add the subscription info in the error message.
Close #22736

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] `az group show`: Error message improvement for resource not found

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
