### PR TITLE
{servicefabric} Fix #16717: Validate an empty array of node types

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/custom.py
@@ -487,7 +487,7 @@ def remove_cluster_node(cmd, client, resource_group_name, cluster_name, node_typ
     compute_client = compute_client_factory(cli_ctx)
     cluster = client.get(resource_group_name, cluster_name)
     node_types = [n for n in cluster.node_types if n.name.lower() == node_type.lower()]
-    if node_types is None:
+    if node_types is None or len(node_types) == 0:
         raise CLIError("Failed to find the node type in the cluster")
 
     node_type = node_types[0]


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/16717. Though the bug is not directly related to the issue, while debugging this issue surfaces while giving wrong node type as parameter.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
