### PR TITLE
[Core] Allow adding dedicated key for collecting cli telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -417,10 +417,15 @@ def set_raw_command_name(command):
 
 
 @decorators.suppress_all_exceptions()
-def add_dedicated_instrumentation_key(dedicated_instrumentation_key: set):
+def add_dedicated_instrumentation_key(dedicated_instrumentation_key):
     if not dedicated_instrumentation_key:
         return
-    _session.instrumentation_key.update(dedicated_instrumentation_key)
+
+    from collections import Iterable
+    if isinstance(dedicated_instrumentation_key, str):
+        _session.instrumentation_key.add(dedicated_instrumentation_key)
+    elif isinstance(dedicated_instrumentation_key, Iterable):
+        _session.instrumentation_key.update(dedicated_instrumentation_key)
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -421,7 +421,7 @@ def add_dedicated_instrumentation_key(dedicated_instrumentation_key):
     if not dedicated_instrumentation_key:
         return
 
-    from collections import Iterable
+    from collections.abc import Iterable
     if isinstance(dedicated_instrumentation_key, str):
         _session.instrumentation_key.add(dedicated_instrumentation_key)
     elif isinstance(dedicated_instrumentation_key, Iterable):

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -16,11 +16,11 @@ from collections import defaultdict
 from functools import wraps
 from knack.util import CLIError
 from azure.cli.core import decorators
+from azure.cli.telemetry import DEFAULT_INSTRUMENTATION_KEY
 
 PRODUCT_NAME = 'azurecli'
 TELEMETRY_VERSION = '0.0.1.4'
 AZURE_CLI_PREFIX = 'Context.Default.AzureCLI.'
-DEFAULT_INSTRUMENTATION_KEY = 'c4395b75-49cc-422c-bc95-c7d51aef5d46'
 CORRELATION_ID_PROP_NAME = 'Reserved.DataModel.CorrelationId'
 # Put a config section or key (section.name) in the allowed set to allow recording the config
 # values in the section or for the key with 'az config set'
@@ -30,6 +30,7 @@ ALLOWED_CONFIG_SECTIONS_OR_KEYS = {'auto-upgrade', 'extension', 'core', 'logging
 
 class TelemetrySession:  # pylint: disable=too-many-instance-attributes
     def __init__(self, correlation_id=None, application=None):
+        self.instrumentation_key = {DEFAULT_INSTRUMENTATION_KEY}
         self.start_time = None
         self.end_time = None
         self.application = application
@@ -66,6 +67,13 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.poll_start_time = None
         self.poll_end_time = None
 
+    def add_event(self, name, properties):
+        for key in self.instrumentation_key:
+            self.events[key].append({
+                'name': name,
+                'properties': properties
+            })
+
     def add_exception(self, exception, fault_type, description=None, message=''):
         # Move the exception info into userTask record, in order to make one Telemetry record for one command
         self.exception_name = exception.__class__.__name__
@@ -97,20 +105,14 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             user_task.update(base)
             user_task.update(cli)
 
-            self.events[DEFAULT_INSTRUMENTATION_KEY].append({
-                'name': '{}/command'.format(PRODUCT_NAME),
-                'properties': user_task
-            })
+            self.add_event('{}/command'.format(PRODUCT_NAME), user_task)
 
             for name, props in self.exceptions:
                 props.update(base)
                 props.update(cli)
                 props.update({CORRELATION_ID_PROP_NAME: str(uuid.uuid4()),
                               'Reserved.EventId': self.event_id})
-                self.events[DEFAULT_INSTRUMENTATION_KEY].append({
-                    'name': name,
-                    'properties': props
-                })
+                self.add_event(name, props)
 
         payload = json.dumps(self.events, separators=(',', ':'))
         return _remove_symbols(payload)
@@ -412,6 +414,13 @@ def set_module_correlation_data(correlation_data):
 def set_raw_command_name(command):
     # the raw command name user inputs
     _session.raw_command = command
+
+
+@decorators.suppress_all_exceptions()
+def add_dedicated_instrumentation_key(dedicated_instrumentation_key: set):
+    if not dedicated_instrumentation_key:
+        return
+    _session.instrumentation_key.update(dedicated_instrumentation_key)
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -44,7 +44,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'argcomplete~=1.8',
-    'azure-cli-telemetry==1.0.7.*',
+    'azure-cli-telemetry==1.0.8.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     'humanfriendly~=10.0',

--- a/src/azure-cli-telemetry/HISTORY.rst
+++ b/src/azure-cli-telemetry/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.0.8
++++++
+* Keep storing telemetry to CLI AppInsights in local cache but send telemetry to other AppInsights immediately
+
 1.0.7
 +++++
 * Support specifying `telemetry.push_interval_in_hours` to force push telemetry cache file

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -10,7 +10,7 @@ import portalocker
 
 from azure.cli.telemetry.util import save_payload
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 DEFAULT_INSTRUMENTATION_KEY = 'c4395b75-49cc-422c-bc95-c7d51aef5d46'
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -59,7 +59,7 @@ def save(config_dir, payload):
         import json
         events = json.loads(payload)
 
-        logger.info('Begin splitting cli events and extra events, total events: {}'.format(len(events)))
+        logger.info('Begin splitting cli events and extra events, total events: %s', len(events))
         cli_events = {}
         client = CliTelemetryClient()
         for key, event in events.items():
@@ -70,9 +70,9 @@ def save(config_dir, payload):
                 client.add(json.dumps(extra_event), flush=True)
         client.flush(force=True)
         cli_payload = json.dumps(cli_events) if cli_events else None
-        logger.info('Finish splitting cli events and extra events, cli events: {}'.format(len(cli_events)))
-    except Exception as ex:
-        logger.info("Split cli events and extra events failure: {}".format(str(ex)))
+        logger.info('Finish splitting cli events and extra events, cli events: %s', len(cli_events))
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.info("Split cli events and extra events failure: %s", str(ex))
         cli_payload = payload
 
     if save_payload(config_dir, cli_payload) and should_upload(config_dir):

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = "1.0.7"
+VERSION = "1.0.8"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.39.0
-azure-cli-telemetry==1.0.7
+azure-cli-telemetry==1.0.8
 azure-cli==2.39.0
 azure-common==1.1.22
 azure-core==1.24.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.39.0
-azure-cli-telemetry==1.0.7
+azure-cli-telemetry==1.0.8
 azure-cli==2.39.0
 azure-common==1.1.22
 azure-core==1.24.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==12.0.0
 azure-cli-core==2.39.0
-azure-cli-telemetry==1.0.7
+azure-cli-telemetry==1.0.8
 azure-cli==2.39.0
 azure-common==1.1.22
 azure-core==1.24.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR allows command modules & cli extensions to add their own appInsights key to collect all existing cli events.
The cli events sent to CLI's AppInsights are stored in local cache file.
While those sent to dedicated AppInsights will be flushed immediately

**Testing Guide**
<!--Example commands with explanations.-->
We can define a decorator:
```
def add_telemetry_dedicated_key(key=''):
    def _decorator(func):
        @wraps(func)
        def _wrapped_func(*args, **kwargs):
            if key:
                from azure.cli.core import telemetry
                telemetry.add_dedicated_instrumentation_key(key)
            return func(*args, **kwargs)
        return _wrapped_func
    return _decorator
```
And then add the decorator for any command's custom function:
```
@add_telemetry_dedicated_key(key='02b91c82-6729-4241-befc-e6d02ca4fbba')
def create_xxx_func(cmd, client, resource_name,...):
```
Then when we run the specific command, cli events will be sent to dedicated AppInsights along with CLI's AppInsights


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
