### PR TITLE
{EventGrid} `az eventgrid topic/domain event-subscription update`: Fix validation of deadletter identity parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/eventgrid/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventgrid/custom.py
@@ -2130,6 +2130,7 @@ def update_event_subscription(
         storage_queue_msg_ttl=None,
         enable_advanced_filtering_on_arrays=None,
         delivery_attribute_mapping=None):
+
     return _update_event_subscription_internal(
         instance=instance,
         endpoint=endpoint,
@@ -2177,7 +2178,7 @@ def _update_event_subscription_internal(  # pylint: disable=too-many-locals,too-
 
     _validate_deadletter_identity_args(
         deadletter_identity,
-        deadletter_endpoint)
+        deadletter_identity_endpoint)
 
     if (endpoint_type is not None and
             endpoint_type.lower() != WEBHOOK_DESTINATION.lower() and


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

This fix is related to multiple az commands, such as az eventgrid event-subscription update, az eventgrid topic event-subscription update, az eventgrid domain event-subscription update, etc, as these event-subscription update commands all call the same internal method.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Our internal validation method is incorrectly checking for the user to specify both the --deadletter-identity and **--deadletter-endpoint**, when it should be checking for --deadletter-identity and **--deadletter-identity-endpoint**.

**Testing Guide**
<!--Example commands with explanations.-->

az eventgrid event-subscription update --source-resource-id {source_resource_id_with_identity} -n {event_subscription_name} --deadletter-identity-endpoint {deadletter_endpoint_id} --deadletter-identity sytemassigned



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
