### PR TITLE
{Doc} Update `quoting-issues-with-powershell.md` to reflect recent fixes

### DIFF
--- a/doc/quoting-issues-with-powershell.md
+++ b/doc/quoting-issues-with-powershell.md
@@ -1,6 +1,40 @@
 # Quoting issues with PowerShell
 
-ℹ **These issues have been fixed in Azure CLI 2.40.0 and PowerShell 7.3. Please update Azure CLI and PowerShell to the latest version to avoid these issues. This document only applies to Azure CLI <= 2.39.0 and PowerShell <= 7.2.**
+ℹ **These issues have been fixed in Azure CLI 2.40.0 and PowerShell 7.3. Please update Azure CLI and PowerShell to the latest versions to avoid these issues. 
+
+With the latest versions, simply pass special characters as you normally would in pure PowerShell script or other shells, such as Bash.
+
+```powershell
+# Pass ampersand '&' as literal character
+> az --debug 'a&b'
+cli.knack.cli: Command arguments: ['--debug', 'a&b']
+
+> az --debug "a&b"
+cli.knack.cli: Command arguments: ['--debug', 'a&b']
+
+# Pass vertical bar '|' as literal character
+> az --debug 'a|b'
+cli.knack.cli: Command arguments: ['--debug', 'a|b']
+
+> az --debug "a|b"
+cli.knack.cli: Command arguments: ['--debug', 'a|b']
+
+# Surround double quotes with single quotes
+> az --debug '{"key": "value"}'
+cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
+
+# Use backtick ` to escape double quotes 
+> az --debug "{`"key`": `"value`"}"
+cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
+
+# Escape double quotes by doubleing them
+> az --debug "{""key"": ""value""}"
+cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
+```
+
+---
+
+**Below content only applies to Azure CLI <= 2.39.0 and PowerShell <= 7.2.**
 
 These issues are being tracked at [#15529](https://github.com/Azure/azure-cli/issues/15529).
 

--- a/doc/quoting-issues-with-powershell.md
+++ b/doc/quoting-issues-with-powershell.md
@@ -1,6 +1,8 @@
 # Quoting issues with PowerShell
 
-This issue is being tracked at [#15529](https://github.com/Azure/azure-cli/issues/15529).
+ℹ **These issues have been fixed in Azure CLI 2.40.0 and PowerShell 7.3. Please update Azure CLI and PowerShell to the latest version to avoid these issues. This document only applies to Azure CLI <= 2.39.0 and PowerShell <= 7.2.**
+
+These issues are being tracked at [#15529](https://github.com/Azure/azure-cli/issues/15529).
 
 ## Symptom
 
@@ -20,7 +22,7 @@ As `az` is a Command Prompt script (at `C:\Program Files (x86)\Microsoft SDKs\Az
 some quoted text
 ```
 
-In order for a symbol to be received by Azure CLI, you will have to take both PowerShell and Command Prompt's parsing into consideration. If a symbol still exists after 2 rounds of parsing, Azure CLI will receive it. 
+In order for a symbol to be received by Azure CLI, you will have to take both PowerShell and Command Prompt's parsing into consideration. If a symbol still exists after 2 rounds of parsing, Azure CLI will receive it.
 
 ## Workaround: the stop-parsing symbol
 To prevent this, you may use [stop-parsing symbol](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing) `--%` between `az` and arguments.
@@ -47,7 +49,7 @@ But keep in mind that **the command still needs to be escaped following the Comm
 
 ### Ampersand `&` is interpreted by Command Prompt
 
- This causes the argument to be parsed again by Command Prompt and breaks the argument. This typically happens when passing a URL with query string to `az`:
+This causes the argument to be parsed again by Command Prompt and breaks the argument. This typically happens when passing a URL with query string to `az`:
 
 ```powershell
 > az 'https://graph.microsoft.com/v1.0/me/events?$orderby=createdDateTime&$skip=20' --debug
@@ -73,7 +75,7 @@ This is what `cmd.exe` or Windows system sees:
 
 ```cmd
 >az a&b --debug
-az: 'a' is not in the 'az' command group. 
+az: 'a' is not in the 'az' command group.
 'b' is not recognized as an internal or external command,
 operable program or batch file.
 ```
@@ -81,7 +83,7 @@ operable program or batch file.
 To solve it:
 
 ```powershell
-# When quoted by single quotes ('), double quotes (") are preserved by PowerShell and sent 
+# When quoted by single quotes ('), double quotes (") are preserved by PowerShell and sent
 # to Command Prompt, so that ampersand (&) is treated as a literal character
 > az '"a&b"' --debug
 Command arguments: ['a&b', '--debug']

--- a/doc/quoting-issues-with-powershell.md
+++ b/doc/quoting-issues-with-powershell.md
@@ -1,6 +1,6 @@
 # Quoting issues with PowerShell
 
-ℹ **These issues have been fixed in Azure CLI 2.40.0 and PowerShell 7.3. Please update Azure CLI and PowerShell to the latest versions to avoid these issues. 
+**These issues have been fixed in Azure CLI 2.40.0 and PowerShell 7.3. Please update Azure CLI and PowerShell to the latest versions to avoid these issues.**
 
 With the latest versions, simply pass special characters as you normally would in pure PowerShell script or other shells, such as Bash.
 
@@ -27,7 +27,7 @@ cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
 > az --debug "{`"key`": `"value`"}"
 cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
 
-# Escape double quotes by doubleing them
+# Escape double quotes by doubling them
 > az --debug "{""key"": ""value""}"
 cli.knack.cli: Command arguments: ['--debug', '{"key": "value"}']
 ```


### PR DESCRIPTION
**Description**<!--Mandatory-->
Since we have now added `ps1` entry scripts for PowerShell and PowerShell 7.3 fixed the dropping-double-quote issue, this document is no longer valid for the latest versions of these tools.

We notify the reader the document is obsolete.
