### PR TITLE
[Compute] `az sig`: Enable private and community conversion for gallery

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -1225,8 +1225,13 @@ short-summary: update a share image gallery.
 examples:
   - name: Enable gallery to be shared to subscription or tenant
     text: |
-        az sig update --resource-group myresourcegroup --gallery-name mygallery \\
+        az sig update --resource-group myResourceGroup --gallery-name myGallery \\
         --permissions groups
+  - name: Update gallery from private to community
+    text: |
+        az sig update -g myResourceGroup --gallery-name myGallery --permissions Community \\
+        --publisher-uri myPublisherUri --publisher-email myPublisherEmail \\
+        --eula myEula --public-name-prefix myPublicNamePrefix
 """
 
 helps['sig gallery-application'] = """

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1228,22 +1228,23 @@ def load_arguments(self, _):
 
     with self.argument_context('sig create') as c:
         c.argument('description', help='the description of the gallery')
-        c.argument('permissions', arg_type=get_enum_type(GallerySharingPermissionTypes), arg_group='Sharing Profile',
-                   min_api='2020-09-30', help='This property allows you to specify the permission of sharing gallery.')
-        c.argument('soft_delete', arg_type=get_three_state_flag(), min_api='2021-03-01', is_preview=True,
-                   help='Enable soft-deletion for resources in this gallery, '
-                        'allowing them to be recovered within retention time.')
-        c.argument('publisher_uri', help='Community gallery publisher uri.')
-        c.argument('publisher_contact', options_list=['--publisher-email'], help='Community gallery publisher contact email.')
-        c.argument('eula', help='Community gallery publisher eula.')
-        c.argument('public_name_prefix', help='Community gallery public name prefix.')
     with self.argument_context('sig update') as c:
         c.ignore('gallery')
-        c.argument('permissions', arg_type=get_enum_type(GallerySharingPermissionTypes), arg_group='Sharing Profile',
-                   min_api='2020-09-30', help='This property allows you to specify the permission of sharing gallery.')
-        c.argument('soft_delete', arg_type=get_three_state_flag(), min_api='2021-03-01', is_preview=True,
-                   help='Enable soft-deletion for resources in this gallery, '
-                        'allowing them to be recovered within retention time.')
+    for scope in ['sig create', 'sig update']:
+        with self.argument_context(scope) as c:
+            c.argument('permissions', arg_type=get_enum_type(GallerySharingPermissionTypes),
+                       arg_group='Sharing Profile',
+                       min_api='2020-09-30',
+                       help='This property allows you to specify the permission of sharing gallery.')
+            c.argument('soft_delete', arg_type=get_three_state_flag(), min_api='2021-03-01', is_preview=True,
+                       help='Enable soft-deletion for resources in this gallery, '
+                            'allowing them to be recovered within retention time.')
+            c.argument('publisher_uri', help='Community gallery publisher uri.')
+            c.argument('publisher_contact', options_list=['--publisher-email'],
+                       help='Community gallery publisher contact email.')
+            c.argument('eula', help='Community gallery publisher eula.')
+            c.argument('public_name_prefix', help='Community gallery public name prefix.')
+
     with self.argument_context('sig image-definition create') as c:
         c.argument('description', help='the description of the gallery image definition')
     with self.argument_context('sig image-definition update') as c:

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -4257,6 +4257,7 @@ def update_image_galleries(cmd, resource_group_name, gallery_name, gallery, perm
             gallery.sharing_profile = SharingProfile(permissions=permissions)
         else:
             gallery.sharing_profile.permissions = permissions
+        community_gallery_info = None
         if permissions == 'Community':
             if publisher_uri is None or publisher_contact is None or eula is None or public_name_prefix is None:
                 raise RequiredArgumentMissingError('If you want to share to the community, '
@@ -4264,12 +4265,11 @@ def update_image_galleries(cmd, resource_group_name, gallery_name, gallery, perm
                                                    ' --publisher-uri, --publisher-email, --eula, --public-name-prefix.')
 
             CommunityGalleryInfo = cmd.get_models('CommunityGalleryInfo', operation_group='shared_galleries')
-            gallery.sharing_profile.community_gallery_info = CommunityGalleryInfo(publisher_uri=publisher_uri,
-                                                                                  publisher_contact=publisher_contact,
-                                                                                  eula=eula,
-                                                                                  public_name_prefix=public_name_prefix)
-        else:
-            gallery.sharing_profile.community_gallery_info = None
+            community_gallery_info = CommunityGalleryInfo(publisher_uri=publisher_uri,
+                                                          publisher_contact=publisher_contact,
+                                                          eula=eula,
+                                                          public_name_prefix=public_name_prefix)
+        gallery.sharing_profile.community_gallery_info = community_gallery_info
 
     if soft_delete is not None:
         gallery.soft_delete_policy.is_soft_delete_enabled = soft_delete

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -4249,13 +4249,28 @@ def list_image_galleries(cmd, resource_group_name=None):
 
 # from azure.mgmt.compute.models import Gallery, SharingProfile
 def update_image_galleries(cmd, resource_group_name, gallery_name, gallery, permissions=None,
-                           soft_delete=None, **kwargs):
+                           soft_delete=None, publisher_uri=None, publisher_contact=None, eula=None,
+                           public_name_prefix=None, **kwargs):
     if permissions:
         if gallery.sharing_profile is None:
             SharingProfile = cmd.get_models('SharingProfile', operation_group='shared_galleries')
             gallery.sharing_profile = SharingProfile(permissions=permissions)
         else:
             gallery.sharing_profile.permissions = permissions
+        if permissions == 'Community':
+            if publisher_uri is None or publisher_contact is None or eula is None or public_name_prefix is None:
+                raise RequiredArgumentMissingError('If you want to share to the community, '
+                                                   'you need to fill in all the following parameters:'
+                                                   ' --publisher-uri, --publisher-email, --eula, --public-name-prefix.')
+
+            CommunityGalleryInfo = cmd.get_models('CommunityGalleryInfo', operation_group='shared_galleries')
+            gallery.sharing_profile.community_gallery_info = CommunityGalleryInfo(publisher_uri=publisher_uri,
+                                                                                  publisher_contact=publisher_contact,
+                                                                                  eula=eula,
+                                                                                  public_name_prefix=public_name_prefix)
+        else:
+            gallery.sharing_profile.community_gallery_info = None
+
     if soft_delete is not None:
         gallery.soft_delete_policy.is_soft_delete_enabled = soft_delete
 

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_update_gallery_permissions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_update_gallery_permissions.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_update_gallery_permissions_000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001","name":"cli_test_update_gallery_permissions_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-08-15T09:54:43Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001","name":"cli_test_update_gallery_permissions_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-08-19T07:48:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:54:56 GMT
+      - Fri, 19 Aug 2022 07:48:21 GMT
       expires:
       - '-1'
       pragma:
@@ -43,8 +43,8 @@ interactions:
       message: OK
 - request:
     body: '{"location": "eastus2euap", "tags": {}, "properties": {"sharingProfile":
-      {"permissions": "Community", "communityGalleryInfo": {"publisherUri": "puburi",
-      "publisherContact": "abc@123.com", "eula": "eula", "publicNamePrefix": "pubname"}}}}'
+      {"permissions": "Community", "communityGalleryInfo": {"publisherUri": "pubUri",
+      "publisherContact": "test@123.com", "eula": "eula", "publicNamePrefix": "pubName"}}}}'
     headers:
       Accept:
       - application/json
@@ -55,7 +55,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '237'
+      - '238'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -69,24 +69,24 @@ interactions:
       string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
         {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
         {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
-        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
-        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-97fc1805-9e9a-428f-8c8f-646e50a0648a\"\r\n
+        \"pubUri\",\r\n        \"publisherContact\": \"test@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubName-e386a018-b2dc-4ef4-ba6f-ae88f7160174\"\r\n
         \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n
         \ }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/f817be5d-8b4b-4eae-b758-37ba96f08049?api-version=2021-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/4b760e9f-2608-4c16-a50f-9af716e2dfda?api-version=2021-10-01
       cache-control:
       - no-cache
       content-length:
-      - '813'
+      - '814'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:55:11 GMT
+      - Fri, 19 Aug 2022 07:48:27 GMT
       expires:
       - '-1'
       pragma:
@@ -99,7 +99,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;298
+      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;297
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -121,12 +121,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/f817be5d-8b4b-4eae-b758-37ba96f08049?api-version=2021-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/4b760e9f-2608-4c16-a50f-9af716e2dfda?api-version=2021-10-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-08-15T09:55:09.9978585+00:00\",\r\n  \"endTime\":
-        \"2022-08-15T09:55:10.2634501+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"f817be5d-8b4b-4eae-b758-37ba96f08049\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2022-08-19T07:48:26.7567528+00:00\",\r\n  \"endTime\":
+        \"2022-08-19T07:48:27.2880053+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"4b760e9f-2608-4c16-a50f-9af716e2dfda\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -135,7 +135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:55:41 GMT
+      - Fri, 19 Aug 2022 07:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -152,7 +152,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1198,Microsoft.Compute/GetOperationStatus30Min;4196
+      - Microsoft.Compute/GetOperationStatus3Min;1198,Microsoft.Compute/GetOperationStatus30Min;4192
     status:
       code: 200
       message: OK
@@ -178,22 +178,22 @@ interactions:
       string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
         {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
         {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
-        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
-        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-97fc1805-9e9a-428f-8c8f-646e50a0648a\"\r\n
+        \"pubUri\",\r\n        \"publisherContact\": \"test@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubName-e386a018-b2dc-4ef4-ba6f-ae88f7160174\"\r\n
         \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '814'
+      - '815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:55:42 GMT
+      - Fri, 19 Aug 2022 07:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -210,7 +210,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;339,Microsoft.Compute/GetGallery30Min;2478
+      - Microsoft.Compute/GetGallery3Min;339,Microsoft.Compute/GetGallery30Min;2469
     status:
       code: 200
       message: OK
@@ -240,17 +240,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?api-version=2022-01-03
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/b1b3e4a7-fc55-42c6-b6ae-0f37538a79ec?api-version=2022-01-03
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Mon, 15 Aug 2022 09:55:45 GMT
+      - Fri, 19 Aug 2022 07:49:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?monitor=true&api-version=2022-01-03
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/b1b3e4a7-fc55-42c6-b6ae-0f37538a79ec?monitor=true&api-version=2022-01-03
       pragma:
       - no-cache
       server:
@@ -261,7 +261,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PostShareGallery3Min;9,Microsoft.Compute/PostShareGallery30Min;59
+      - Microsoft.Compute/PostShareGallery3Min;9,Microsoft.Compute/PostShareGallery30Min;58
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
@@ -283,12 +283,12 @@ interactions:
       User-Agent:
       - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?api-version=2022-01-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/b1b3e4a7-fc55-42c6-b6ae-0f37538a79ec?api-version=2022-01-03
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-08-15T09:55:46.0449739+00:00\",\r\n  \"endTime\":
-        \"2022-08-15T09:55:47.2168015+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"c197ccee-63c5-4d9f-8a03-a5f9c894c84b\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2022-08-19T07:49:01.2725016+00:00\",\r\n  \"endTime\":
+        \"2022-08-19T07:49:02.4912693+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"b1b3e4a7-fc55-42c6-b6ae-0f37538a79ec\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -297,7 +297,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:56:37 GMT
+      - Fri, 19 Aug 2022 07:49:32 GMT
       expires:
       - '-1'
       pragma:
@@ -314,7 +314,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1196,Microsoft.Compute/GetOperationStatus30Min;4194
+      - Microsoft.Compute/GetOperationStatus3Min;1196,Microsoft.Compute/GetOperationStatus30Min;4190
     status:
       code: 200
       message: OK
@@ -334,7 +334,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?monitor=true&api-version=2022-01-03
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/b1b3e4a7-fc55-42c6-b6ae-0f37538a79ec?monitor=true&api-version=2022-01-03
   response:
     body:
       string: ''
@@ -344,7 +344,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 15 Aug 2022 09:56:37 GMT
+      - Fri, 19 Aug 2022 07:49:32 GMT
       expires:
       - '-1'
       pragma:
@@ -357,7 +357,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1195,Microsoft.Compute/GetOperationStatus30Min;4193
+      - Microsoft.Compute/GetOperationStatus3Min;1195,Microsoft.Compute/GetOperationStatus30Min;4189
     status:
       code: 200
       message: OK
@@ -383,7 +383,7 @@ interactions:
       string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
         {\r\n      \"permissions\": \"Private\"\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\"\r\n  }\r\n}"
     headers:
@@ -394,7 +394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:56:40 GMT
+      - Fri, 19 Aug 2022 07:49:34 GMT
       expires:
       - '-1'
       pragma:
@@ -411,7 +411,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;337,Microsoft.Compute/GetGallery30Min;2474
+      - Microsoft.Compute/GetGallery3Min;337,Microsoft.Compute/GetGallery30Min;2466
     status:
       code: 200
       message: OK
@@ -437,7 +437,7 @@ interactions:
       string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
         {\r\n      \"permissions\": \"Private\"\r\n    },\r\n    \"provisioningState\":
         \"Succeeded\"\r\n  }\r\n}"
     headers:
@@ -448,7 +448,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:56:43 GMT
+      - Fri, 19 Aug 2022 07:49:36 GMT
       expires:
       - '-1'
       pragma:
@@ -465,15 +465,15 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2473
+      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2465
     status:
       code: 200
       message: OK
 - request:
     body: '{"location": "eastus2euap", "tags": {}, "properties": {"identifier": {},
       "sharingProfile": {"permissions": "Community", "communityGalleryInfo": {"publisherUri":
-      "puburi", "publisherContact": "abc@123.com", "eula": "eula", "publicNamePrefix":
-      "pubname"}}}}'
+      "pubUri", "publisherContact": "test@123.com", "eula": "eula", "publicNamePrefix":
+      "pubName"}}}}'
     headers:
       Accept:
       - application/json
@@ -484,7 +484,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '255'
+      - '256'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -498,24 +498,24 @@ interactions:
       string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
         {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
         {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
-        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
-        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-18671266-e9ec-438a-b52e-516dd40d2a58\"\r\n
+        \"pubUri\",\r\n        \"publisherContact\": \"test@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubName-e817fe49-b90a-4be9-b632-6fd45c958b77\"\r\n
         \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
         \ }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/1be3fae3-82c0-401d-83bd-1365c5cd3563?api-version=2021-10-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c3be984d-3aa3-4087-a00b-6ba209e8edb2?api-version=2021-10-01
       cache-control:
       - no-cache
       content-length:
-      - '814'
+      - '815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:58:22 GMT
+      - Fri, 19 Aug 2022 07:49:37 GMT
       expires:
       - '-1'
       pragma:
@@ -529,216 +529,6 @@ interactions:
       - chunked
       vary:
       - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;297
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/1be3fae3-82c0-401d-83bd-1365c5cd3563?api-version=2021-10-01
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-08-15T09:58:22.5613773+00:00\",\r\n  \"endTime\":
-        \"2022-08-15T09:58:23.6238352+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"1be3fae3-82c0-401d-83bd-1365c5cd3563\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 09:58:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1196,Microsoft.Compute/GetOperationStatus30Min;4192
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig update
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
-        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
-        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
-        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
-        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
-        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-18671266-e9ec-438a-b52e-516dd40d2a58\"\r\n
-        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
-        \ }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '814'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 09:58:52 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;339,Microsoft.Compute/GetGallery30Min;2467
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --gallery-name --permissions
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_update_gallery_permissions_000001?api-version=2021-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001","name":"cli_test_update_gallery_permissions_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-08-15T09:54:43Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '367'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 09:58:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "eastus2euap", "tags": {}, "properties": {"sharingProfile":
-      {"permissions": "Groups"}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '100'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --gallery-name --permissions
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
-        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
-        \"Creating\"\r\n  }\r\n}"
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/266e23da-ccd1-4beb-9ca0-ff35dfdde635?api-version=2021-10-01
-      cache-control:
-      - no-cache
-      content-length:
-      - '525'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 09:59:02 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
@@ -746,8 +536,8 @@ interactions:
       x-ms-ratelimit-remaining-subscription-writes:
       - '1199'
     status:
-      code: 201
-      message: Created
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -756,20 +546,20 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - sig create
+      - sig update
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --gallery-name --permissions
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
       User-Agent:
       - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/266e23da-ccd1-4beb-9ca0-ff35dfdde635?api-version=2021-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c3be984d-3aa3-4087-a00b-6ba209e8edb2?api-version=2021-10-01
   response:
     body:
-      string: "{\r\n  \"startTime\": \"2022-08-15T09:59:01.2333663+00:00\",\r\n  \"endTime\":
-        \"2022-08-15T09:59:01.5458432+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"266e23da-ccd1-4beb-9ca0-ff35dfdde635\"\r\n}"
+      string: "{\r\n  \"startTime\": \"2022-08-19T07:49:38.5695466+00:00\",\r\n  \"endTime\":
+        \"2022-08-19T07:49:38.8664271+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"c3be984d-3aa3-4087-a00b-6ba209e8edb2\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -778,7 +568,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 09:59:32 GMT
+      - Fri, 19 Aug 2022 07:50:08 GMT
       expires:
       - '-1'
       pragma:
@@ -795,7 +585,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1197,Microsoft.Compute/GetOperationStatus30Min;4190
+      - Microsoft.Compute/GetOperationStatus3Min;1194,Microsoft.Compute/GetOperationStatus30Min;4188
     status:
       code: 200
       message: OK
@@ -804,208 +594,6 @@ interactions:
     headers:
       Accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --gallery-name --permissions
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
-        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
-        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
-        \"Succeeded\"\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 09:59:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2459
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"operationType": "Add", "groups": [{"type": "Subscriptions", "ids": ["0b1f6471-1bf0-4dda-aec3-cb9272f09590"]},
-      {"type": "AADTenants", "ids": ["2f4a9838-26b7-47ee-be60-ccc1fdec5953"]}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig share add
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '185'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - --gallery-name -g --subscription-ids --tenant-ids
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: POST
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003/share?api-version=2022-01-03
-  response:
-    body:
-      string: ''
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?api-version=2022-01-03
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 15 Aug 2022 09:59:35 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?monitor=true&api-version=2022-01-03
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/PostShareGallery3Min;9,Microsoft.Compute/PostShareGallery30Min;58
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig share add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --gallery-name -g --subscription-ids --tenant-ids
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?api-version=2022-01-03
-  response:
-    body:
-      string: "{\r\n  \"startTime\": \"2022-08-15T09:59:36.4208549+00:00\",\r\n  \"endTime\":
-        \"2022-08-15T09:59:36.8583805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
-        \ \"name\": \"0320810f-2224-4db2-95a4-e1e53590398e\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '184'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 10:01:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1195,Microsoft.Compute/GetOperationStatus30Min;4188
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig share add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --gallery-name -g --subscription-ids --tenant-ids
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?monitor=true&api-version=2022-01-03
-  response:
-    body:
-      string: ''
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '0'
-      date:
-      - Mon, 15 Aug 2022 10:01:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetOperationStatus3Min;1194,Microsoft.Compute/GetOperationStatus30Min;4187
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -1013,87 +601,32 @@ interactions:
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g --gallery-name --permissions
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
       User-Agent:
       - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
   response:
     body:
-      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
         \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
         \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
-        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
-        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
-        \"Succeeded\"\r\n  }\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '526'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 Aug 2022 10:02:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/GetGallery3Min;344,Microsoft.Compute/GetGallery30Min;2454
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "eastus2euap", "tags": {}, "properties": {"identifier": {},
-      "sharingProfile": {"permissions": "Private"}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sig update
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '119'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --gallery-name --permissions
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
-  response:
-    body:
-      string: "{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\":
-        \"Cannot update the gallery 'gallery2000003' sharing permissions from 'Groups'
-        to 'Private. Permissions can only be changed by a POST ShareGallery call.
-        Currently, gallery permissions can only be set to 'Groups' or 'Community'
-        during creation.\",\r\n    \"target\": \"gallery.properties.sharingProfile.permissions\"\r\n
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY13ZWMTBL\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
+        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
+        \"pubUri\",\r\n        \"publisherContact\": \"test@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubName-e817fe49-b90a-4be9-b632-6fd45c958b77\"\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
         \ }\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '380'
+      - '815'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 Aug 2022 10:02:10 GMT
+      - Fri, 19 Aug 2022 07:50:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1103,13 +636,15 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-resource:
-      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;295
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2463
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_update_gallery_permissions.yaml
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/recordings/test_update_gallery_permissions.yaml
@@ -1,0 +1,1115 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_update_gallery_permissions_000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001","name":"cli_test_update_gallery_permissions_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-08-15T09:54:43Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:54:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2euap", "tags": {}, "properties": {"sharingProfile":
+      {"permissions": "Community", "communityGalleryInfo": {"publisherUri": "puburi",
+      "publisherContact": "abc@123.com", "eula": "eula", "publicNamePrefix": "pubname"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
+        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
+        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-97fc1805-9e9a-428f-8c8f-646e50a0648a\"\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Creating\"\r\n
+        \ }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/f817be5d-8b4b-4eae-b758-37ba96f08049?api-version=2021-10-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '813'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:55:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;298
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/f817be5d-8b4b-4eae-b758-37ba96f08049?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2022-08-15T09:55:09.9978585+00:00\",\r\n  \"endTime\":
+        \"2022-08-15T09:55:10.2634501+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"f817be5d-8b4b-4eae-b758-37ba96f08049\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:55:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1198,Microsoft.Compute/GetOperationStatus30Min;4196
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
+        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
+        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-97fc1805-9e9a-428f-8c8f-646e50a0648a\"\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '814'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:55:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;339,Microsoft.Compute/GetGallery30Min;2478
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"operationType": "Reset"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share reset
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '26'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --gallery-name -g
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002/share?api-version=2022-01-03
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?api-version=2022-01-03
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 09:55:45 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?monitor=true&api-version=2022-01-03
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/PostShareGallery3Min;9,Microsoft.Compute/PostShareGallery30Min;59
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share reset
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --gallery-name -g
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?api-version=2022-01-03
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2022-08-15T09:55:46.0449739+00:00\",\r\n  \"endTime\":
+        \"2022-08-15T09:55:47.2168015+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"c197ccee-63c5-4d9f-8a03-a5f9c894c84b\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:56:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1196,Microsoft.Compute/GetOperationStatus30Min;4194
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share reset
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --gallery-name -g
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/c197ccee-63c5-4d9f-8a03-a5f9c894c84b?monitor=true&api-version=2022-01-03
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 09:56:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1195,Microsoft.Compute/GetOperationStatus30Min;4193
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --gallery-name --resource-group --select
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01&$select=Permissions
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Private\"\r\n    },\r\n    \"provisioningState\":
+        \"Succeeded\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '527'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:56:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;337,Microsoft.Compute/GetGallery30Min;2474
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Private\"\r\n    },\r\n    \"provisioningState\":
+        \"Succeeded\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '527'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:56:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2473
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2euap", "tags": {}, "properties": {"identifier": {},
+      "sharingProfile": {"permissions": "Community", "communityGalleryInfo": {"publisherUri":
+      "puburi", "publisherContact": "abc@123.com", "eula": "eula", "publicNamePrefix":
+      "pubname"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
+        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
+        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-18671266-e9ec-438a-b52e-516dd40d2a58\"\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
+        \ }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/1be3fae3-82c0-401d-83bd-1365c5cd3563?api-version=2021-10-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '814'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:58:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;297
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/1be3fae3-82c0-401d-83bd-1365c5cd3563?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2022-08-15T09:58:22.5613773+00:00\",\r\n  \"endTime\":
+        \"2022-08-15T09:58:23.6238352+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"1be3fae3-82c0-401d-83bd-1365c5cd3563\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:58:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1196,Microsoft.Compute/GetOperationStatus30Min;4192
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions --publisher-uri --publisher-email --eula --public-name-prefix
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery1000002\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery1000002\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY1SEBYPJ6\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Community\",\r\n      \"communityGalleryInfo\":
+        {\r\n        \"communityGalleryEnabled\": false,\r\n        \"publisherUri\":
+        \"puburi\",\r\n        \"publisherContact\": \"abc@123.com\",\r\n        \"eula\":
+        \"eula\",\r\n        \"publicNames\": [\r\n          \"pubname-18671266-e9ec-438a-b52e-516dd40d2a58\"\r\n
+        \       ]\r\n      }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '814'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:58:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;339,Microsoft.Compute/GetGallery30Min;2467
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_update_gallery_permissions_000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001","name":"cli_test_update_gallery_permissions_000001","type":"Microsoft.Resources/resourceGroups","location":"eastus2euap","tags":{"product":"azurecli","cause":"automation","date":"2022-08-15T09:54:43Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:58:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2euap", "tags": {}, "properties": {"sharingProfile":
+      {"permissions": "Groups"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
+        \"Creating\"\r\n  }\r\n}"
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/266e23da-ccd1-4beb-9ca0-ff35dfdde635?api-version=2021-10-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '525'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:59:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/CreateUpdateGallery3Min;48,Microsoft.Compute/CreateUpdateGallery30Min;296
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/266e23da-ccd1-4beb-9ca0-ff35dfdde635?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2022-08-15T09:59:01.2333663+00:00\",\r\n  \"endTime\":
+        \"2022-08-15T09:59:01.5458432+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"266e23da-ccd1-4beb-9ca0-ff35dfdde635\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:59:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1197,Microsoft.Compute/GetOperationStatus30Min;4190
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
+        \"Succeeded\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '526'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 09:59:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;336,Microsoft.Compute/GetGallery30Min;2459
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"operationType": "Add", "groups": [{"type": "Subscriptions", "ids": ["0b1f6471-1bf0-4dda-aec3-cb9272f09590"]},
+      {"type": "AADTenants", "ids": ["2f4a9838-26b7-47ee-be60-ccc1fdec5953"]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share add
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '185'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --gallery-name -g --subscription-ids --tenant-ids
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003/share?api-version=2022-01-03
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?api-version=2022-01-03
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 09:59:35 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?monitor=true&api-version=2022-01-03
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/PostShareGallery3Min;9,Microsoft.Compute/PostShareGallery30Min;58
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --gallery-name -g --subscription-ids --tenant-ids
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?api-version=2022-01-03
+  response:
+    body:
+      string: "{\r\n  \"startTime\": \"2022-08-15T09:59:36.4208549+00:00\",\r\n  \"endTime\":
+        \"2022-08-15T09:59:36.8583805+00:00\",\r\n  \"status\": \"Succeeded\",\r\n
+        \ \"name\": \"0320810f-2224-4db2-95a4-e1e53590398e\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 10:01:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1195,Microsoft.Compute/GetOperationStatus30Min;4188
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig share add
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --gallery-name -g --subscription-ids --tenant-ids
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/EastUS2EUAP/capsOperations/0320810f-2224-4db2-95a4-e1e53590398e?monitor=true&api-version=2022-01-03
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Mon, 15 Aug 2022 10:01:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetOperationStatus3Min;1194,Microsoft.Compute/GetOperationStatus30Min;4187
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"gallery2000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003\",\r\n
+        \ \"type\": \"Microsoft.Compute/galleries\",\r\n  \"location\": \"eastus2euap\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"identifier\": {\r\n      \"uniqueName\":
+        \"0b1f6471-1bf0-4dda-aec3-cb9272f09590-GALLERY22XBDDHC\"\r\n    },\r\n    \"sharingProfile\":
+        {\r\n      \"permissions\": \"Groups\"\r\n    },\r\n    \"provisioningState\":
+        \"Succeeded\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '526'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 10:02:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetGallery3Min;344,Microsoft.Compute/GetGallery30Min;2454
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "eastus2euap", "tags": {}, "properties": {"identifier": {},
+      "sharingProfile": {"permissions": "Private"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sig update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --gallery-name --permissions
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.8.0 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_update_gallery_permissions_000001/providers/Microsoft.Compute/galleries/gallery2000003?api-version=2021-10-01
+  response:
+    body:
+      string: "{\r\n  \"error\": {\r\n    \"code\": \"InvalidParameter\",\r\n    \"message\":
+        \"Cannot update the gallery 'gallery2000003' sharing permissions from 'Groups'
+        to 'Private. Permissions can only be changed by a POST ShareGallery call.
+        Currently, gallery permissions can only be set to 'Groups' or 'Community'
+        during creation.\",\r\n    \"target\": \"gallery.properties.sharingProfile.permissions\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '380'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 15 Aug 2022 10:02:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/CreateUpdateGallery3Min;49,Microsoft.Compute/CreateUpdateGallery30Min;295
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -5964,6 +5964,27 @@ class VMGalleryImage(ScenarioTest):
             self.check('sharingProfile.permissions', 'Private')
         ])
 
+    @ResourceGroupPreparer(location='eastus2')
+    def test_update_gallery_permissions(self, resource_group):
+        self.kwargs.update({
+            'gallery1': self.create_random_name('gallery', 15),
+            'gallery2': self.create_random_name('gallery', 15),
+            'subId': '0b1f6471-1bf0-4dda-aec3-cb9272f09590',
+            'tenantId': '2f4a9838-26b7-47ee-be60-ccc1fdec5953',
+        })
+        self.cmd('sig create -g {rg} --gallery-name {gallery1} --permissions Community --publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname', checks=[
+            self.check('sharingProfile.permissions', 'Community')
+        ])
+        self.cmd('sig update -g {rg} --gallery-name {gallery1} --permissions Private', checks=[
+            self.check('sharingProfile.permissions', 'Private')
+        ])
+        self.cmd('sig create -g {rg} --gallery-name {gallery2} --permissions Groups', checks=[
+            self.check('sharingProfile.permissions', 'Groups')
+        ])
+        self.cmd('sig share add --gallery-name {gallery} -g {rg} --subscription-ids {subId} --tenant-ids {tenantId}')
+        self.cmd('sig update -g {rg} --gallery-name {gallery2} --permissions Private', checks=[
+            self.check('sharingProfile.permissions', 'Private')
+        ])
 
 class VMGalleryApplication(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -5968,43 +5968,25 @@ class VMGalleryImage(ScenarioTest):
     def test_update_gallery_permissions(self, resource_group):
         self.kwargs.update({
             'gallery1': self.create_random_name('gallery1', 15),
-            'gallery2': self.create_random_name('gallery2', 15),
-            'subId': '0b1f6471-1bf0-4dda-aec3-cb9272f09590',
-            'tenantId': '2f4a9838-26b7-47ee-be60-ccc1fdec5953',
+            'gallery2': self.create_random_name('gallery2', 15)
         })
         self.cmd('sig create -g {rg} --gallery-name {gallery1} --permissions Community '
-                 '--publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname',
+                 '--publisher-uri pubUri --publisher-email test@123.com --eula eula --public-name-prefix pubName',
                  checks=[
                      self.check('sharingProfile.permissions', 'Community')
                  ])
         # update gallery from community to private
-        self.cmd('sig update -g {rg} --gallery-name {gallery1} --permissions Private', checks=[
+        self.cmd('sig share reset --gallery-name {gallery1} -g {rg}')
+        self.cmd('sig show --gallery-name {gallery1} --resource-group {rg} --select Permissions', checks=[
             self.check('sharingProfile.permissions', 'Private')
         ])
-        # self.cmd('sig share reset --gallery-name {gallery1} -g {rg}')
-        # self.cmd('sig show --gallery-name {gallery1} --resource-group {rg} --select Permissions', checks=[
-        #     self.check('sharingProfile.permissions', 'Private')
-        # ])
 
         # update gallery from private to community
         self.cmd('sig update -g {rg} --gallery-name {gallery1} --permissions Community '
-                 '--publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname',
+                 '--publisher-uri pubUri --publisher-email test@123.com --eula eula --public-name-prefix pubName',
                  checks=[
                      self.check('sharingProfile.permissions', 'Community')
                  ])
-
-        self.cmd('sig create -g {rg} --gallery-name {gallery2} --permissions Groups', checks=[
-            self.check('sharingProfile.permissions', 'Groups')
-        ])
-        self.cmd('sig share add --gallery-name {gallery2} -g {rg} --subscription-ids {subId} --tenant-ids {tenantId}')
-        # update gallery from groups to private
-        self.cmd('sig update -g {rg} --gallery-name {gallery2} --permissions Private', checks=[
-            self.check('sharingProfile.permissions', 'Private')
-        ])
-        # update gallery from private to groups
-        self.cmd('sig update -g {rg} --gallery-name {gallery2} --permissions Groups', checks=[
-            self.check('sharingProfile.permissions', 'Groups')
-        ])
 
 
 class VMGalleryApplication(ScenarioTest):

--- a/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/tests/latest/test_vm_commands.py
@@ -5964,27 +5964,48 @@ class VMGalleryImage(ScenarioTest):
             self.check('sharingProfile.permissions', 'Private')
         ])
 
-    @ResourceGroupPreparer(location='eastus2')
+    @ResourceGroupPreparer(name_prefix='cli_test_update_gallery_permissions_', location='eastus2euap')
     def test_update_gallery_permissions(self, resource_group):
         self.kwargs.update({
-            'gallery1': self.create_random_name('gallery', 15),
-            'gallery2': self.create_random_name('gallery', 15),
+            'gallery1': self.create_random_name('gallery1', 15),
+            'gallery2': self.create_random_name('gallery2', 15),
             'subId': '0b1f6471-1bf0-4dda-aec3-cb9272f09590',
             'tenantId': '2f4a9838-26b7-47ee-be60-ccc1fdec5953',
         })
-        self.cmd('sig create -g {rg} --gallery-name {gallery1} --permissions Community --publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname', checks=[
-            self.check('sharingProfile.permissions', 'Community')
-        ])
+        self.cmd('sig create -g {rg} --gallery-name {gallery1} --permissions Community '
+                 '--publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname',
+                 checks=[
+                     self.check('sharingProfile.permissions', 'Community')
+                 ])
+        # update gallery from community to private
         self.cmd('sig update -g {rg} --gallery-name {gallery1} --permissions Private', checks=[
             self.check('sharingProfile.permissions', 'Private')
         ])
+        # self.cmd('sig share reset --gallery-name {gallery1} -g {rg}')
+        # self.cmd('sig show --gallery-name {gallery1} --resource-group {rg} --select Permissions', checks=[
+        #     self.check('sharingProfile.permissions', 'Private')
+        # ])
+
+        # update gallery from private to community
+        self.cmd('sig update -g {rg} --gallery-name {gallery1} --permissions Community '
+                 '--publisher-uri puburi --publisher-email abc@123.com --eula eula --public-name-prefix pubname',
+                 checks=[
+                     self.check('sharingProfile.permissions', 'Community')
+                 ])
+
         self.cmd('sig create -g {rg} --gallery-name {gallery2} --permissions Groups', checks=[
             self.check('sharingProfile.permissions', 'Groups')
         ])
-        self.cmd('sig share add --gallery-name {gallery} -g {rg} --subscription-ids {subId} --tenant-ids {tenantId}')
+        self.cmd('sig share add --gallery-name {gallery2} -g {rg} --subscription-ids {subId} --tenant-ids {tenantId}')
+        # update gallery from groups to private
         self.cmd('sig update -g {rg} --gallery-name {gallery2} --permissions Private', checks=[
             self.check('sharingProfile.permissions', 'Private')
         ])
+        # update gallery from private to groups
+        self.cmd('sig update -g {rg} --gallery-name {gallery2} --permissions Groups', checks=[
+            self.check('sharingProfile.permissions', 'Groups')
+        ])
+
 
 class VMGalleryApplication(ScenarioTest):
     @ResourceGroupPreparer(location='eastus')


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In `az sig update` command, add parameters, which previously only applied to `az sig create` command, to support updating gallery from private to community and from community to private.
Use `az sig share reset` command to support reset gallery to private. 
Close #22223

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] `az sig update`: Add parameters to support updating gallery from private to community
[Compute] `az sig share reset`: Update gallery from community to private

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
