### PR TITLE
{Telemetry} Collect `Context.Default.AzureCLI.CloudName` info

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -203,6 +203,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'debug_info', ','.join(self.debug_info))
         set_custom_properties(result, 'PollStartTime', str(self.poll_start_time))
         set_custom_properties(result, 'PollEndTime', str(self.poll_end_time))
+        set_custom_properties(result, 'CloudName', _get_cloud_name())
 
         return result
 
@@ -559,6 +560,14 @@ def _get_azure_subscription_id():
         return _get_profile().get_subscription_id()
     except CLIError:
         return None
+
+
+@decorators.suppress_all_exceptions(fallback_return=None)
+def _get_cloud_name():
+    try:
+        return _session.application.cloud.name
+    except AttributeError:
+        return 'unknown'
 
 
 def _get_shell_type():


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #23409 
We will save cloud name info to telemetry which will be stored in `Context.Default.AzureCLI.CloudName` within `Properties` field

**Testing Guide**
<!--Example commands with explanations.-->
Run any cli command and check local cache file ($home_dir/.azure/telemetry/cache)
Search for `Context.Default.AzureCLI.CloudName`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
