### PR TITLE
{AzureSynapse} fixes Azure/azure-cli#23562

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/synapse/manual/_params.py
@@ -947,7 +947,7 @@ def load_arguments(self, _):
     for scope in ['show', 'create', 'delete']:
         with self.argument_context('synapse managed-private-endpoints ' + scope) as c:
             c.argument('workspace_name', arg_type=workspace_name_arg_type, id_part='name')
-            c.argument('managed_private_endpoint_name', options_list=['--pe-name'], help='The managed private endpoint name.')
+            c.argument('managed_private_endpoint_name', arg_type=workspace_name_arg_type, options_list=['--pe-name'], help='The managed private endpoint name.')
 
     with self.argument_context('synapse managed-private-endpoints list') as c:
         c.argument('workspace_name', arg_type=workspace_name_arg_type)


### PR DESCRIPTION
fixes Azure/azure-cli#23562

The below command mentions about having --workspace-name as the optional parameter. But is is a required parameter.

az synapse managed-private-endpoints delete --pe-name
                                            [--ids]
                                            [--workspace-name]
                                            [--yes]

Error:
(--workspace-name | --ids) are required

More Info: https://docs.microsoft.com/en-us/cli/azure/synapse/managed-private-endpoints?view=azure-cli-latest#az-synapse-managed-private-endpoints-create

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
