### PR TITLE
{AKS} update logs DCR to cluster resource group instead of workspace resource group for consistency with Prometheus Addon

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -371,7 +371,7 @@ def ensure_container_insights_for_monitoring(
                         lambda x: region_names_to_id[x], resource["locations"])
                     if location not in region_ids:
                         raise ClientRequestError(
-                            f"Data Collection Rules are not supported for cluster region {location}")
+                            f"Data Collection Rules are not supported for LA workspace region {location}")
                 if resource["resourceType"].lower() == "datacollectionruleassociations":
                     region_ids = map(
                         lambda x: region_names_to_id[x], resource["locations"])

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -300,7 +300,7 @@ def ensure_container_insights_for_monitoring(
             f"providers/Microsoft.ContainerService/managedClusters/{cluster_name}"
         )
         dataCollectionRuleName = f"MSCI-{cluster_name}-{cluster_region}"
-        dcr_resource_id  = (
+        dcr_resource_id = (
             f"/subscriptions/{cluster_subscription}/resourceGroups/{cluster_resource_group_name}/"
             f"providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
         )

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -298,7 +298,6 @@ def ensure_container_insights_for_monitoring(
     # extract subscription ID and resource group from workspace_resource_id URL
     try:
         subscription_id = workspace_resource_id.split("/")[2]
-        resource_group = workspace_resource_id.split("/")[4]
     except IndexError:
         raise AzCLIError(
             "Could not locate resource group in workspace-resource-id URL."

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -300,7 +300,7 @@ def ensure_container_insights_for_monitoring(
             f"providers/Microsoft.ContainerService/managedClusters/{cluster_name}"
         )
         dataCollectionRuleName = f"MSCI-{cluster_name}-{cluster_region}"
-        dcr_resource_id = (
+        dcr_resource_id  = (
             f"/subscriptions/{cluster_subscription}/resourceGroups/{cluster_resource_group_name}/"
             f"providers/Microsoft.Insights/dataCollectionRules/{dataCollectionRuleName}"
         )

--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -369,9 +369,9 @@ def ensure_container_insights_for_monitoring(
                 if resource["resourceType"].lower() == "datacollectionrules":
                     region_ids = map(
                         lambda x: region_names_to_id[x], resource["locations"])
-                    if cluster_region not in region_ids:
+                    if location not in region_ids:
                         raise ClientRequestError(
-                            f"Data Collection Rules are not supported for cluster region {cluster_region}")
+                            f"Data Collection Rules are not supported for cluster region {location}")
                 if resource["resourceType"].lower() == "datacollectionruleassociations":
                     region_ids = map(
                         lambda x: region_names_to_id[x], resource["locations"])


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR is updating the creation of the DCR to the clusters resource group instead of the workspaces resource group to make it consistent with our new addon experience (managed prometheus azure monitor metrics addon)

**Testing Guide**
<!--Example commands with explanations.-->

az aks enable-addons -a monitoring --enable-msi-auth-for-monitoring -g kaveeshclitest -n kaveesh11

Use the flag '--enable-msi-auth-for-monitoring' to be able to test that the new MSI is being created in the clusters resource group.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
