### PR TITLE
{Auth} Show device code message regardless of `core.only_show_errors` config option

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -6,6 +6,7 @@
 import json
 import os
 import re
+import sys
 
 from azure.cli.core._environment import get_config_dir
 from knack.log import get_logger
@@ -148,7 +149,8 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         if "user_code" not in flow:
             raise ValueError(
                 "Fail to create device flow. Err: %s" % json.dumps(flow, indent=4))
-        logger.warning(flow["message"])
+        from azure.cli.core.style import print_styled_text, Style
+        print_styled_text((Style.WARNING, flow["message"]), file=sys.stderr)
         result = self._msal_app.acquire_token_by_device_flow(flow, **kwargs)  # By default it will block
         return check_result(result)
 


### PR DESCRIPTION
Fix https://github.com/Azure/azure-cli/issues/23320

**Related command**
`az login`

**Description**<!--Mandatory-->
Currently device code message is printed using `logger.warning` which is controlled by `core.only_show_errors` config option. If `core.only_show_errors` is set to `true`, device code message will be hidden.

This PR switches to `print_styled_text` so that device code message is printed directly to `sys.stderr`, regardless of `core.only_show_errors` config option.

**Testing Guide**
```
az login --use-device-code
```