### PR TITLE
[Backup] Fix #23655: `az backup restore restore-disks`: Support storage account being in a different resource group

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -897,6 +897,9 @@ backup restore restore-disks:
     target_vnet_resource_group:
       rule_exclusions:
       - option_length_too_long
+    storage_account_resource_group:
+      rule_exclusions:
+      - option_length_too_long
 backup vault backup-properties set:
   parameters:
     backup_storage_redundancy:

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -366,7 +366,7 @@ def load_arguments(self, _):
         c.argument('target_vnet_resource_group', help='Name of the resource group which contains the target VNet, in the case of Alternate Location restore to a new VM.')
         c.argument('target_subnet_name', help='Name of the subnet in which the target VM should be created, in the case of Alternate Location restore a new VM')
         c.argument('target_subscription_id', help='ID of the subscription to which the resource should be restored')
-        c.argument('storage_account_resource_group', help='Name of the resource group which contains the storage account')
+        c.argument('storage_account_resource_group', help='Name of the resource group which contains the storage account. Default value will be same as --resource-group if not specified.')
 
     with self.argument_context('backup restore restore-azurefileshare') as c:
         c.argument('resolve_conflict', resolve_conflict_type)

--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -366,6 +366,7 @@ def load_arguments(self, _):
         c.argument('target_vnet_resource_group', help='Name of the resource group which contains the target VNet, in the case of Alternate Location restore to a new VM.')
         c.argument('target_subnet_name', help='Name of the subnet in which the target VM should be created, in the case of Alternate Location restore a new VM')
         c.argument('target_subscription_id', help='ID of the subscription to which the resource should be restored')
+        c.argument('storage_account_resource_group', help='Name of the resource group which contains the storage account')
 
     with self.argument_context('backup restore restore-azurefileshare') as c:
         c.argument('resolve_conflict', resolve_conflict_type)

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1069,7 +1069,7 @@ def restore_disks(cmd, client, resource_group_name, vault_name, container_name, 
                   rehydration_priority=None, disk_encryption_set_id=None, mi_system_assigned=None,
                   mi_user_assigned=None, target_zone=None, restore_mode='AlternateLocation', target_vm_name=None,
                   target_vnet_name=None, target_vnet_resource_group=None, target_subnet_name=None,
-                  target_subscription_id=None):
+                  target_subscription_id=None, storage_account_resource_group=None):
     target_subscription = get_subscription_id(cmd.cli_ctx)
     if target_subscription_id is not None and restore_mode == "AlternateLocation":
         target_subscription = target_subscription_id
@@ -1105,7 +1105,9 @@ def restore_disks(cmd, client, resource_group_name, vault_name, container_name, 
             """)
 
     # Construct trigger restore request object
-    sa_name, sa_rg = cust_help.get_resource_name_and_rg(resource_group_name, storage_account)
+    if storage_account_resource_group is None:
+        storage_account_resource_group = resource_group_name
+    sa_name, sa_rg = cust_help.get_resource_name_and_rg(storage_account_resource_group, storage_account)
     _storage_account_id = _get_storage_account_id(cmd.cli_ctx, target_subscription, sa_name, sa_rg)
     _source_resource_id = item.properties.source_resource_id
     target_rg_id = None

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1063,6 +1063,7 @@ def _get_alr_restore_mode(target_vm_name, target_vnet_name, target_vnet_resource
 
 
 # pylint: disable=too-many-locals
+# pylint: disable=too-many-statements
 def restore_disks(cmd, client, resource_group_name, vault_name, container_name, item_name, rp_name, storage_account,
                   target_resource_group=None, restore_to_staging_storage_account=None, restore_only_osdisk=None,
                   diskslist=None, restore_as_unmanaged_disks=None, use_secondary_region=None, rehydration_duration=15,

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -405,6 +405,7 @@ def disable_auto_for_azure_wl(cmd, client, resource_group_name, vault_name, prot
 
 
 # pylint: disable=too-many-locals
+# pylint: disable=too-many-statements
 def restore_disks(cmd, client, resource_group_name, vault_name, container_name, item_name, rp_name, storage_account,
                   target_resource_group=None, restore_to_staging_storage_account=None, restore_only_osdisk=None,
                   diskslist=None, restore_as_unmanaged_disks=None, use_secondary_region=None, rehydration_duration=15,

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_base.py
@@ -411,7 +411,7 @@ def restore_disks(cmd, client, resource_group_name, vault_name, container_name, 
                   rehydration_priority=None, disk_encryption_set_id=None, mi_system_assigned=None,
                   mi_user_assigned=None, target_zone=None, restore_mode='AlternateLocation', target_vm_name=None,
                   target_vnet_name=None, target_vnet_resource_group=None, target_subnet_name=None,
-                  target_subscription_id=None):
+                  target_subscription_id=None, storage_account_resource_group=None):
 
     if rehydration_duration < 10 or rehydration_duration > 30:
         raise InvalidArgumentValueError('--rehydration-duration must have a value between 10 and 30 (both inclusive).')
@@ -428,7 +428,7 @@ def restore_disks(cmd, client, resource_group_name, vault_name, container_name, 
                                 rehydration_duration, rehydration_priority, disk_encryption_set_id,
                                 mi_system_assigned, mi_user_assigned, target_zone, restore_mode, target_vm_name,
                                 target_vnet_name, target_vnet_resource_group, target_subnet_name,
-                                target_subscription_id)
+                                target_subscription_id, storage_account_resource_group)
 
 
 def enable_for_azurefileshare(cmd, client, resource_group_name, vault_name, policy_name, storage_account,

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_restore_when_storage_in_different_rg.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_restore_when_storage_in_different_rg.yaml
@@ -1,0 +1,6438 @@
+interactions:
+- request:
+    body: '{"location": "eastasia", "properties": {"monitoringSettings": {"azureMonitorAlertSettings":
+      {"alertsForAllJobFailures": "Enabled"}, "classicAlertSettings": {"alertsForCriticalOperations":
+      "Enabled"}}}, "sku": {"name": "Standard"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '230'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000004","etag":"W/\"datetime''2022-08-25T19%3A32%3A25.0689609Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/operationStatus/MjA0NztkMGMyYjI3MC02NDQ5LTQxYWMtYjA0OC00Zjc3YWIyOThkZjY=?api-version=2022-04-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '622'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:32:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '209'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/operationStatus/MjA0NztkMGMyYjI3MC02NDQ5LTQxYWMtYjA0OC00Zjc3YWIyOThkZjY=?api-version=2022-04-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/operationStatus/MjA0NztkMGMyYjI3MC02NDQ5LTQxYWMtYjA0OC00Zjc3YWIyOThkZjY=\",\r\n
+        \ \"name\": \"MjA0NztkMGMyYjI3MC02NDQ5LTQxYWMtYjA0OC00Zjc3YWIyOThkZjY=\",\r\n
+        \ \"status\": \"Succeeded\",\r\n  \"percentComplete\": 0.0\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '360'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:33:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000004","etag":"W/\"datetime''2022-08-25T19%3A32%3A26.8897623Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '619'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:33:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupconfig/vaultconfig?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '382'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:33:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupResourceGuardProxies?api-version=2022-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:33:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupconfig/vaultconfig?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '383'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:33:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastasia","tags":{"product":"azurecli","cause":"automation","date":"2022-08-25T19:32:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '312'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
+  response:
+    body:
+      string: "{\n  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json\",\n
+        \ \"contentVersion\": \"1.0.0.0\",\n  \"parameters\": {},\n  \"variables\":
+        {},\n  \"resources\": [],\n  \"outputs\": {\n    \"aliases\": {\n      \"type\":
+        \"object\",\n      \"value\": {\n        \"Linux\": {\n          \"CentOS\":
+        {\n            \"publisher\": \"OpenLogic\",\n            \"offer\": \"CentOS\",\n
+        \           \"sku\": \"7.5\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"Debian\": {\n            \"publisher\":
+        \"Debian\",\n            \"offer\": \"debian-10\",\n            \"sku\": \"10\",\n
+        \           \"version\": \"latest\",\n            \"architecture\": \"x64\"\n
+        \         },\n          \"Flatcar\": {\n            \"publisher\": \"kinvolk\",\n
+        \           \"offer\": \"flatcar-container-linux-free\",\n            \"sku\":
+        \"stable\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"openSUSE-Leap\": {\n            \"publisher\":
+        \"SUSE\",\n            \"offer\": \"opensuse-leap-15-3\",\n            \"sku\":
+        \"gen2\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"RHEL\": {\n            \"publisher\": \"RedHat\",\n
+        \           \"offer\": \"RHEL\",\n            \"sku\": \"7-LVM\",\n            \"version\":
+        \"latest\",\n            \"architecture\": \"x64\"\n          },\n          \"SLES\":
+        {\n            \"publisher\": \"SUSE\",\n            \"offer\": \"sles-15-sp3\",\n
+        \           \"sku\": \"gen2\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"UbuntuLTS\": {\n            \"publisher\":
+        \"Canonical\",\n            \"offer\": \"UbuntuServer\",\n            \"sku\":
+        \"18.04-LTS\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          }\n        },\n        \"Windows\": {\n          \"Win2022Datacenter\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2022-Datacenter\",\n            \"version\":
+        \"latest\",\n            \"architecture\": \"x64\"\n          },\n          \"Win2022AzureEditionCore\":
+        {\n            \"publisher\": \"MicrosoftWindowsServer\",\n            \"offer\":
+        \"WindowsServer\",\n            \"sku\": \"2022-datacenter-azure-edition-core\",\n
+        \           \"version\": \"latest\",\n            \"architecture\": \"x64\"\n
+        \         },\n          \"Win2019Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2019-Datacenter\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"Win2016Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2016-Datacenter\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"Win2012R2Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2012-R2-Datacenter\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"Win2012Datacenter\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2012-Datacenter\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          },\n          \"Win2008R2SP1\": {\n            \"publisher\":
+        \"MicrosoftWindowsServer\",\n            \"offer\": \"WindowsServer\",\n            \"sku\":
+        \"2008-R2-SP1\",\n            \"version\": \"latest\",\n            \"architecture\":
+        \"x64\"\n          }\n        }\n      }\n    }\n  }\n}"
+    headers:
+      accept-ranges:
+      - bytes
+      access-control-allow-origin:
+      - '*'
+      cache-control:
+      - max-age=300
+      connection:
+      - keep-alive
+      content-length:
+      - '3463'
+      content-security-policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      content-type:
+      - text/plain; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:33 GMT
+      etag:
+      - W/"41b202f4dc5098d126019dc00721a4c5e30df0c5196794514fadc3710ee2a5cb"
+      expires:
+      - Thu, 25 Aug 2022 19:38:33 GMT
+      source-age:
+      - '0'
+      strict-transport-security:
+      - max-age=31536000
+      vary:
+      - Authorization,Accept-Encoding,Origin
+      via:
+      - 1.1 varnish
+      x-cache:
+      - HIT
+      x-cache-hits:
+      - '1'
+      x-content-type-options:
+      - nosniff
+      x-fastly-request-id:
+      - 30dfc3bcf10ff061eb06694fb5ec0be94241a777
+      x-frame-options:
+      - deny
+      x-github-request-id:
+      - 648E:4658:4B0E2D:642B3C:6307BDF5
+      x-served-by:
+      - cache-yul12832-YUL
+      x-timer:
+      - S1661456014.598085,VS0,VE78
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions?$top=1&$orderby=name%20desc&api-version=2022-03-01
+  response:
+    body:
+      string: "[\r\n  {\r\n    \"location\": \"eastasia\",\r\n    \"name\": \"9600.20520.220807\",\r\n
+        \   \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20520.220807\"\r\n
+        \ }\r\n]"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43999
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions/9600.20520.220807?api-version=2022-03-01
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n    \"architecture\":
+        \"x64\",\r\n    \"replicaType\": \"Unmanaged\",\r\n    \"disallowed\": {\r\n
+        \     \"vmDiskType\": \"None\"\r\n    },\r\n    \"automaticOSUpgradeProperties\":
+        {\r\n      \"automaticOSUpgradeSupported\": true\r\n    },\r\n    \"imageDeprecationStatus\":
+        {\r\n      \"imageState\": \"Active\"\r\n    },\r\n    \"features\": [\r\n
+        \     {\r\n        \"name\": \"IsAcceleratedNetworkSupported\",\r\n        \"value\":
+        \"True\"\r\n      },\r\n      {\r\n        \"name\": \"DiskControllerTypes\",\r\n
+        \       \"value\": \"SCSI\"\r\n      },\r\n      {\r\n        \"name\": \"IsHibernateSupported\",\r\n
+        \       \"value\": \"False\"\r\n      }\r\n    ],\r\n    \"osDiskImage\":
+        {\r\n      \"operatingSystem\": \"Windows\",\r\n      \"sizeInGb\": 128,\r\n
+        \     \"sizeInBytes\": 136367309312\r\n    },\r\n    \"dataDiskImages\": []\r\n
+        \ },\r\n  \"location\": \"eastasia\",\r\n  \"name\": \"9600.20520.220807\",\r\n
+        \ \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20520.220807\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1078'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73999
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-network/20.0.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2018-01-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
+      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
+      [{"name": "clitest-vm000005VNET", "type": "Microsoft.Network/virtualNetworks",
+      "location": "eastasia", "apiVersion": "2015-06-15", "dependsOn": [], "tags":
+      {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099",
+      "AutoShutdown": "No"}, "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+      "subnets": [{"name": "clitest-vm000005Subnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}]}}, {"type": "Microsoft.Network/networkSecurityGroups", "name":
+      "clitest-vm000005NSG", "apiVersion": "2015-06-15", "location": "eastasia", "tags":
+      {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099",
+      "AutoShutdown": "No"}, "dependsOn": []}, {"apiVersion": "2018-01-01", "type":
+      "Microsoft.Network/publicIPAddresses", "name": "clitest-vm000005PublicIP", "location":
+      "eastasia", "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest",
+      "DeleteBy": "12-2099", "AutoShutdown": "No"}, "dependsOn": [], "properties":
+      {"publicIPAllocationMethod": null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
+      "name": "clitest-vm000005VMNic", "location": "eastasia", "tags": {"MabUsed":
+      "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown":
+      "No"}, "dependsOn": ["Microsoft.Network/virtualNetworks/clitest-vm000005VNET",
+      "Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG", "Microsoft.Network/publicIpAddresses/clitest-vm000005PublicIP"],
+      "properties": {"ipConfigurations": [{"name": "ipconfigclitest-vm000005", "properties":
+      {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"}}},
+      {"apiVersion": "2022-03-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      "clitest-vm000005", "location": "eastasia", "tags": {"MabUsed": "Yes", "Owner":
+      "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown": "No"},
+      "dependsOn": ["Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic",
+      "properties": {"deleteOption": null}}]}, "storageProfile": {"osDisk": {"createOption":
+      "fromImage", "name": null, "caching": "ReadWrite", "managedDisk": {"storageAccountType":
+      null}}, "imageReference": {"publisher": "MicrosoftWindowsServer", "offer": "WindowsServer",
+      "sku": "2012-R2-Datacenter", "version": "latest"}}, "osProfile": {"computerName":
+      "clitest-vm000005", "adminUsername": "clitest-vm000005", "adminPassword": "[parameters(''adminPassword'')]"}}}],
+      "outputs": {}}, "parameters": {"adminPassword": {"value": "%j^VYw9Q3Z@Cu$*h"}},
+      "mode": "incremental"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3602'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_nur5tP4gDdhuNxQ2WjXgWgzYDPY3DSUA","name":"vm_deploy_nur5tP4gDdhuNxQ2WjXgWgzYDPY3DSUA","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17589588869592961049","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2022-08-25T19:33:41.8625161Z","duration":"PT0.0006129S","correlationId":"f0142610-fd14-42bb-958c-027b09b6f88d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastasia"]},{"resourceType":"networkSecurityGroups","locations":["eastasia"]},{"resourceType":"publicIPAddresses","locations":["eastasia"]},{"resourceType":"networkInterfaces","locations":["eastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_nur5tP4gDdhuNxQ2WjXgWgzYDPY3DSUA/operationStatuses/08585401508667010373?api-version=2021-04-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2535'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:33:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585401508667010373?api-version=2021-04-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585401508667010373?api-version=2021-04-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_nur5tP4gDdhuNxQ2WjXgWgzYDPY3DSUA","name":"vm_deploy_nur5tP4gDdhuNxQ2WjXgWgzYDPY3DSUA","type":"Microsoft.Resources/deployments","properties":{"templateHash":"17589588869592961049","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2022-08-25T19:34:35.1767467Z","duration":"PT53.3148435S","correlationId":"f0142610-fd14-42bb-958c-027b09b6f88d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastasia"]},{"resourceType":"networkSecurityGroups","locations":["eastasia"]},{"resourceType":"publicIPAddresses","locations":["eastasia"]},{"resourceType":"networkInterfaces","locations":["eastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000005VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000005PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000005VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000005"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005?$expand=instanceView&api-version=2022-03-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000005\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastasia\",\r\n
+        \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
+        \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"e2ac224c-f9c1-4bdf-8f23-4f9f72feab57\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"9600.20520.220807\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_ca35c1ff9a084f95ae9c67768be8b6b1\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_ca35c1ff9a084f95ae9c67768be8b6b1\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        127\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"clitest-vm000005\",\r\n      \"adminUsername\":
+        \"clitest-vm000005\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\":
+        true,\r\n        \"enableAutomaticUpdates\": true,\r\n        \"patchSettings\":
+        {\r\n          \"patchMode\": \"AutomaticByOS\",\r\n          \"assessmentMode\":
+        \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
+        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\": {\r\n      \"vmAgent\":
+        {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n        \"statuses\": [\r\n
+        \         {\r\n            \"code\": \"ProvisioningState/Unavailable\",\r\n
+        \           \"level\": \"Warning\",\r\n            \"displayStatus\": \"Not
+        Ready\",\r\n            \"message\": \"VM status blob is found but not yet
+        populated.\",\r\n            \"time\": \"2022-08-25T19:34:45+00:00\"\r\n          }\r\n
+        \       ]\r\n      },\r\n      \"disks\": [\r\n        {\r\n          \"name\":
+        \"clitest-vm000005_disk1_ca35c1ff9a084f95ae9c67768be8b6b1\",\r\n          \"statuses\":
+        [\r\n            {\r\n              \"code\": \"ProvisioningState/succeeded\",\r\n
+        \             \"level\": \"Info\",\r\n              \"displayStatus\": \"Provisioning
+        succeeded\",\r\n              \"time\": \"2022-08-25T19:34:13.2391297+00:00\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\":
+        \"V1\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2022-08-25T19:34:28.2080238+00:00\"\r\n
+        \       },\r\n        {\r\n          \"code\": \"PowerState/running\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2022-08-25T19:34:11.4266126+00:00\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3426'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3997,Microsoft.Compute/LowCostGet30Min;31997
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-network/20.0.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000005VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\",\r\n
+        \ \"etag\": \"W/\\\"c0a6c186-0324-4357-a96c-77c8f591d66c\\\"\",\r\n  \"tags\":
+        {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n    \"Purpose\":
+        \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\": \"No\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"b1f1c1cd-1a0f-4305-99d0-3613caa88624\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000005\",\r\n        \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\",\r\n
+        \       \"etag\": \"W/\\\"c0a6c186-0324-4357-a96c-77c8f591d66c\\\"\",\r\n
+        \       \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000005VNET/subnets/clitest-vm000005Subnet\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"1oe0kii1pbueleyriggzxl133d.hx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-85-90-80\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000005NSG\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\",\r\n
+        \ \"location\": \"eastasia\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2476'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:46 GMT
+      etag:
+      - W/"c0a6c186-0324-4357-a96c-77c8f591d66c"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - afbcd296-2d6b-4c53-9f7f-9b2057bf7cf4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json, text/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-network/20.0.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP?api-version=2018-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000005PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000005PublicIP\",\r\n
+        \ \"etag\": \"W/\\\"bc7cfede-84fa-49cf-919f-b0fe7679e0f5\\\"\",\r\n  \"location\":
+        \"eastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\":
+        \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n
+        \   \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\":
+        \"Succeeded\",\r\n    \"resourceGuid\": \"75747602-d579-4177-8e8b-d14876a66efe\",\r\n
+        \   \"ipAddress\": \"20.239.75.96\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n
+        \   \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic/ipConfigurations/ipconfigclitest-vm000005\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1062'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:46 GMT
+      etag:
+      - W/"bc7cfede-84fa-49cf-919f-b0fe7679e0f5"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 7d4c5af6-f139-4938-97db-c52ac2e76e4c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-compute/27.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005?api-version=2022-03-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000005\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005\",\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastasia\",\r\n
+        \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n
+        \   \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"AutoShutdown\":
+        \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"vmId\": \"e2ac224c-f9c1-4bdf-8f23-4f9f72feab57\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\",\r\n        \"exactVersion\":
+        \"9600.20520.220807\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Windows\",\r\n        \"name\": \"clitest-vm000005_disk1_ca35c1ff9a084f95ae9c67768be8b6b1\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\",\r\n
+        \         \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/clitest-vm000005_disk1_ca35c1ff9a084f95ae9c67768be8b6b1\"\r\n
+        \       },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\":
+        127\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\":
+        {\r\n      \"computerName\": \"clitest-vm000005\",\r\n      \"adminUsername\":
+        \"clitest-vm000005\",\r\n      \"windowsConfiguration\": {\r\n        \"provisionVMAgent\":
+        true,\r\n        \"enableAutomaticUpdates\": true,\r\n        \"patchSettings\":
+        {\r\n          \"patchMode\": \"AutomaticByOS\",\r\n          \"assessmentMode\":
+        \"ImageDefault\"\r\n        },\r\n        \"enableVMAgentPlatformUpdates\":
+        false\r\n      },\r\n      \"secrets\": [],\r\n      \"allowExtensionOperations\":
+        true,\r\n      \"requireGuestProvisionSignal\": true\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000005VMNic\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\": \"2022-08-25T19:34:11.4266126+00:00\"\r\n
+        \ }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:34:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3996,Microsoft.Compute/LowCostGet30Min;31996
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000004","etag":"W/\"datetime''2022-08-25T19%3A32%3A26.8897623Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"Unassigned","redundancySettings":{"standardTierStorageRedundancy":"GeoRedundant","crossRegionRestore":"Disabled"},"monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '757'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:34:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2022-08-26T05:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-08-26T05:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '764'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:34:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectableItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:34:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/refreshContainers?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationsStatus/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:34:55 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:34:56 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:35:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/operationResults/29fbebf4-9b96-43d7-918c-c3468fdc9b5c?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Thu, 25 Aug 2022 19:35:07 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectableItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000005","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '917'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "Microsoft.Compute/virtualMachines",
+      "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/vm%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:35:11 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:35:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '138'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '135'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"InProgress","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5f6854d8-4053-4034-87fb-8ed304cb909b?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5f6854d8-4053-4034-87fb-8ed304cb909b","name":"5f6854d8-4053-4034-87fb-8ed304cb909b","status":"Succeeded","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"2022-08-25T19:35:12.1889784Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"2479d6ea-ca23-4cf9-bf6c-9172cf197970"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/2479d6ea-ca23-4cf9-bf6c-9172cf197970?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/2479d6ea-ca23-4cf9-bf6c-9172cf197970","name":"2479d6ea-ca23-4cf9-bf6c-9172cf197970","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M31.552151S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2022-08-25T19:35:12.1889784Z","endTime":"2022-08-25T19:36:43.7411294Z","activityId":"fa8f4ee4-24ac-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '849'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1508'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"objectType": "IaasVMBackupRequest", "recoveryPointExpiryTimeInUTC":
+      "2022-09-24T00:00:00.000Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/backup?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/d7fd5eca-bc06-416a-9465-b325239db499?api-version=2022-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:36:49 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/d7fd5eca-bc06-416a-9465-b325239db499?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/d7fd5eca-bc06-416a-9465-b325239db499?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"d7fd5eca-bc06-416a-9465-b325239db499","name":"d7fd5eca-bc06-416a-9465-b325239db499","status":"Succeeded","startTime":"2022-08-25T19:36:50.7137453Z","endTime":"2022-08-25T19:36:50.7137453Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"1d2e360b-e4c3-4787-9200-c4bad81f70c8"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT3.3294135S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1036'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT4.6029231S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1036'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT5.3125259S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1036'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:36:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT36.1489149S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1037'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:37:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M6.9733443S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:37:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M37.8491093S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:38:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT2M8.623828S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1037'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:38:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT2M39.6125282S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:39:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT3M10.3665526S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:40:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT3M42.3863942S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:40:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT4M13.158806S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:41:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT4M43.8248329S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:41:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT5M14.4537625S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:42:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '138'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT5M45.1971466S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:42:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT6M16.034501S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:43:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT6M46.8024261S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:43:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '135'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT7M17.6034849S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"InProgress"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1039'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:44:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT7M48.6291694S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"Completed"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:44:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT8M19.8857896S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"Completed"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:45:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '132'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT8M50.816201S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"Completed"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1037'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:45:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT9M21.7145537S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"Completed"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2022-08-25T19:36:50.7137453Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1038'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:46:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/1d2e360b-e4c3-4787-9200-c4bad81f70c8","name":"1d2e360b-e4c3-4787-9200-c4bad81f70c8","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT9M40.234628S","errorDetails":[{"errorCode":400158,"errorTitle":"UserErrorJobSuccessfullyCancelled","errorString":"Job
+        is cancelled.","recommendations":[]}],"virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","duration":"PT0S","status":"Completed"},{"taskId":"Transfer data
+        to vault","duration":"PT0S","status":"Cancelled"}],"propertyBag":{"VM Name":"clitest-vm000005","Recovery
+        Point Expiry Time in UTC":"9/24/2022 12:00:00 AM","Backup Size":"0 MB"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Backup","status":"CompletedWithWarnings","startTime":"2022-08-25T19:36:50.7137453Z","endTime":"2022-08-25T19:46:30.9483733Z","activityId":"41aba82c-24ad-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1251'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:46:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"TransientDegraded","resourceHealthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}]}},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"ActionSuggested","healthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}],"lastBackupStatus":"Failed","lastBackupTime":"2022-08-25T19:43:12.0517966Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2022-08-25T19:36:56.5371335Z","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1919'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/recoveryPoints?api-version=2022-02-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/recoveryPoints/2026846362914711367","name":"2026846362914711367","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"IaasVMRecoveryPoint","recoveryPointType":"AppConsistent","recoveryPointTime":"2022-08-25T19:36:56.5371335Z","recoveryPointAdditionalInfo":"","sourceVMStorageType":"PremiumVMOnPartialPremiumStorage","isSourceVMEncrypted":false,"isInstantIlrSessionActive":false,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}],"isManagedVirtualMachine":true,"virtualMachineSize":"Standard_DS1_v2","originalStorageAccountOption":false,"osType":"Windows","recoveryPointMoveReadinessInfo":{"ArchivedRP":{"isReadyForMove":false,"additionalInfo":"Recovery
+        point cannot be moved to Archive tier due to insufficient retention duration
+        specified in policy.. Update policy on the protected item with appropriate
+        retention setting and try again."}}}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1287'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"TransientDegraded","resourceHealthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}]}},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"ActionSuggested","healthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}],"lastBackupStatus":"Failed","lastBackupTime":"2022-08-25T19:43:12.0517966Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2022-08-25T19:36:56.5371335Z","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1919'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectionContainers?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+friendlyName+eq+%27clitest-vm000005%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"TransientDegraded","resourceHealthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}]}},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"ActionSuggested","healthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}],"lastBackupStatus":"Failed","lastBackupTime":"2022-08-25T19:43:12.0517966Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2022-08-25T19:36:56.5371335Z","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1919'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectionContainers?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+friendlyName+eq+%27clitest-vm000005%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:47:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/recoveryPoints/2026846362914711367?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/recoveryPoints/2026846362914711367","name":"2026846362914711367","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"IaasVMRecoveryPoint","recoveryPointType":"AppConsistent","recoveryPointTime":"2022-08-25T19:36:56.5371335Z","recoveryPointAdditionalInfo":"","sourceVMStorageType":"PremiumVMOnPartialPremiumStorage","isSourceVMEncrypted":false,"isInstantIlrSessionActive":false,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"}],"isManagedVirtualMachine":true,"virtualMachineSize":"Standard_DS1_v2","originalStorageAccountOption":false,"osType":"Windows","recoveryPointMoveReadinessInfo":{"ArchivedRP":{"isReadyForMove":false,"additionalInfo":"Recovery
+        point cannot be moved to Archive tier due to insufficient retention duration
+        specified in policy.. Update policy on the protected item with appropriate
+        retention setting and try again."}}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1275'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000004","etag":"W/\"datetime''2022-08-25T19%3A32%3A26.8897623Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","backupStorageVersion":"V2","redundancySettings":{"standardTierStorageRedundancy":"GeoRedundant","crossRegionRestore":"Disabled"},"monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '749'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupEncryptionConfigs/backupResourceEncryptionConfig?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupEncryptionConfigs/backupResourceEncryptionConfig","name":"backupResourceEncryptionConfig","type":"Microsoft.RecoveryServices/vaults/backupEncryptionConfigs","properties":{"useSystemAssignedIdentity":true,"encryptionAtRestType":"MicrosoftManaged","lastUpdateStatus":"NotEnabled","infrastructureEncryptionState":"Disabled"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '483'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.ClassicStorage/storageAccounts/clitest000008?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ClassicStorage/storageAccounts/clitest000008''
+        under resource group ''clitest.rg000003'' was not found. For more details
+        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '242'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:48:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000003/providers/Microsoft.Storage/storageAccounts/clitest000008?api-version=2016-01-01
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000003/providers/Microsoft.Storage/storageAccounts/clitest000008","name":"clitest000008","type":"Microsoft.Storage/storageAccounts","location":"eastasia","tags":{},"properties":{"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2022-08-25T19:47:23.4669258Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-08-25T19:47:23.4200516Z","primaryEndpoints":{"blob":"https://clitest000008.blob.core.windows.net/","queue":"https://clitest000008.queue.core.windows.net/","table":"https://clitest000008.table.core.windows.net/","file":"https://clitest000008.file.core.windows.net/"},"primaryLocation":"eastasia","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '839'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"objectType": "IaasVMRestoreRequest", "recoveryPointId":
+      "2026846362914711367", "recoveryType": "RestoreDisks", "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005",
+      "targetResourceGroupId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000002",
+      "storageAccountId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000003/providers/Microsoft.Storage/storageAccounts/clitest000008",
+      "region": "eastasia", "createNewCloudService": false, "originalStorageAccountOption":
+      false}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '666'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/recoveryPoints/2026846362914711367/restore?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationsStatus/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:48:07 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/operationResults/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","status":"Succeeded","startTime":"2022-08-25T19:48:07.5339596Z","endTime":"2022-08-25T19:48:07.5339596Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"c7781de3-4bde-4ba7-a850-3121e1d17440"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r -t --storage-account --storage-account-resource-group
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT3.369502S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"InProgress"}],"propertyBag":{"Job
+        Type":"Recover disks","Target VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Target resource group":"clitest.rg000002"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":1.0},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"InProgress","startTime":"2022-08-25T19:48:07.5339596Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1108'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT6.1287458S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"InProgress"}],"propertyBag":{"Job
+        Type":"Recover disks","Target VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Target resource group":"clitest.rg000002"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":1.0},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"InProgress","startTime":"2022-08-25T19:48:07.5339596Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1109'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT6.9179334S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"InProgress"}],"propertyBag":{"Job
+        Type":"Recover disks","Target VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Target resource group":"clitest.rg000002"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":1.0},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"InProgress","startTime":"2022-08-25T19:48:07.5339596Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1109'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT37.9956109S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"Completed","taskExecutionDetails":"127
+        GBs / 127 GBs Transferred"}],"propertyBag":{"Job Type":"Recover disks","Target
+        VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Target resource group":"clitest.rg000002"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":99.0,"estimatedRemainingDuration":"PT2M"},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"InProgress","startTime":"2022-08-25T19:48:07.5339596Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1201'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:48:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M7.3057401S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"Completed","taskExecutionDetails":"127
+        GBs / 127 GBs Transferred"}],"propertyBag":{"Job Type":"Recover disks","Target
+        VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Config Blob Name":"config-clitestvmp5qdu-c7781de3-4bde-4ba7-a850-3121e1d17440.json","Config
+        Blob Container Name":"clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa","Config
+        Blob Uri":"https://clitest000008.blob.core.windows.net/clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa/config-clitestvmp5qdu-c7781de3-4bde-4ba7-a850-3121e1d17440.json","Target
+        resource group":"clitest.rg000002","Template Blob Uri":"https://clitest000008.blob.core.windows.net/clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa/azuredeployc7781de3-4bde-4ba7-a850-3121e1d17440.json"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":100.0,"estimatedRemainingDuration":"PT0S"},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"Completed","startTime":"2022-08-25T19:48:07.5339596Z","endTime":"2022-08-25T19:49:14.8396997Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1750'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/c7781de3-4bde-4ba7-a850-3121e1d17440","name":"c7781de3-4bde-4ba7-a850-3121e1d17440","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M7.3057401S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Transfer
+        data from vault","duration":"PT0S","status":"Completed","taskExecutionDetails":"127
+        GBs / 127 GBs Transferred"}],"propertyBag":{"Job Type":"Recover disks","Target
+        VM Name":"vmName","Target Storage Account Name":"clitest000008","Recovery
+        point time ":"8/25/2022 7:36:56 PM","Config Blob Name":"config-clitestvmp5qdu-c7781de3-4bde-4ba7-a850-3121e1d17440.json","Config
+        Blob Container Name":"clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa","Config
+        Blob Uri":"https://clitest000008.blob.core.windows.net/clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa/config-clitestvmp5qdu-c7781de3-4bde-4ba7-a850-3121e1d17440.json","Target
+        resource group":"clitest.rg000002","Template Blob Uri":"https://clitest000008.blob.core.windows.net/clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa/azuredeployc7781de3-4bde-4ba7-a850-3121e1d17440.json"},"internalPropertyBag":{"restoreLocationType":"RestoreDisks"},"progressPercentage":100.0,"estimatedRemainingDuration":"PT0S"},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"Restore","status":"Completed","startTime":"2022-08-25T19:48:07.5339596Z","endTime":"2022-08-25T19:49:14.8396997Z","activityId":"cf04d04e-24ae-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1750'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -c -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/storageAccounts?api-version=2022-05-01
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000003/providers/Microsoft.Storage/storageAccounts/clitest000008","name":"clitest000008","type":"Microsoft.Storage/storageAccounts","location":"eastasia","tags":{},"properties":{"keyCreationTime":{"key1":"2022-08-25T19:47:23.4669258Z","key2":"2022-08-25T19:47:23.4669258Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-25T19:47:23.4669258Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-25T19:47:23.4669258Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2022-08-25T19:47:23.4200516Z","primaryEndpoints":{"blob":"https://clitest000008.blob.core.windows.net/","queue":"https://clitest000008.queue.core.windows.net/","table":"https://clitest000008.table.core.windows.net/","file":"https://clitest000008.file.core.windows.net/"},"primaryLocation":"eastasia","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-common-cc-pr/providers/Microsoft.Storage/storageAccounts/docsfxprcc","name":"docsfxprcc","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"defaultToOAuthAuthentication":false,"publicNetworkAccess":"Disabled","keyCreationTime":{"key1":"2022-04-21T01:27:00.4485798Z","key2":"2022-04-21T01:27:00.4485798Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"resourceAccessRules":[],"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[{"value":"70.55.195.114","action":"Allow"}],"defaultAction":"Deny"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-21T01:27:00.4641465Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-21T01:27:00.4641465Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-21T01:27:00.3704622Z","primaryEndpoints":{"dfs":"https://docsfxprcc.dfs.core.windows.net/","web":"https://docsfxprcc.z9.web.core.windows.net/","blob":"https://docsfxprcc.blob.core.windows.net/","queue":"https://docsfxprcc.queue.core.windows.net/","table":"https://docsfxprcc.table.core.windows.net/","file":"https://docsfxprcc.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-python-rg-rg/providers/Microsoft.Storage/storageAccounts/newstrhryfx84","name":"newstrhryfx84","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{},"properties":{"keyCreationTime":{"key1":"2022-07-20T16:56:04.0681194Z","key2":"2022-07-20T16:56:04.0681194Z"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-20T16:56:04.0837494Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-07-20T16:56:04.0837494Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-07-20T16:56:03.9899885Z","primaryEndpoints":{"dfs":"https://newstrhryfx84.dfs.core.windows.net/","web":"https://newstrhryfx84.z9.web.core.windows.net/","blob":"https://newstrhryfx84.blob.core.windows.net/","queue":"https://newstrhryfx84.queue.core.windows.net/","table":"https://newstrhryfx84.table.core.windows.net/","file":"https://newstrhryfx84.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-common-cc-pr/providers/Microsoft.Storage/storageAccounts/stcommonfx","name":"stcommonfx","type":"Microsoft.Storage/storageAccounts","location":"canadacentral","tags":{"env":"prod","app":"common","owner":"youness.dendane@fxinnovation.com"},"properties":{"defaultToOAuthAuthentication":false,"keyCreationTime":{"key1":"2022-04-15T02:54:50.4151247Z","key2":"2022-04-15T02:54:50.4151247Z"},"allowCrossTenantReplication":true,"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_2","allowBlobPublicAccess":false,"allowSharedKeyAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"requireInfrastructureEncryption":false,"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-15T02:54:50.4151247Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-04-15T02:54:50.4151247Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-04-15T02:54:50.3369842Z","primaryEndpoints":{"dfs":"https://stcommonfx.dfs.core.windows.net/","web":"https://stcommonfx.z9.web.core.windows.net/","blob":"https://stcommonfx.blob.core.windows.net/","queue":"https://stcommonfx.queue.core.windows.net/","table":"https://stcommonfx.table.core.windows.net/","file":"https://stcommonfx.file.core.windows.net/"},"primaryLocation":"canadacentral","statusOfPrimary":"available"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '5921'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 25 Aug 2022 19:49:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-original-request-ids:
+      - 5876f1e8-402d-41f3-beb0-a6d9ab90734d
+      - 77d4c65d-b992-47a0-a4fd-677920e968b4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob exists
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --account-name -c -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000003/providers/Microsoft.Storage/storageAccounts/clitest000008/listKeys?api-version=2022-05-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2022-08-25T19:47:23.4669258Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-08-25T19:47:23.4669258Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage blob exists
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -c -n
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+      x-ms-date:
+      - Thu, 25 Aug 2022 19:49:50 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: HEAD
+    uri: https://clitest000008.blob.core.windows.net/clitestvmp5qdu-d8e98925541344eaa2b51b3af6ef4bfa/config-clitestvmp5qdu-c7781de3-4bde-4ba7-a850-3121e1d17440.json
+  response:
+    body:
+      string: ''
+    headers:
+      accept-ranges:
+      - bytes
+      content-length:
+      - '5120'
+      content-type:
+      - application/octet-stream
+      date:
+      - Thu, 25 Aug 2022 19:49:51 GMT
+      etag:
+      - '"0x8DA86D2E2DBE392"'
+      last-modified:
+      - Thu, 25 Aug 2022 19:49:13 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-blob-sequence-number:
+      - '0'
+      x-ms-blob-type:
+      - PageBlob
+      x-ms-creation-time:
+      - Thu, 25 Aug 2022 19:49:13 GMT
+      x-ms-lease-state:
+      - available
+      x-ms-lease-status:
+      - unlocked
+      x-ms-meta-configblobsize:
+      - '5120'
+      x-ms-server-encrypted:
+      - 'true'
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type -v -g --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectionContainers?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c --query
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"TransientDegraded","resourceHealthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}]},"RestoreOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"ActionSuggested","healthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}],"lastBackupStatus":"Failed","lastBackupTime":"2022-08-25T19:43:12.0517966Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2022-08-25T19:36:56.5371335Z","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2071'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupProtectedItems?api-version=2022-02-01&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"TransientDegraded","resourceHealthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}]},"RestoreOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000005","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"ActionSuggested","healthDetails":[{"code":400158,"title":"UserErrorJobSuccessfullyCancelled","message":"Job
+        is cancelled.","recommendations":[]}],"lastBackupStatus":"Failed","lastBackupTime":"2022-08-25T19:43:12.0517966Z","protectedItemDataId":"365524995","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000005","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2022-08-25T19:36:56.5371335Z","isArchiveEnabled":false}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2071'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupResourceGuardProxies?api-version=2022-02-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:49:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000005?api-version=2022-02-01
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:49:59 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperationResults/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14999'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '143'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:50:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '138'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '135'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '132'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"InProgress","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupOperations/5e097f4e-bdbb-48df-b5de-bbf5b0a55353?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","name":"5e097f4e-bdbb-48df-b5de-bbf5b0a55353","status":"Succeeded","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"2022-08-25T19:49:59.8305612Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"3c55aaf2-abdd-4308-b179-f18b0df2a740"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '128'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservicesbackup/5.0.0 Python/3.9.13
+        (macOS-12.5.1-x86_64-i386-64bit)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/3c55aaf2-abdd-4308-b179-f18b0df2a740?api-version=2022-02-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004/backupJobs/3c55aaf2-abdd-4308-b179-f18b0df2a740","name":"3c55aaf2-abdd-4308-b179-f18b0df2a740","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000005","duration":"PT1M51.492668S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000005","Number of Recovery Points":"1"}},"entityFriendlyName":"clitest-vm000005","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2022-08-25T19:49:59.8305612Z","endTime":"2022-08-25T19:51:51.3232292Z","activityId":"17b69d72-24af-11ed-a9c7-acde48001122"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '852'
+      content-type:
+      - application/json
+      date:
+      - Thu, 25 Aug 2022 19:51:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g --yes
+      User-Agent:
+      - AZURECLI/2.39.0 azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.9.13 (macOS-12.5.1-x86_64-i386-64bit)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000004?api-version=2022-04-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 25 Aug 2022 19:52:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '9'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/test_backup_commands.py
@@ -634,6 +634,58 @@ class BackupTests(ScenarioTest, unittest.TestCase):
             self.check("resourceGroup", '{rg}')
         ])
 
+    @AllowLargeResponse()
+    @ResourceGroupPreparer(location="eastasia")
+    @ResourceGroupPreparer(parameter_name="target_resource_group", location="eastasia")
+    @ResourceGroupPreparer(parameter_name="storage_account_resource_group", location="eastasia")
+    @VaultPreparer(soft_delete=False)
+    @VMPreparer()
+    @ItemPreparer()
+    @RPPreparer()
+    @StorageAccountPreparer(location="eastasia", resource_group_parameter_name="storage_account_resource_group")
+    def test_backup_restore_when_storage_in_different_rg(self, resource_group, target_resource_group, vault_name, vm_name, storage_account, storage_account_resource_group):
+
+        self.kwargs.update({
+            'vault': vault_name,
+            'vm': vm_name,
+            'target_rg': target_resource_group,
+            'rg': resource_group,
+            'sa': storage_account,
+            'sa_rg': storage_account_resource_group,
+            'vm_id': "VM;iaasvmcontainerv2;" + resource_group + ";" + vm_name,
+            'container_id': "IaasVMContainer;iaasvmcontainerv2;" + resource_group + ";" + vm_name,
+            'vnet_name': self.create_random_name('clitest-vnet', 30),
+            'subnet_name': self.create_random_name('clitest-subnet', 30),
+            'target_vm_name': self.create_random_name('clitest-tvm', 15)
+        })
+
+        self.kwargs['rp'] = self.cmd('backup recoverypoint list --backup-management-type AzureIaasVM --workload-type VM -g {rg} -v {vault} -c {vm} -i {vm} --query [0].name').get_output_in_json()
+
+        # Trigger Restore Disks
+        trigger_restore_job_json = self.cmd('backup restore restore-disks -g {rg} -v {vault} -c {vm} -i {vm} -r {rp} -t {target_rg} --storage-account {sa} --storage-account-resource-group {sa_rg}', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "InProgress"),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
+        self.kwargs['job'] = trigger_restore_job_json['name']
+        self.cmd('backup job wait -g {rg} -v {vault} -n {job}')
+
+        trigger_restore_job_details = self.cmd('backup job show -g {rg} -v {vault} -n {job}', checks=[
+            self.check("properties.entityFriendlyName", '{vm}'),
+            self.check("properties.operation", "Restore"),
+            self.check("properties.status", "Completed"),
+            self.check("resourceGroup", '{rg}')
+        ]).get_output_in_json()
+
+        property_bag = trigger_restore_job_details['properties']['extendedInfo']['propertyBag']
+        self.assertEqual(property_bag['Target Storage Account Name'], storage_account)
+
+        self.kwargs['container'] = property_bag['Config Blob Container Name']
+        self.kwargs['blob'] = property_bag['Config Blob Name']
+
+        self.cmd('storage blob exists --account-name {sa} -c {container} -n {blob}', checks=self.check("exists", True))
+
 
     #@AllowLargeResponse()
     #@ResourceGroupPreparer(location="centraluseuap")


### PR DESCRIPTION
**Related command**
```pwsh
az backup restore restore-disks
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR comes to fix the case when we want to do a restore, but the storage account is in a different resource group than the vault. More information here: #23655 

We now can support this scenario by adding a new param `--storage-account-resource-group` that indicates the resource group of the storage account.

If `--storage-account-resource-group` is not passed, `--storage-account-resource-group` will default to the value of the `--resource-group` parameter.

**Testing Guide**
<!--Example commands with explanations.-->
```pwsh
az backup restore restore-disks \
--resource-group {rg} \
--vault-name {vault_name} \
--container-name {vm} \
--item-name {vm} \
--storage-account {sa} \
--storage-account-resource-group {sa_rg} \
--rp-name {rp}
```

**History Notes**
Fix #23655: `az backup restore restore-disks`: Support storage account being in a different resource group than the recovery service vault

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
