### PR TITLE
{CI} Fix automation full test not failure issue

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -267,7 +267,7 @@ class AutomaticScheduling(object):
 
     def run_instance_modules(self, instance_modules):
         # divide the modules that the current instance needs to execute into parallel or serial execution
-        error_flag = False
+        serial_error_flag = parallel_error_flag = False
         serial_tests = []
         parallel_tests = []
         for k, v in instance_modules.items():
@@ -279,13 +279,13 @@ class AutomaticScheduling(object):
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{instance_idx}.serial.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + serial_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '"--durations=10"']
-            error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
+            serial_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
         if parallel_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{instance_idx}.parallel.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallel_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '"--durations=10"']
-            error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-        return error_flag
+            parallel_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
+        return serial_error_flag or parallel_error_flag
 
 
 def main():

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_express_route_port.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_express_route_port.yaml
@@ -342,7 +342,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.26.0 azsdk-python-azure-mgmt-keyvault/9.0.0 Python/3.8.10 (Windows-10-10.0.19043-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002?api-version=2021-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002?api-version=2022-07-01
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002",
@@ -425,7 +425,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.26.0 azsdk-python-azure-mgmt-keyvault/9.0.0 Python/3.8.10 (Windows-10-10.0.19043-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002?api-version=2021-06-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002?api-version=2022-07-01
   response:
     body:
       string: '{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_express_route_port000001/providers/Microsoft.KeyVault/vaults/test-er-port-kv000002",


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
There's a strange phenomenon in our dev CI (eg https://github.com/Azure/azure-cli/runs/7969635224) that
- `Automation Full Test` all pass
- `Test XX Package` fail in `test_network_express_route_port`

The `test_network_express_route_port` fails because of keyvault bumping version without rerecording `test_network_express_route_port.yaml`. This failure doesn't show up in [keyvault bump version PR](https://github.com/Azure/azure-cli/pull/23621) either

This PR:
- fix `Automation Full Test` doesn't fail issue
- fix `test_network_express_route_port` recording failure

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
