### PR TITLE
[AKS] `az aks update`: Update without args prompts to reconcile

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -622,7 +622,7 @@ examples:
 
 helps['aks update'] = """
 type: command
-short-summary: Update a managed Kubernetes cluster.
+short-summary: Update a managed Kubernetes cluster. When called with no optional arguments this attempts to move the cluster to its goal state without changing the current cluster configuration. This can be used to move out of a non succeeded state.
 parameters:
   - name: --enable-cluster-autoscaler -e
     type: bool
@@ -801,6 +801,8 @@ parameters:
     short-summary: HTTP Proxy configuration for this cluster.
 
 examples:
+  - name: Reconcile the cluster back to its current state.
+    text: az aks update -g MyResourceGroup -n MyManagedCluster
   - name: Update a kubernetes cluster with standard SKU load balancer to use two AKS created IPs for the load balancer outbound connection usage.
     text: az aks update -g MyResourceGroup -n MyManagedCluster --load-balancer-managed-outbound-ip-count 2
   - name: Update a kubernetes cluster with standard SKU load balancer to use the provided public IPs for the load balancer outbound connection usage.
@@ -1161,7 +1163,8 @@ short-summary: Show the details for a node pool in the managed Kubernetes cluste
 
 helps['aks nodepool update'] = """
 type: command
-short-summary: Update a node pool to enable/disable cluster-autoscaler or change min-count or max-count
+short-summary: Update a node pool properties.
+long-summary: Update a node pool to enable/disable cluster-autoscaler or change min-count or max-count. When called with no optional arguments this attempts to move the node pool to its goal state without changing the current node pool configuration. This can be used to move out of a non succeeded state.
 parameters:
   - name: --enable-cluster-autoscaler -e
     type: bool
@@ -1197,6 +1200,8 @@ parameters:
     type: string
     short-summary: Comma-separated key-value pairs to specify custom headers.
 examples:
+  - name: Reconcile the nodepool back to its current state.
+    text: az aks nodepool update -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster
   - name: Enable cluster-autoscaler within node count range [1,5]
     text: az aks nodepool update --enable-cluster-autoscaler --min-count 1 --max-count 5 -g MyResourceGroup -n nodepool1 --cluster-name MyManagedCluster
   - name: Disable cluster-autoscaler for an existing cluster

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -28,6 +28,7 @@ from azure.cli.command_modules.acs._helpers import (
     check_is_managed_aad_cluster,
     check_is_msi_cluster,
     check_is_private_cluster,
+    format_parameter_name_to_option_name,
     get_user_assigned_identity_by_resource_id,
     map_azure_error_to_cli_error,
     safe_list_get,
@@ -5377,49 +5378,18 @@ class AKSManagedClusterUpdateDecorator(BaseAKSManagedClusterDecorator):
         )
 
         if not is_changed and is_default:
-            # Note: Uncomment the followings to automatically generate the error message.
-            # option_names = [
-            #     '"{}"'.format(format_parameter_name_to_option_name(x))
-            #     for x in self.context.raw_param.keys()
-            #     if x not in excluded_keys
-            # ]
-            # error_msg = "Please specify one or more of {}.".format(
-            #     " or ".join(option_names)
-            # )
-            # raise RequiredArgumentMissingError(error_msg)
-            raise RequiredArgumentMissingError(
-                'Please specify one or more of "--enable-cluster-autoscaler" or '
-                '"--disable-cluster-autoscaler" or '
-                '"--update-cluster-autoscaler" or '
-                '"--cluster-autoscaler-profile" or '
-                '"--load-balancer-managed-outbound-ip-count" or '
-                '"--load-balancer-outbound-ips" or '
-                '"--load-balancer-outbound-ip-prefixes" or '
-                '"--load-balancer-outbound-ports" or '
-                '"--load-balancer-idle-timeout" or '
-                '"--nat-gateway-managed-outbound-ip-count" or '
-                '"--nat-gateway-idle-timeout" or '
-                '"--auto-upgrade-channel" or '
-                '"--attach-acr" or "--detach-acr" or '
-                '"--uptime-sla" or '
-                '"--no-uptime-sla" or '
-                '"--api-server-authorized-ip-ranges" or '
-                '"--enable-aad" or '
-                '"--aad-tenant-id" or '
-                '"--aad-admin-group-object-ids" or '
-                '"--enable-ahub" or '
-                '"--disable-ahub" or '
-                '"--windows-admin-password" or '
-                '"--enable-managed-identity" or '
-                '"--assign-identity" or '
-                '"--enable-azure-rbac" or '
-                '"--disable-azure-rbac" or '
-                '"--enable-public-fqdn" or '
-                '"--disable-public-fqdn" or '
-                '"--tags" or '
-                '"--nodepool-labels" or '
-                '"--enble-windows-gmsa".'
-            )
+            reconcilePrompt = 'no argument specified to update would you like to reconcile to current settings?'
+            if not prompt_y_n(reconcilePrompt, default="n"):
+                # Note: Uncomment the followings to automatically generate the error message.
+                option_names = [
+                    '"{}"'.format(format_parameter_name_to_option_name(x))
+                    for x in self.context.raw_param.keys()
+                    if x not in excluded_keys
+                ]
+                error_msg = "Please specify one or more of {}.".format(
+                    " or ".join(option_names)
+                )
+                raise RequiredArgumentMissingError(error_msg)
 
     def _ensure_mc(self, mc: ManagedCluster) -> None:
         """Internal function to ensure that the incoming `mc` object is valid and the same as the attached `mc` object

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -6637,7 +6637,17 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             ResourceType.MGMT_CONTAINERSERVICE,
         )
         # fail on no updated parameter provided
-        with self.assertRaises(RequiredArgumentMissingError):
+        with patch(
+            "azure.cli.command_modules.acs.managed_cluster_decorator.prompt_y_n",
+            return_value=False,
+        ), self.assertRaises(RequiredArgumentMissingError):
+            dec_1.check_raw_parameters()
+
+        # unless user says they want to reconcile
+        with patch(
+            "azure.cli.command_modules.acs.managed_cluster_decorator.prompt_y_n",
+            return_value=True,
+        ):
             dec_1.check_raw_parameters()
 
         # custom value


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

- `az aks update`
- `az aks nodepool update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Add support for calling `az aks update` and `az aks nodepool update` with no optional arguments, which attempts to move the cluster/node pool to its goal state without changing the current cluster/node pool configuration. This can be used to move out of a non-succeeded state.

Sync PR [#4759](https://github.com/Azure/azure-cli-extensions/pull/4759).


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
