### PR TITLE
[AKS] Fix #23653: `az aks create`: Fix the CrashLoopBackOff issue when set `--network-policy` to 'Calico'

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -39,7 +39,7 @@ from azure.cli.command_modules.acs._validators import (
     validate_keyvault_secrets_provider_disable_and_enable_parameters,
     validate_kubectl_version, validate_kubelogin_version,
     validate_linux_host_name, validate_list_of_integers,
-    validate_load_balancer_idle_timeout,
+    validate_load_balancer_idle_timeout, validate_network_policy,
     validate_load_balancer_outbound_ip_prefixes,
     validate_load_balancer_outbound_ips, validate_load_balancer_outbound_ports,
     validate_load_balancer_sku, validate_max_surge,
@@ -257,7 +257,7 @@ def load_arguments(self, _):
         c.argument('nat_gateway_idle_timeout', type=int, validator=validate_nat_gateway_idle_timeout)
         c.argument('outbound_type', arg_type=get_enum_type(outbound_types))
         c.argument('network_plugin', arg_type=get_enum_type(network_plugins))
-        c.argument('network_policy')
+        c.argument('network_policy', validator=validate_network_policy)
         c.argument('auto_upgrade_channel', arg_type=get_enum_type(auto_upgrade_channels))
         c.argument('cluster_autoscaler_profile', nargs='+', options_list=["--cluster-autoscaler-profile", "--ca-profile"],
                    help="Space-separated list of key=value pairs for configuring cluster autoscaler. Pass an empty string to clear the profile.")

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -223,7 +223,7 @@ def validate_load_balancer_idle_timeout(namespace):
         if namespace.load_balancer_idle_timeout < 4 or namespace.load_balancer_idle_timeout > 100:
             raise CLIError("--load-balancer-idle-timeout must be in the range [4,100]")
 
-            
+
 def validate_network_policy(namespace):
     """validate network policy to be in lowercase"""
     if namespace.network_policy.islower() is False:

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -226,7 +226,7 @@ def validate_load_balancer_idle_timeout(namespace):
             
 def validate_network_policy(namespace):
     """validate network policy to be in lowercase"""
-    if namespace.network_policy.islower() == False:
+    if namespace.network_policy.islower() is False:
             raise CLIError("--network-policy should be provided in lowercase")
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -223,6 +223,12 @@ def validate_load_balancer_idle_timeout(namespace):
         if namespace.load_balancer_idle_timeout < 4 or namespace.load_balancer_idle_timeout > 100:
             raise CLIError("--load-balancer-idle-timeout must be in the range [4,100]")
 
+            
+def validate_network_policy(namespace):
+    """validate network policy to be in lowercase"""
+    if namespace.network_policy.islower() == False:
+            raise CLIError("--network-policy should be provided in lowercase")
+
 
 def validate_nat_gateway_managed_outbound_ip_count(namespace):
     """validate NAT gateway profile managed outbound IP count"""

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -227,7 +227,7 @@ def validate_load_balancer_idle_timeout(namespace):
 def validate_network_policy(namespace):
     """validate network policy to be in lowercase"""
     if namespace.network_policy.islower() is False:
-            raise InvalidArgumentValueError("--network-policy should be provided in lowercase")
+        raise InvalidArgumentValueError("--network-policy should be provided in lowercase")
 
 
 def validate_nat_gateway_managed_outbound_ip_count(namespace):

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -226,7 +226,7 @@ def validate_load_balancer_idle_timeout(namespace):
 
 def validate_network_policy(namespace):
     """validate network policy to be in lowercase"""
-    if namespace.network_policy.islower() is False:
+    if namespace.network_policy is not None and namespace.network_policy.islower() is False:
         raise InvalidArgumentValueError("--network-policy should be provided in lowercase")
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_validators.py
@@ -227,7 +227,7 @@ def validate_load_balancer_idle_timeout(namespace):
 def validate_network_policy(namespace):
     """validate network policy to be in lowercase"""
     if namespace.network_policy.islower() is False:
-            raise CLIError("--network-policy should be provided in lowercase")
+            raise InvalidArgumentValueError("--network-policy should be provided in lowercase")
 
 
 def validate_nat_gateway_managed_outbound_ip_count(namespace):


### PR DESCRIPTION
 fixes Azure/azure-cli#23653

When using 'az aks create' to build an AKS cluster, if you set --network-policy to 'Calico' vs. 'calico', the cluster will successfully create, but there will be system pods in CrashLoopBackOff.

--network-policy = calico  --> works fine.

--network-policy = Calico --> results in CrashLoopBackOff issue.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
