### PR TITLE
{SQL} `az sql update`: Remove debug output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -503,7 +503,6 @@ def _get_identity_object_from_type(
     if assignIdentityIsPresent is False and existingResourceIdentity is not None:
         identityResult = existingResourceIdentity
 
-    print(identityResult)
     return identityResult
 
 


### PR DESCRIPTION
**Related command**
az sql server update

**Description**<!--Mandatory-->
Calling ```az sql server update -n X -g Y -p Y``` output a debug info block that broke parsing for parent script.
I removed the debug output, fixing the problem.

Example of the problem:
```
az sql server update -n sql-[redacted] -g rg-[redacted] -p [redacted] --output jsonc
{'additional_properties': {}, 'user_assigned_identities': None, 'principal_id': '[redacted]', 'type': 'SystemAssigned', 'tenant_id': '[redacted]'}
{
  "administratorLogin": "[redacted]",
  "administratorLoginPassword": null,
  "administrators": {
    "administratorType": "ActiveDirectory",
    "azureAdOnlyAuthentication": false,
    "login": "[redacted]",
    "principalType": "Group",
    "sid": "[redacted]",
    "tenantId": "[redacted]"
  },
``` 

Fixed output:
```
az sql server update -n sql-[redacted] -g rg-[redacted] -p [redacted] --output jsonc
{
  "administratorLogin": "[redacted]",
  "administratorLoginPassword": null,
  "administrators": {
    "administratorType": "ActiveDirectory",
    "azureAdOnlyAuthentication": false,
    "login": "[redacted]",
    "principalType": "Group",
    "sid": "[redacted]",
    "tenantId": "[redacted]"
  },
``` 

**Testing Guide**
```az sql server update -n X -g Y -p Y``` now only outputs the command result



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
