### PR TITLE
{AMS} `az ams job start`: Update error message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/ams/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_validators.py
@@ -100,6 +100,9 @@ def validate_output_assets(ns):
         from azure.mgmt.media.models import JobOutputAsset
 
         name_and_label = asset_string.split('=')
+        if len(name_and_label) <= 1:
+            message = "Output assets are not in correct format. Output assets should be in 'assetName=label' format. An asset without label can be sent like this: 'assetName='"
+            raise ValueError(message)
         name = name_and_label[0]
         label = name_and_label[1]
         return JobOutputAsset(asset_name=name, label=label)

--- a/src/azure-cli/azure/cli/command_modules/ams/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/_validators.py
@@ -101,7 +101,8 @@ def validate_output_assets(ns):
 
         name_and_label = asset_string.split('=')
         if len(name_and_label) <= 1:
-            message = "Output assets are not in correct format. Output assets should be in 'assetName=label' format. An asset without label can be sent like this: 'assetName='"
+            message = "Output assets are not in correct format. Output assets should be in 'assetName=label'" \
+                      " format. An asset without label can be sent like this: 'assetName='"
             raise ValueError(message)
         name = name_and_label[0]
         label = name_and_label[1]


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az ams job start --account-name accountName --input-asset-name "inputAssetName" --files "fileName" --transform-name "transformName" --output-assets "outputasset" -g rg --name "jobName"`
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Related to this stack overflow question: https://stackoverflow.com/questions/73525827/azure-cli-az-ams-job-start-is-returning-index-out-of-range?newreg=ad82ab836d0a4c85a8a95ec008a7df9a
**Testing Guide**
<!--Example commands with explanations.-->

`az ams job start --account-name accountName --input-asset-name "inputAssetName" --files "fileName" --transform-name "transformName" --output-assets "outputasset" -g rg --name "jobName"`

Above command produces new error output
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
