### PR TITLE
{RDBMS} Fix check for data encryption for geo-redundant server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -264,7 +264,7 @@ def _mysql_byok_validator(byok_identity, backup_byok_identity, byok_key, backup_
         raise ArgumentUsageError("Data encryption cannot be disabled if key or backup key is provided.")
 
     if not disable_data_encryption and (geo_redundant_backup and geo_redundant_backup.lower() == 'enabled') and \
-       backup_byok_identity is None:
+       (byok_identity is not None and backup_byok_identity is None):
         raise ArgumentUsageError("Backup identity and key need to be provided for geo-redundant server.")
 
     if (instance and instance.replication_role == "Replica") and (disable_data_encryption or byok_key):


### PR DESCRIPTION
**Related command**
`az mysql flexible-server create/update`

**Description**<!--Mandatory-->
Fixing a condition check for servers with geo-redundant backup enabled: if we are going to create/update a geo-redundant server and touch data encryption properties, we need to set both principal keys and backup keys; but if we don't want to touch that properties and instead update other things the check will fail and ask for backup key anyway when it's not intended. So, the fix is just to detect if **principal key is provided but backup key is not provided**, not only check if the backup key is not provided.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
