### PR TITLE
{AKS} Add Qatar region to CI

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/addonconfiguration.py
@@ -67,6 +67,7 @@ def ensure_default_log_analytics_workspace_for_monitoring(
         "switzerlandnorth": "CHN",
         "switzerlandwest": "CHW",
         "uaecentral": "AUH",
+        "qatarcentral": "QAC",
     }
     AzureCloudRegionToOmsRegionMap = {
         "australiacentral": "australiacentral",
@@ -112,6 +113,7 @@ def ensure_default_log_analytics_workspace_for_monitoring(
         "eastus2euap": "eastus2euap",
         "centraluseuap": "eastus2euap",
         "brazilsoutheast": "brazilsoutheast",
+        "qatarcentral": "qatarcentral",
     }
 
     # mapping for azure china cloud


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**
This PR is adding Qatar region to the region map. This creates a default location for the workspace during the onboarding scenario.

**Testing Guide**
az aks create -g MyResourceGroup -n MyManagedCluster 
If the resource group's location is in Qatar and workspaceId is not specified, it will create a default workspace in the same location as resource group and the default workspace naming convention contains Qatar region code "QAC"

**History Notes**
[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
