### PR TITLE
[App Config] `az appconfig kv export`: Fix MemoryError while exporting large stores

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
+++ b/src/azure-cli/azure/cli/command_modules/appconfig/_kv_helpers.py
@@ -698,7 +698,6 @@ def __print_preview(old_json, new_json, strict=False):
 def __export_kvset_to_file(file_path, keyvalues, yes):
     kvset = __serialize_kv_list_to_comparable_json_list(keyvalues, ImportExportProfiles.KVSET)
     obj = {KVSetConstants.KVSETRootElementName: kvset}
-    json_string = json.dumps(obj, indent=2, ensure_ascii=False)
     if not yes:
         logger.warning('\n---------------- KVSet Preview ----------------')
         if len(kvset) == 0:
@@ -708,7 +707,7 @@ def __export_kvset_to_file(file_path, keyvalues, yes):
         user_confirmation('Do you want to continue? \n')
     try:
         with open(file_path, 'w', encoding='utf-8') as fp:
-            fp.write(json_string)
+            json.dump(obj, fp, indent=2, ensure_ascii=False)
     except Exception as exception:
         raise FileOperationError("Failed to export key-values to file. " + str(exception))
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Exporting a store to a file:
`az appconfig kv export -d file --path outputfile.json --format json --label * --profile appconfig/kvset -n "MyStoreName" --yes`

**Description**<!--Mandatory-->
Prevents MemoryError crash while exporting AppConfig stores by reducing memory allocation from ~5GB to ~1.5GB for config stores containing about 1GB data.

**Testing Guide**
<!--Example commands with explanations.-->
Manual testing with large store using command above.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
