### PR TITLE
{Packaging} Fix #23559: Disable build_id links

### DIFF
--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -43,6 +43,9 @@ BuildRequires:  %{python_package}-devel
 #      https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
 %undefine _package_note_file
 
+# Do not generate build_id links to prevent conflicts with other package.
+%define _build_id_links none
+
 %description
 A great cloud needs great tools; we're excited to introduce Azure CLI,
  our next generation multi-platform command line experience for Azure.


### PR DESCRIPTION
Fix #23559. This PR disables the generation of build_id links to prevent conflicting with `azure-security` package in RHEL 8.5 on Azure.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
