### PR TITLE
{AD} Remove "below" from JSON arguments' help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -17,7 +17,7 @@ from azure.cli.command_modules.role._validators import validate_group, validate_
 
 name_arg_type = CLIArgumentType(options_list=('--name', '-n'), metavar='NAME')
 
-JSON_PROPERTY_HELP = "Should be JSON file path or in-line JSON string. See examples below for details"
+JSON_PROPERTY_HELP = "Should be JSON file path or in-line JSON string. See examples for details"
 
 
 # pylint: disable=too-many-statements


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->

Close #23812

In in-tool help, the examples appear **below** the argument help.

```
> az ad app create -h

...
JSON property Arguments
    --app-roles                    : The collection of roles assigned to the application. With app
                                     role assignments, these roles can be assigned to users, groups,
                                     or service principals associated with other applications.
                                     Should be JSON file path or in-line JSON string. See examples
                                     below for details.
...

Examples
    ...

    Create an application with a role
        az ad app create --display-name mytestapp --identifier-uris https://mytestapp.websites.net
        --app-roles @manifest.json
        ("manifest.json" contains the following content)
        [{
            "allowedMemberTypes": [
              "User"
            ],
            "description": "Approvers can mark documents as approved",
            "displayName": "Approver",
            "isEnabled": "true",
            "value": "approver"
        }]
```

But in the document https://docs.microsoft.com/en-us/cli/azure/ad/app?view=azure-cli-latest, the examples appear **above** the argument help, so we don't be that specific.
