### PR TITLE
[Storage] `az storage blob/container`: Support `--account-name` for non-standard account URL

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -225,10 +225,10 @@ def cf_blob_service(cli_ctx, kwargs):
     if not account_url:
         account_url = get_account_url(cli_ctx, account_name=account_name, service='blob')
     credential = account_key or sas_token or token_credential
-    if account_name and isinstance(credential, str):
+    if account_name and account_key:
         # For non-standard account URL such as Edge Zone, account_name can't be parsed from account_url. Use credential
         # dict instead.
-        credential = {'account_key': credential, 'account_name': account_name}
+        credential = {'account_key': account_key, 'account_name': account_name}
 
     return t_blob_service(account_url=account_url, credential=credential,
                           connection_timeout=kwargs.pop('connection_timeout', None), **client_kwargs)

--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -225,7 +225,7 @@ def cf_blob_service(cli_ctx, kwargs):
     if not account_url:
         account_url = get_account_url(cli_ctx, account_name=account_name, service='blob')
     credential = account_key or sas_token or token_credential
-    if account_name:
+    if account_name and isinstance(credential, str):
         # For non-standard account URL such as Edge Zone, account_name can't be parsed from account_url. Use credential
         # dict instead.
         credential = {'account_key': credential, 'account_name': account_name}

--- a/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_client_factory.py
@@ -225,6 +225,10 @@ def cf_blob_service(cli_ctx, kwargs):
     if not account_url:
         account_url = get_account_url(cli_ctx, account_name=account_name, service='blob')
     credential = account_key or sas_token or token_credential
+    if account_name:
+        # For non-standard account URL such as Edge Zone, account_name can't be parsed from account_url. Use credential
+        # dict instead.
+        credential = {'account_key': credential, 'account_name': account_name}
 
     return t_blob_service(account_url=account_url, credential=credential,
                           connection_timeout=kwargs.pop('connection_timeout', None), **client_kwargs)

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_account_extended_location.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_account_extended_location.yaml
@@ -19,7 +19,8 @@ interactions:
       ParameterSetName:
       - -n -g --edge-zone -l --sku
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002?api-version=2022-05-01
   response:
@@ -33,11 +34,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Fri, 19 Aug 2022 02:44:53 GMT
+      - Fri, 09 Sep 2022 08:46:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus2euap/asyncoperations/3c23f9a3-2a27-424c-af72-396d1b1550a4?monitor=true&api-version=2022-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus2euap/asyncoperations/a367be71-5c06-4a8d-bb58-00d335b99775?monitor=true&api-version=2022-05-01
       pragma:
       - no-cache
       server:
@@ -47,7 +48,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -65,12 +66,13 @@ interactions:
       ParameterSetName:
       - -n -g --edge-zone -l --sku
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus2euap/asyncoperations/3c23f9a3-2a27-424c-af72-396d1b1550a4?monitor=true&api-version=2022-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/eastus2euap/asyncoperations/a367be71-5c06-4a8d-bb58-00d335b99775?monitor=true&api-version=2022-05-01
   response:
     body:
-      string: '{"extendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002","name":"edge1000002","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2022-08-19T02:44:52.0849796Z","key2":"2022-08-19T02:44:52.0849796Z"},"primaryExtendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-19T02:44:52.3037605Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-19T02:44:52.3037605Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-19T02:44:51.9600181Z","primaryEndpoints":{"web":"https://edge1000002.web.microsoftrrdclab1.edgestorage.azure.net/","blob":"https://edge1000002.blob.microsoftrrdclab1.edgestorage.azure.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+      string: '{"extendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002","name":"edge1000002","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2022-09-09T08:46:00.0880108Z","key2":"2022-09-09T08:46:00.0880108Z"},"primaryExtendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:00.4942733Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:00.4942733Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-09-09T08:45:59.9630189Z","primaryEndpoints":{"web":"https://edge1000002.web.microsoftrrdclab1.edgestorage.azure.net/","blob":"https://edge1000002.blob.microsoftrrdclab1.edgestorage.azure.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -79,7 +81,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 19 Aug 2022 02:45:11 GMT
+      - Fri, 09 Sep 2022 08:46:20 GMT
       expires:
       - '-1'
       pragma:
@@ -111,12 +113,13 @@ interactions:
       ParameterSetName:
       - -n -g --edge-zone --sku
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cliedgezone000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001","name":"cliedgezone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-08-19T02:44:47Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001","name":"cliedgezone000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-09-09T08:45:51Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -125,7 +128,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 19 Aug 2022 02:45:11 GMT
+      - Fri, 09 Sep 2022 08:46:20 GMT
       expires:
       - '-1'
       pragma:
@@ -159,7 +162,8 @@ interactions:
       ParameterSetName:
       - -n -g --edge-zone --sku
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge2000003?api-version=2022-05-01
   response:
@@ -173,11 +177,11 @@ interactions:
       content-type:
       - text/plain; charset=utf-8
       date:
-      - Fri, 19 Aug 2022 02:45:17 GMT
+      - Fri, 09 Sep 2022 08:46:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/68c89c23-6efe-4b18-99d0-bb6848a57f6b?monitor=true&api-version=2022-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/5cc6f7dc-e5d8-49a4-81c0-ad41432d670e?monitor=true&api-version=2022-05-01
       pragma:
       - no-cache
       server:
@@ -187,7 +191,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -205,12 +209,13 @@ interactions:
       ParameterSetName:
       - -n -g --edge-zone --sku
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/68c89c23-6efe-4b18-99d0-bb6848a57f6b?monitor=true&api-version=2022-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Storage/locations/westus/asyncoperations/5cc6f7dc-e5d8-49a4-81c0-ad41432d670e?monitor=true&api-version=2022-05-01
   response:
     body:
-      string: '{"extendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge2000003","name":"edge2000003","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":"2022-08-19T02:45:16.0931148Z","key2":"2022-08-19T02:45:16.0931148Z"},"primaryExtendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-19T02:45:16.1087408Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-08-19T02:45:16.1087408Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-08-19T02:45:15.9837589Z","primaryEndpoints":{"web":"https://edge2000003.web.microsoftlosangeles1.edgestorage.azure.net/","blob":"https://edge2000003.blob.microsoftlosangeles1.edgestorage.azure.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
+      string: '{"extendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge2000003","name":"edge2000003","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{},"properties":{"keyCreationTime":{"key1":"2022-09-09T08:46:27.3217806Z","key2":"2022-09-09T08:46:27.3217806Z"},"primaryExtendedLocation":{"type":"EdgeZone","name":"microsoftlosangeles1"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:27.3217806Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:27.3217806Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-09-09T08:46:27.2124080Z","primaryEndpoints":{"web":"https://edge2000003.web.microsoftlosangeles1.edgestorage.azure.net/","blob":"https://edge2000003.blob.microsoftlosangeles1.edgestorage.azure.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}}'
     headers:
       cache-control:
       - no-cache
@@ -219,7 +224,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 19 Aug 2022 02:45:34 GMT
+      - Fri, 09 Sep 2022 08:46:46 GMT
       expires:
       - '-1'
       pragma:
@@ -237,4 +242,144 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g
+      User-Agent:
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002?api-version=2022-05-01
+  response:
+    body:
+      string: '{"extendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"StorageV2","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002","name":"edge1000002","type":"Microsoft.Storage/storageAccounts","location":"eastus2euap","tags":{},"properties":{"keyCreationTime":{"key1":"2022-09-09T08:46:00.0880108Z","key2":"2022-09-09T08:46:00.0880108Z"},"primaryExtendedLocation":{"type":"EdgeZone","name":"microsoftrrdclab1"},"privateEndpointConnections":[],"minimumTlsVersion":"TLS1_0","allowBlobPublicAccess":true,"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":true,"encryption":{"services":{"file":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:00.4942733Z"},"blob":{"keyType":"Account","enabled":true,"lastEnabledTime":"2022-09-09T08:46:00.4942733Z"}},"keySource":"Microsoft.Storage"},"accessTier":"Hot","provisioningState":"Succeeded","creationTime":"2022-09-09T08:45:59.9630189Z","primaryEndpoints":{"web":"https://edge1000002.web.microsoftrrdclab1.edgestorage.azure.net/","blob":"https://edge1000002.blob.microsoftrrdclab1.edgestorage.azure.net/"},"primaryLocation":"eastus2euap","statusOfPrimary":"available"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1362'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Sep 2022 08:46:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account keys list
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g --query
+      User-Agent:
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cliedgezone000001/providers/Microsoft.Storage/storageAccounts/edge1000002/listKeys?api-version=2022-05-01&$expand=kerb
+  response:
+    body:
+      string: '{"keys":[{"creationTime":"2022-09-09T08:46:00.0880108Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-09-09T08:46:00.0880108Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '260'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Sep 2022 08:46:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '11999'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/xml
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage container create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n --account-name --blob-endpoint --account-key
+      User-Agent:
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
+      x-ms-date:
+      - Fri, 09 Sep 2022 08:46:50 GMT
+      x-ms-version:
+      - '2021-06-08'
+    method: PUT
+    uri: https://edge1000002.blob.microsoftrrdclab1.edgestorage.azure.net/container000004?restype=container
+  response:
+    body:
+      string: ''
+    headers:
+      content-length:
+      - '0'
+      date:
+      - Fri, 09 Sep 2022 08:46:50 GMT
+      etag:
+      - '"0x8DA923FD67BFEBD"'
+      last-modified:
+      - Fri, 09 Sep 2022 08:46:50 GMT
+      server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      x-ms-version:
+      - '2021-06-08'
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_list_scenarios.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_blob_list_scenarios.yaml
@@ -15,12 +15,13 @@ interactions:
       ParameterSetName:
       - -n -g --query -o
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-storage/20.1.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-azure-mgmt-storage/20.1.0 Python/3.10.5
+        (Windows-10-10.0.22000-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest000001/providers/Microsoft.Storage/storageAccounts/storage000002/listKeys?api-version=2022-05-01&$expand=kerb
   response:
     body:
-      string: '{"keys":[{"creationTime":"2022-08-19T02:53:47.8529238Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-08-19T02:53:47.8529238Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
+      string: '{"keys":[{"creationTime":"2022-09-14T07:08:27.3639001Z","keyName":"key1","value":"veryFakedStorageAccountKey==","permissions":"FULL"},{"creationTime":"2022-09-14T07:08:27.3639001Z","keyName":"key2","value":"veryFakedStorageAccountKey==","permissions":"FULL"}]}'
     headers:
       cache-control:
       - no-cache
@@ -29,7 +30,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Fri, 19 Aug 2022 02:54:09 GMT
+      - Wed, 14 Sep 2022 07:08:48 GMT
       expires:
       - '-1'
       pragma:
@@ -45,7 +46,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '11997'
+      - '11999'
     status:
       code: 200
       message: OK
@@ -65,9 +66,9 @@ interactions:
       ParameterSetName:
       - -n --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:10 GMT
+      - Wed, 14 Sep 2022 07:08:49 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -79,11 +80,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 19 Aug 2022 02:54:11 GMT
+      - Wed, 14 Sep 2022 07:08:50 GMT
       etag:
-      - '"0x8DA818E17F6DDFA"'
+      - '"0x8DA961FF98AC2A4"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:11 GMT
+      - Wed, 14 Sep 2022 07:08:50 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-version:
@@ -111,11 +112,11 @@ interactions:
       ParameterSetName:
       - -c -f -n --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:11 GMT
+      - Wed, 14 Sep 2022 07:08:50 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -129,11 +130,11 @@ interactions:
       content-md5:
       - DfvoqkwgtS4bi/PLbL3xkw==
       date:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:51 GMT
       etag:
-      - '"0x8DA818E193428C6"'
+      - '"0x8DA961FFAEBBEC1"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -159,9 +160,9 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:52 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -169,9 +170,9 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:13
-        GMT</Last-Modified><Etag>0x8DA818E193428C6</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:52
+        GMT</Last-Modified><Etag>0x8DA961FFAEBBEC1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -179,7 +180,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -205,9 +206,9 @@ interactions:
       ParameterSetName:
       - -c -n --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:14 GMT
+      - Wed, 14 Sep 2022 07:08:54 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -219,17 +220,17 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 19 Aug 2022 02:54:14 GMT
+      - Wed, 14 Sep 2022 07:08:55 GMT
       etag:
-      - '"0x8DA818E193428C6"'
+      - '"0x8DA961FFAEBBEC1"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:52 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
       - 'false'
       x-ms-snapshot:
-      - '2022-08-19T02:54:15.9250115Z'
+      - '2022-09-14T07:08:55.1727189Z'
       x-ms-version:
       - '2021-06-08'
     status:
@@ -249,9 +250,9 @@ interactions:
       ParameterSetName:
       - -c --include --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:16 GMT
+      - Wed, 14 Sep 2022 07:08:55 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -259,14 +260,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Snapshot>2022-08-19T02:54:15.9250115Z</Snapshot><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:13
-        GMT</Last-Modified><Etag>0x8DA818E193428C6</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Snapshot>2022-09-14T07:08:55.1727189Z</Snapshot><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:52
+        GMT</Last-Modified><Etag>0x8DA961FFAEBBEC1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:13
-        GMT</Last-Modified><Etag>0x8DA818E193428C6</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:52
+        GMT</Last-Modified><Etag>0x8DA961FFAEBBEC1</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -274,7 +275,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:16 GMT
+      - Wed, 14 Sep 2022 07:08:55 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -300,9 +301,9 @@ interactions:
       ParameterSetName:
       - -c -n --metadata --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:17 GMT
+      - Wed, 14 Sep 2022 07:08:56 GMT
       x-ms-meta-test:
       - '1'
       x-ms-version:
@@ -316,11 +317,11 @@ interactions:
       content-length:
       - '0'
       date:
-      - Fri, 19 Aug 2022 02:54:18 GMT
+      - Wed, 14 Sep 2022 07:08:57 GMT
       etag:
-      - '"0x8DA818E1C21647C"'
+      - '"0x8DA961FFE3935E5"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:18 GMT
+      - Wed, 14 Sep 2022 07:08:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-request-server-encrypted:
@@ -344,9 +345,9 @@ interactions:
       ParameterSetName:
       - -c -n --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:18 GMT
+      - Wed, 14 Sep 2022 07:08:58 GMT
       x-ms-version:
       - '2021-06-08'
     method: HEAD
@@ -364,11 +365,11 @@ interactions:
       content-type:
       - application/octet-stream
       date:
-      - Fri, 19 Aug 2022 02:54:18 GMT
+      - Wed, 14 Sep 2022 07:08:58 GMT
       etag:
-      - '"0x8DA818E1C21647C"'
+      - '"0x8DA961FFE3935E5"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:18 GMT
+      - Wed, 14 Sep 2022 07:08:57 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-access-tier:
@@ -378,7 +379,7 @@ interactions:
       x-ms-blob-type:
       - BlockBlob
       x-ms-creation-time:
-      - Fri, 19 Aug 2022 02:54:13 GMT
+      - Wed, 14 Sep 2022 07:08:52 GMT
       x-ms-lease-state:
       - available
       x-ms-lease-status:
@@ -406,9 +407,9 @@ interactions:
       ParameterSetName:
       - -c --include --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:19 GMT
+      - Wed, 14 Sep 2022 07:08:59 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -416,9 +417,9 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:18
-        GMT</Last-Modified><Etag>0x8DA818E1C21647C</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><Metadata><test>1</test></Metadata><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -426,7 +427,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:20 GMT
+      - Wed, 14 Sep 2022 07:09:00 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -456,11 +457,11 @@ interactions:
       ParameterSetName:
       - -c -f -n --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-blob-type:
       - BlockBlob
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:21 GMT
+      - Wed, 14 Sep 2022 07:09:01 GMT
       x-ms-version:
       - '2021-06-08'
     method: PUT
@@ -474,11 +475,11 @@ interactions:
       content-md5:
       - DfvoqkwgtS4bi/PLbL3xkw==
       date:
-      - Fri, 19 Aug 2022 02:54:22 GMT
+      - Wed, 14 Sep 2022 07:09:02 GMT
       etag:
-      - '"0x8DA818E1ED65A78"'
+      - '"0x8DA962001303548"'
       last-modified:
-      - Fri, 19 Aug 2022 02:54:22 GMT
+      - Wed, 14 Sep 2022 07:09:02 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       x-ms-content-crc64:
@@ -504,9 +505,9 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:23 GMT
+      - Wed, 14 Sep 2022 07:09:03 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -514,14 +515,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:22 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:22
-        GMT</Last-Modified><Etag>0x8DA818E1ED65A78</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:18
-        GMT</Last-Modified><Etag>0x8DA818E1C21647C</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:09:02 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:09:02
+        GMT</Last-Modified><Etag>0x8DA962001303548</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -529,7 +530,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:23 GMT
+      - Wed, 14 Sep 2022 07:09:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -553,9 +554,9 @@ interactions:
       ParameterSetName:
       - -c --num-results --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:24 GMT
+      - Wed, 14 Sep 2022 07:09:04 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -563,17 +564,17 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:22 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:22
-        GMT</Last-Modified><Etag>0x8DA818E1ED65A78</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9iaGtlcHR1dG5rb294amkybHc2dGchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
+        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9ieTJkMnlvNzd5MnNhcXN3MzJrZGYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:24 GMT
+      - Wed, 14 Sep 2022 07:09:04 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -597,9 +598,9 @@ interactions:
       ParameterSetName:
       - -c --num-results --show-next-marker --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:25 GMT
+      - Wed, 14 Sep 2022 07:09:06 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -607,17 +608,17 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:22 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:22
-        GMT</Last-Modified><Etag>0x8DA818E1ED65A78</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><MaxResults>1</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9iaGtlcHR1dG5rb294amkybHc2dGchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
+        /></Blob></Blobs><NextMarker>2!96!MDAwMDI4IWRpci9ibG9ieTJkMnlvNzd5MnNhcXN3MzJrZGYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</NextMarker></EnumerationResults>"
     headers:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:26 GMT
+      - Wed, 14 Sep 2022 07:09:06 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -641,19 +642,19 @@ interactions:
       ParameterSetName:
       - -c --marker --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:26 GMT
+      - Wed, 14 Sep 2022 07:09:07 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
-    uri: https://storage000002.blob.core.windows.net/con000003?restype=container&comp=list&marker=2%2196%21MDAwMDI4IWRpci9ibG9iaGtlcHR1dG5rb294amkybHc2dGchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh&maxresults=5000
+    uri: https://storage000002.blob.core.windows.net/con000003?restype=container&comp=list&marker=2%2196%21MDAwMDI4IWRpci9ibG9ieTJkMnlvNzd5MnNhcXN3MzJrZGYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh&maxresults=5000
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Marker>2!96!MDAwMDI4IWRpci9ibG9iaGtlcHR1dG5rb294amkybHc2dGchMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</Marker><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:18
-        GMT</Last-Modified><Etag>0x8DA818E1C21647C</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Marker>2!96!MDAwMDI4IWRpci9ibG9ieTJkMnlvNzd5MnNhcXN3MzJrZGYhMDAwMDI4ITk5OTktMTItMzFUMjM6NTk6NTkuOTk5OTk5OVoh</Marker><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:09:02 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:09:02
+        GMT</Last-Modified><Etag>0x8DA962001303548</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -661,7 +662,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:27 GMT
+      - Wed, 14 Sep 2022 07:09:08 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -685,9 +686,9 @@ interactions:
       ParameterSetName:
       - -c --prefix --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:28 GMT
+      - Wed, 14 Sep 2022 07:09:08 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -695,14 +696,14 @@ interactions:
   response:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
-        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Prefix>dir/</Prefix><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:22 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:22
-        GMT</Last-Modified><Etag>0x8DA818E1ED65A78</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ServiceEndpoint=\"https://storage000002.blob.core.windows.net/\" ContainerName=\"con000003\"><Prefix>dir/</Prefix><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:18
-        GMT</Last-Modified><Etag>0x8DA818E1C21647C</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:09:02 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:09:02
+        GMT</Last-Modified><Etag>0x8DA962001303548</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -710,7 +711,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:28 GMT
+      - Wed, 14 Sep 2022 07:09:09 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -734,9 +735,9 @@ interactions:
       ParameterSetName:
       - -c --delimiter --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:29 GMT
+      - Wed, 14 Sep 2022 07:09:10 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -750,7 +751,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:30 GMT
+      - Wed, 14 Sep 2022 07:09:11 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -774,9 +775,9 @@ interactions:
       ParameterSetName:
       - -c --delimiter --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:30 GMT
+      - Wed, 14 Sep 2022 07:09:11 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -790,7 +791,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:31 GMT
+      - Wed, 14 Sep 2022 07:09:12 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:
@@ -814,9 +815,9 @@ interactions:
       ParameterSetName:
       - -c --account-name --account-key
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-storage-blob/12.12.0 Python/3.7.9 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.40.0 (PIP) azsdk-python-storage-blob/12.12.0 Python/3.10.5 (Windows-10-10.0.22000-SP0)
       x-ms-date:
-      - Fri, 19 Aug 2022 02:54:36 GMT
+      - Wed, 14 Sep 2022 07:09:18 GMT
       x-ms-version:
       - '2021-06-08'
     method: GET
@@ -825,14 +826,14 @@ interactions:
     body:
       string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults
         ServiceEndpoint=\"https://storage000002-secondary.blob.core.windows.net/\"
-        ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:22 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:22
-        GMT</Last-Modified><Etag>0x8DA818E1ED65A78</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        ContainerName=\"con000003\"><MaxResults>5000</MaxResults><Blobs><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:08:52 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:08:57
+        GMT</Last-Modified><Etag>0x8DA961FFE3935E5</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
-        /></Blob><Blob><Name>dir/blob000004</Name><Properties><Creation-Time>Fri,
-        19 Aug 2022 02:54:13 GMT</Creation-Time><Last-Modified>Fri, 19 Aug 2022 02:54:18
-        GMT</Last-Modified><Etag>0x8DA818E1C21647C</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
+        /></Blob><Blob><Name>dir/blob000005</Name><Properties><Creation-Time>Wed,
+        14 Sep 2022 07:09:02 GMT</Creation-Time><Last-Modified>Wed, 14 Sep 2022 07:09:02
+        GMT</Last-Modified><Etag>0x8DA962001303548</Etag><Content-Length>131072</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding
         /><Content-Language /><Content-CRC64 /><Content-MD5>DfvoqkwgtS4bi/PLbL3xkw==</Content-MD5><Cache-Control
         /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties><OrMetadata
         /></Blob></Blobs><NextMarker /></EnumerationResults>"
@@ -840,7 +841,7 @@ interactions:
       content-type:
       - application/xml
       date:
-      - Fri, 19 Aug 2022 02:54:37 GMT
+      - Wed, 14 Sep 2022 07:09:18 GMT
       server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       transfer-encoding:


### PR DESCRIPTION
**Related command**
`az storage container`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When use non-standard account URL, account name can't be parsed from URL, thus `ValueError: Unable to determine account name for shared key credential` is raised. In this PR, it will use credential dict if `account_name` is provided.

Close https://github.com/Azure/azure-cli/issues/23702. 

**Testing Guide**
`az storage account create --name <name> --resource-group <rg> --edge-zone microsoftrrdclab1 -l eastus2euap`
`az storage container create -n test --blob-endpoint <blob-endpoint> --account-name <name> --account-key <account-key>`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
