### PR TITLE
[RDBMS] `az mysql/postgres flexible-server create/update`: Deprecate `Enabled` for `--high-availability` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_mysql.py
@@ -98,7 +98,7 @@ examples:
     text: >
       # create keyvault
 
-      az keyvault create -g testGroup -n testVault --location testLocation --enable-soft-delete true --enable-purge-protection true
+      az keyvault create -g testGroup -n testVault --location testLocation --enable-purge-protection true
 
 
       # create key in keyvault
@@ -125,7 +125,7 @@ examples:
     text: >
       # create keyvault
 
-      az keyvault create -g testGroup -n testVault --location testLocation --enable-soft-delete true --enable-purge-protection true
+      az keyvault create -g testGroup -n testVault --location testLocation --enable-purge-protection true
 
 
       # create key in keyvault
@@ -145,7 +145,7 @@ examples:
 
       # create backup keyvault
 
-      az keyvault create -g testGroup -n testBackupVault --location testBackupLocation --enable-soft-delete true --enable-purge-protection true
+      az keyvault create -g testGroup -n testBackupVault --location testBackupLocation --enable-purge-protection true
 
 
       # create backup key in backup keyvault

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -369,10 +369,9 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         high_availability_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled', 'Enabled']),
+            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled']),
             options_list=['--high-availability'],
-            help='Enable (ZoneRedundant or SameZone) or disable high availability feature. '
-                 'Default value is Disabled. High availability can only be set during flexible server create time. '
+            help='Enable (ZoneRedundant or SameZone) or disable high availability feature.'
         )
 
         mysql_version_upgrade_arg_type = CLIArgumentType(

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -16,7 +16,8 @@ from azure.cli.core.commands.parameters import (
     get_three_state_flag)
 from azure.cli.command_modules.rdbms.validators import configuration_value_validator, validate_subnet, \
     tls_validator, public_access_validator, maintenance_window_validator, ip_address_validator, \
-    retention_validator, firewall_rule_name_validator, validate_identity, validate_byok_identity, validate_identities
+    retention_validator, firewall_rule_name_validator, validate_identity, validate_byok_identity, validate_identities, \
+    high_availability_validator
 from azure.cli.core.local_context import LocalContextAttribute, LocalContextAction
 
 from .randomname.generate import generate_username
@@ -369,9 +370,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         high_availability_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled']),
+            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled', 'Enabled']),
             options_list=['--high-availability'],
-            help='Enable (ZoneRedundant or SameZone) or disable high availability feature.'
+            help='Enable (ZoneRedundant or SameZone) or disable high availability feature.',
+            validator=high_availability_validator
         )
 
         mysql_version_upgrade_arg_type = CLIArgumentType(

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -60,9 +60,6 @@ def flexible_server_create(cmd, client,
 
     # Process parameters
     server_name = server_name.lower()
-    if high_availability and high_availability.lower() == 'enabled':
-        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
-        high_availability = 'ZoneRedundant'
 
     # MySQL chnged MemoryOptimized tier to BusinessCritical (only in client tool not in list-skus return)
     if tier == 'BusinessCritical':
@@ -345,10 +342,6 @@ def flexible_server_update_custom_func(cmd, client, instance,
         cf_availability_without_location=cf_mysql_check_resource_availability_without_location,
         logging_name='MySQL', command_group='mysql', server_client=client, location=instance.location)
 
-    if high_availability and high_availability.lower() == 'enabled':
-        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
-        high_availability = 'ZoneRedundant'
-
     # MySQL chnged MemoryOptimized tier to BusinessCritical (only in client tool not in list-skus return)
     if tier == 'BusinessCritical':
         tier = 'MemoryOptimized'
@@ -488,7 +481,7 @@ def server_delete_func(cmd, client, resource_group_name, server_name, yes=None):
 
 def flexible_server_restart(cmd, client, resource_group_name, server_name, fail_over=None):
     instance = client.get(resource_group_name, server_name)
-    if fail_over is not None and instance.high_availability.mode not in ["ZoneRedundant", "Enabled"]:
+    if fail_over is not None and instance.high_availability.mode != "ZoneRedundant":
         raise ArgumentUsageError("Failing over can only be triggered for zone redundant servers.")
 
     if fail_over is not None:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -52,9 +52,6 @@ def flexible_server_create(cmd, client,
                                                                              server_name, 'postgres')
 
     server_name = server_name.lower()
-    if high_availability and high_availability.lower() == 'enabled':
-        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
-        high_availability = 'ZoneRedundant'
 
     pg_arguments_validator(db_context,
                            server_name=server_name,
@@ -248,10 +245,6 @@ def flexible_server_update_custom_func(cmd, client, instance,
     db_context = DbContext(
         cmd=cmd, azure_sdk=postgresql_flexibleservers, cf_firewall=cf_postgres_flexible_firewall_rules, cf_db=cf_postgres_flexible_db,
         cf_availability=cf_postgres_check_resource_availability, logging_name='PostgreSQL', command_group='postgres', server_client=client)
-
-    if high_availability and high_availability.lower() == 'enabled':
-        logger.warning('\'Enabled\' value for high availability parameter will be deprecated. Please use \'ZoneRedundant\' or \'SameZone\' instead.')
-        high_availability = 'ZoneRedundant'
 
     pg_arguments_validator(db_context,
                            location=location,

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -222,7 +222,7 @@ def _mysql_auto_grow_validator(auto_grow, replication_role, high_availability, i
     if replication_role not in ('None', None) and auto_grow.lower() == 'disabled':
         raise ValidationError("Auto grow feature for replica server cannot be disabled.")
     # if ha, cannot be disabled
-    if high_availability in ['Enabled', 'ZoneRedundant'] and auto_grow.lower() == 'disabled':
+    if high_availability == 'ZoneRedundant' and auto_grow.lower() == 'disabled':
         raise ValidationError("Auto grow feature for high availability server cannot be disabled.")
 
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -595,3 +595,10 @@ def validate_byok_identity(cmd, namespace):
 def validate_identities(cmd, namespace):
     if namespace.identities:
         namespace.identities = [_validate_identity(cmd, namespace, identity) for identity in namespace.identities]
+
+
+def high_availability_validator(namespace):
+    if namespace.high_availability and namespace.high_availability == 'Enabled':
+        logger.warning("'Enabled' value for high availability parameter will be deprecated by April 2023. "
+                       "Please use 'ZoneRedundant' or 'SameZone' instead.")
+        namespace.high_availability = 'ZoneRedundant'


### PR DESCRIPTION
**Related command**
`az mysql/postgres flexible-server create/update`

**Description**<!--Mandatory-->
`Enabled` value for `--high-availability` argument in commands `az mysql/postgres flexible-server create/update` will be deprecated by the next release in April 2023. The possible values for that argument will be only `ZoneRedundant`, `SameZone` and `Disabled`, the value `Enabled` is the same as `ZoneRedundant`. For now, we'll still allow to use `Enabled` but we change the warning message to include the date when it will be removed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
