### PR TITLE
{Front Door} Fix #23864: `az afd origin-group update` description

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cdn/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/_help.py
@@ -1136,7 +1136,7 @@ examples:
 
 helps['afd origin-group update'] = """
 type: command
-short-summary: Creates a new origin group within the specified profile.
+short-summary: Updates an existing origin group within the specified profile.
 examples:
   - name: Update the probe setting of the specified origin group.
     text: >


### PR DESCRIPTION
In the documentation the definitions of az afd origin-group create and az aft origin-group update commands' descriptions are same which is "Creates a new origin group within the specified profile". Definition of update command needs to be updated.

This PR updates the description of az afd origin-group update command.

fixes Azure/azure-cli#23864

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
