### PR TITLE
{SQL} fixes Azure/azure-cli#23885 - commands.py

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -147,8 +147,8 @@ def load_command_table(self, _):
                                  transform=database_lro_transform,
                                  table_transformer=db_table_format)
 
-        g.custom_command('export', 'db_export')
-        g.custom_command('import', 'db_import')
+        g.custom_command('export', 'db_export', supports_no_wait=True)
+        g.custom_command('import', 'db_import', supports_no_wait=True)
 
     capabilities_operations = CliCommandType(
         operations_tmpl='azure.mgmt.sql.operations#CapabilitiesOperations.{}',

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1452,10 +1452,10 @@ def db_export(
     kwargs['storage_key'] = storage_key
 
     return client.begin_export(
-        no_wait,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,
+        no_wait=no_wait,
         parameters=kwargs)
 
 
@@ -1478,10 +1478,10 @@ def db_import(
     kwargs['storage_key'] = storage_key
 
     return client.begin_import_method(
-        no_wait,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,
+        no_wait=no_wait,
         parameters=kwargs)
 
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1451,11 +1451,12 @@ def db_export(
     kwargs['storage_key_type'] = storage_key_type
     kwargs['storage_key'] = storage_key
 
-    return client.begin_export(
+    return sdk_no_wait(
+        no_wait,
+        client.begin_export,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,
-        no_wait=no_wait,
         parameters=kwargs)
 
 
@@ -1477,11 +1478,12 @@ def db_import(
     kwargs['storage_key_type'] = storage_key_type
     kwargs['storage_key'] = storage_key
 
-    return client.begin_import_method(
+    return sdk_no_wait(
+        no_wait,
+        client.begin_import_method,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,
-        no_wait=no_wait,
         parameters=kwargs)
 
 

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1440,6 +1440,7 @@ def db_export(
         resource_group_name,
         storage_key_type,
         storage_key,
+        no_wait=False,
         **kwargs):
     '''
     Exports a database to a bacpac file.
@@ -1451,6 +1452,7 @@ def db_export(
     kwargs['storage_key'] = storage_key
 
     return client.begin_export(
+        no_wait,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,
@@ -1464,6 +1466,7 @@ def db_import(
         resource_group_name,
         storage_key_type,
         storage_key,
+        no_wait=False,
         **kwargs):
     '''
     Imports a bacpac file into an existing database.
@@ -1475,6 +1478,7 @@ def db_import(
     kwargs['storage_key'] = storage_key
 
     return client.begin_import_method(
+        no_wait,
         database_name=database_name,
         server_name=server_name,
         resource_group_name=resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1467,7 +1467,6 @@ def db_import(
         resource_group_name,
         storage_key_type,
         storage_key,
-        no_wait=False,
         **kwargs):
     '''
     Imports a bacpac file into an existing database.

--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -1467,6 +1467,7 @@ def db_import(
         resource_group_name,
         storage_key_type,
         storage_key,
+        no_wait=False,
         **kwargs):
     '''
     Imports a bacpac file into an existing database.


### PR DESCRIPTION
fixes Azure/azure-cli#23885

az sql db import/export commands can take so long to run that it will time out the CLI or DevOps pipeline leveraging AzureCLI.

SO this PR addresses this issue by adding the --no-wait parameter to these commands.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
