### PR TITLE
{AzureMediaService} fixes Azure/azure-cli#23937

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -17,7 +17,7 @@ def get_mediaservice(client, account_name, resource_group_name=None):
         raise ValidationError('Please specify the account-name and resource-group-name')
     else:
         return client.get(resource_group_name,
-                         account_name) if resource_group_name else client.get_by_subscription(account_name)
+                           account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 
 def list_mediaservices(client, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -15,9 +15,7 @@ from azure.mgmt.media.models import (MediaService, MediaServiceIdentity, Storage
 def get_mediaservice(client, account_name, resource_group_name=None):
     if account_name is not None and resource_group_name is None:
         raise ValidationError('Please specify the account-name and resource-group-name')
-    else:
-        return client.get(resource_group_name,
-                          account_name) if resource_group_name else client.get_by_subscription(account_name)
+    return client.get(resource_group_name, account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 
 def list_mediaservices(client, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -15,7 +15,7 @@ from azure.mgmt.media.models import (MediaService, MediaServiceIdentity, Storage
 def get_mediaservice(client, account_name, resource_group_name=None):
     if account_name is not None and resource_group_name is None:
         raise ValidationError('Please specify the account-name and resource-group-name')
-    return client.get(resource_group_name, 
+    return client.get(resource_group_name,
                       account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -17,7 +17,7 @@ def get_mediaservice(client, account_name, resource_group_name=None):
         raise ValidationError('Please specify the account-name and resource-group-name')
     else:
         return client.get(resource_group_name,
-                      account_name) if resource_group_name else client.get_by_subscription(account_name)
+                         account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 
 def list_mediaservices(client, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -13,7 +13,10 @@ from azure.mgmt.media.models import (MediaService, MediaServiceIdentity, Storage
 
 
 def get_mediaservice(client, account_name, resource_group_name=None):
-    return client.get(resource_group_name,
+    if account_name is not None and resource_group_name is None:
+        raise ValidationError('Please specify the account-name and resource-group-name')
+    else:
+        return client.get(resource_group_name,
                       account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -15,7 +15,8 @@ from azure.mgmt.media.models import (MediaService, MediaServiceIdentity, Storage
 def get_mediaservice(client, account_name, resource_group_name=None):
     if account_name is not None and resource_group_name is None:
         raise ValidationError('Please specify the account-name and resource-group-name')
-    return client.get(resource_group_name, account_name) if resource_group_name else client.get_by_subscription(account_name)
+    return client.get(resource_group_name, 
+                      account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 
 def list_mediaservices(client, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/account.py
@@ -17,7 +17,7 @@ def get_mediaservice(client, account_name, resource_group_name=None):
         raise ValidationError('Please specify the account-name and resource-group-name')
     else:
         return client.get(resource_group_name,
-                           account_name) if resource_group_name else client.get_by_subscription(account_name)
+                          account_name) if resource_group_name else client.get_by_subscription(account_name)
 
 
 def list_mediaservices(client, resource_group_name=None):


### PR DESCRIPTION
fixes Azure/azure-cli#23937
Looking at this test case https://github.com/phcooper/azure-cli/blob/1e7f7962df34f3104db4f2eefdcbdfe46ccd4bc1/src/azure-cli/azure/cli/command_modules/ams/tests/latest/test_ams_account_scenarios.py#L34 

It clearly indicates that the Resource Group and Account name both are required.

Currently the CLI command az ams account show --name <mediaservicename> throws the below error:

  File "/usr/local/Cellar/azure-cli/2.40.0/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 363, in handler
    show_exception_handler(ex)
  File "/usr/local/Cellar/azure-cli/2.40.0/libexec/lib/python3.10/site-packages/azure/cli/core/commands/arm.py", line 429, in show_exception_handler
    raise ex
  File "/usr/local/Cellar/azure-cli/2.40.0/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 361, in handler
    return op(**command_args)
  File "/usr/local/Cellar/azure-cli/2.40.0/libexec/lib/python3.10/site-packages/azure/cli/command_modules/ams/operations/account.py", line 17, in get_mediaservice
    account_name) if resource_group_name else client.get_by_subscription(account_name)
AttributeError: 'MediaservicesOperations' object has no attribute 'get_by_subscription'

And the az ams account show command requires both Resource Group and Account Name and the customer has shared the feedback that it shouldn't throw the error but instead give a friendly error message. This PR helps to achieve this.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
