### PR TITLE
[RDBMS] `az mysql flexible-server stop`: Change stopped time logging message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -39,8 +39,9 @@ def flexible_server_update_get(client, resource_group_name, server_name):
 
 
 def flexible_server_stop(client, resource_group_name=None, server_name=None):
-    logger.warning("Server will be automatically started after 7 days "
-                   "if you do not perform a manual start operation")
+    days = 30 if isinstance(client, MySqlServersOperations) else 7
+    logger.warning("Server will be automatically started after {} days "
+                   "if you do not perform a manual start operation".format(days))
     return client.begin_stop(resource_group_name, server_name)
 
 

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -40,8 +40,8 @@ def flexible_server_update_get(client, resource_group_name, server_name):
 
 def flexible_server_stop(client, resource_group_name=None, server_name=None):
     days = 30 if isinstance(client, MySqlServersOperations) else 7
-    logger.warning("Server will be automatically started after {} days "
-                   "if you do not perform a manual start operation".format(days))
+    logger.warning("Server will be automatically started after %d days "
+                   "if you do not perform a manual start operation", days)
     return client.begin_stop(resource_group_name, server_name)
 
 


### PR DESCRIPTION
**Related command**
`az mysql flexible-server stop`

**Description**<!--Mandatory-->
For MySQL flexible server there was a change that allows the server to stop for 30 days, so we need to change the logging message that still says 7 days. For PostgreSQL there is no change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
