### PR TITLE
[Storage] `az storage account update`: Fix updating `--default-share-permission` will wipe out other ADProperties issue

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -451,15 +451,14 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
 
     if enable_files_aadkerb is not None:
         if enable_files_aadkerb:  # enable AADKERB
-            origin_storage_account = get_storage_account_properties(cmd.cli_ctx, instance.id)
-            if origin_storage_account.azure_files_identity_based_authentication and \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options \
+            if instance.azure_files_identity_based_authentication and \
+                    instance.azure_files_identity_based_authentication.directory_service_options \
                     == 'AADDS':
                 raise CLIError("The Storage account already enabled AzureActiveDirectoryDomainServicesForFile, "
                                "please disable it by running this cmdlets with \"--enable-files-aadds false\" "
                                "before enable AzureActiveDirectoryKerberosForFile.")
-            if origin_storage_account.azure_files_identity_based_authentication and \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options == 'AD':
+            if instance.azure_files_identity_based_authentication and \
+                    instance.azure_files_identity_based_authentication.directory_service_options == 'AD':
                 raise CLIError("The Storage account already enabled ActiveDirectoryDomainServicesForFile, "
                                "please disable it by running this cmdlets with \"--enable-files-adds false\" "
                                "before enable AzureActiveDirectoryKerberosForFile.")
@@ -474,14 +473,13 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
 
         else:  # disable AADKERB
             # Only disable AADKERB and keep others unchanged
-            origin_storage_account = get_storage_account_properties(cmd.cli_ctx, instance.id)
-            if not origin_storage_account.azure_files_identity_based_authentication or \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options == 'AADKERB':
+            if not instance.azure_files_identity_based_authentication or \
+                    instance.azure_files_identity_based_authentication.directory_service_options == 'AADKERB':
                 params.azure_files_identity_based_authentication = AzureFilesIdentityBasedAuthentication(
                     directory_service_options='None')
             else:
                 params.azure_files_identity_based_authentication = \
-                    origin_storage_account.azure_files_identity_based_authentication
+                    instance.azure_files_identity_based_authentication
 
     if enable_files_adds is not None:
         ActiveDirectoryProperties = cmd.get_models('ActiveDirectoryProperties')
@@ -491,15 +489,14 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
                 raise CLIError("To enable ActiveDirectoryDomainServicesForFile, user must specify all of: "
                                "--domain-name, --net-bios-domain-name, --forest-name, --domain-guid, --domain-sid and "
                                "--azure_storage_sid arguments in Azure Active Directory Properties Argument group.")
-            origin_storage_account = get_storage_account_properties(cmd.cli_ctx, instance.id)
-            if origin_storage_account.azure_files_identity_based_authentication and \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options \
+            if instance.azure_files_identity_based_authentication and \
+                    instance.azure_files_identity_based_authentication.directory_service_options \
                     == 'AADDS':
                 raise CLIError("The Storage account already enabled AzureActiveDirectoryDomainServicesForFile, "
                                "please disable it by running this cmdlets with \"--enable-files-aadds false\" "
                                "before enable ActiveDirectoryDomainServicesForFile.")
-            if origin_storage_account.azure_files_identity_based_authentication and \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options == 'AADKERB':
+            if instance.azure_files_identity_based_authentication and \
+                    instance.azure_files_identity_based_authentication.directory_service_options == 'AADKERB':
                 raise CLIError("The Storage account already enabled AzureActiveDirectoryKerberosForFile, "
                                "please disable it by running this cmdlets with \"--enable-files-aadkerb false\" "
                                "before enable ActiveDirectoryDomainServicesForFile.")
@@ -522,18 +519,18 @@ def update_storage_account(cmd, instance, sku=None, tags=None, custom_domain=Non
                                "--domain-name, --net-bios-domain-name, --forest-name, --domain-guid, --domain-sid and "
                                "--azure_storage_sid arguments in Azure Active Directory Properties Argument group.")
             # Only disable AD and keep others unchanged
-            origin_storage_account = get_storage_account_properties(cmd.cli_ctx, instance.id)
-            if not origin_storage_account.azure_files_identity_based_authentication or \
-                    origin_storage_account.azure_files_identity_based_authentication.directory_service_options == 'AD':
+            if not instance.azure_files_identity_based_authentication or \
+                    instance.azure_files_identity_based_authentication.directory_service_options == 'AD':
                 params.azure_files_identity_based_authentication = AzureFilesIdentityBasedAuthentication(
                     directory_service_options='None')
             else:
                 params.azure_files_identity_based_authentication = \
-                    origin_storage_account.azure_files_identity_based_authentication
+                    instance.azure_files_identity_based_authentication
     if default_share_permission is not None:
         if params.azure_files_identity_based_authentication is None:
             params.azure_files_identity_based_authentication = AzureFilesIdentityBasedAuthentication(
-                directory_service_options='None')
+                directory_service_options='None') if instance.azure_files_identity_based_authentication is None \
+                else instance.azure_files_identity_based_authentication
         params.azure_files_identity_based_authentication.default_share_permission = default_share_permission
 
     if assign_identity:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Suppose we have a storage account with such file identity auth property:
```
az storage account show -n testsa0923 -g test0923
{
  ......
  "azureFilesIdentityBasedAuthentication": {
    "activeDirectoryProperties": {
      "accountType": null,
      "azureStorageSid": "S-1-5-21-1234567890-1234567890-1234567890-1234",
      "domainGuid": "12345678-1234-1234-1234-123456789012",
      "domainName": "mydomain.com",
      "domainSid": "S-1-5-21-1234567890-1234567890-1234567890",
      "forestName": "mydomain.com",
      "netBiosDomainName": "mydomain.com",
      "samAccountName": null
    },
    "defaultSharePermission": "None",
    "directoryServiceOptions": "None"
  },
  ......
}

```
When updating `defaultSharePermission` under `azureFilesIdentityBasedAuthentication`, `activeDirectoryProperties` under `azureFilesIdentityBasedAuthentication` will be reset to `null`:
```
> az storage account update -n testsa0923 -g test0923 --default-share-permission StorageFileDataSmbShareContributor
{
  ......
  "azureFilesIdentityBasedAuthentication": {
    "activeDirectoryProperties": null,
    "defaultSharePermission": "StorageFileDataSmbShareContributor",
    "directoryServiceOptions": "None"
  },
  ......
}
```
This PR will fix this issue

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
