### PR TITLE
[RDBMS] `az mysql flexible-server ad-admin delete`: Disable `aad_auth_only` when dropping AAD admin

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/recordings/test_mysql_flexible_server_identity_aad_admin_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/recordings/test_mysql_flexible_server_identity_aad_admin_mgmt.yaml
@@ -13,8 +13,7 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: HEAD
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
@@ -26,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 31 Aug 2022 06:41:03 GMT
+      - Mon, 26 Sep 2022 03:14:51 GMT
       expires:
       - '-1'
       pragma:
@@ -52,13 +51,12 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-08-31T06:41:02Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -67,7 +65,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:41:02 GMT
+      - Mon, 26 Sep 2022 03:14:50 GMT
       expires:
       - '-1'
       pragma:
@@ -99,8 +97,7 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/checkNameAvailability?api-version=2021-12-01-preview
   response:
@@ -114,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:41:04 GMT
+      - Mon, 26 Sep 2022 03:14:52 GMT
       expires:
       - '-1'
       pragma:
@@ -148,8 +145,7 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/capabilities?api-version=2021-12-01-preview
   response:
@@ -163,7 +159,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:41:05 GMT
+      - Mon, 26 Sep 2022 03:14:54 GMT
       expires:
       - '-1'
       pragma:
@@ -195,8 +191,7 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/capabilities?api-version=2021-12-01-preview
   response:
@@ -210,7 +205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:41:06 GMT
+      - Mon, 26 Sep 2022 03:14:56 GMT
       expires:
       - '-1'
       pragma:
@@ -230,8 +225,8 @@ interactions:
       message: OK
 - request:
     body: '{"location": "northeurope", "sku": {"name": "Standard_D2ds_v4", "tier":
-      "GeneralPurpose"}, "properties": {"administratorLogin": "bouncybongo2", "administratorLoginPassword":
-      "knq9JM4_ay9mcASI0FHSIg", "version": "5.7", "createMode": "Create", "storage":
+      "GeneralPurpose"}, "properties": {"administratorLogin": "amusedrice1", "administratorLoginPassword":
+      "a5CcnpdqddCJhoN5kVdc9A", "version": "5.7", "createMode": "Create", "storage":
       {"storageSizeGB": 32, "iops": 396, "autoGrow": "Enabled"}, "backup": {"backupRetentionDays":
       7, "geoRedundantBackup": "Disabled"}, "highAvailability": {"mode": "Disabled"},
       "network": {}}}'
@@ -245,34 +240,33 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '441'
+      - '440'
       Content-Type:
       - application/json
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T06:41:10.3Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:15:01.333Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/97524ac6-d3f8-4b90-b9cb-985b48012051?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '86'
+      - '88'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:41:10 GMT
+      - Mon, 26 Sep 2022 03:15:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/97524ac6-d3f8-4b90-b9cb-985b48012051?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -300,22 +294,21 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/97524ac6-d3f8-4b90-b9cb-985b48012051?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"97524ac6-d3f8-4b90-b9cb-985b48012051","status":"InProgress","startTime":"2022-08-31T06:41:10.3Z"}'
+      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:42:10 GMT
+      - Mon, 26 Sep 2022 03:16:01 GMT
       expires:
       - '-1'
       pragma:
@@ -347,22 +340,21 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/97524ac6-d3f8-4b90-b9cb-985b48012051?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"97524ac6-d3f8-4b90-b9cb-985b48012051","status":"InProgress","startTime":"2022-08-31T06:41:10.3Z"}'
+      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:43:10 GMT
+      - Mon, 26 Sep 2022 03:17:02 GMT
       expires:
       - '-1'
       pragma:
@@ -394,22 +386,21 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/97524ac6-d3f8-4b90-b9cb-985b48012051?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"97524ac6-d3f8-4b90-b9cb-985b48012051","status":"Succeeded","startTime":"2022-08-31T06:41:10.3Z"}'
+      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '105'
+      - '108'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:11 GMT
+      - Mon, 26 Sep 2022 03:18:02 GMT
       expires:
       - '-1'
       pragma:
@@ -441,23 +432,68 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"Succeeded","startTime":"2022-09-26T03:15:01.333Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:19:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -n --public-access --tier --sku-name
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1019'
+      - '1074'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:11 GMT
+      - Mon, 26 Sep 2022 03:19:04 GMT
       expires:
       - '-1'
       pragma:
@@ -493,16 +529,15 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/databases/flexibleserverdb?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2022-08-31T06:44:12.663Z"}'
+      string: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2022-09-26T03:19:07.207Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/5c89a87b-0fed-45d4-b8c7-4d5c0b17a22d?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -510,11 +545,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:12 GMT
+      - Mon, 26 Sep 2022 03:19:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/5c89a87b-0fed-45d4-b8c7-4d5c0b17a22d?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -524,7 +559,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -542,13 +577,12 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/5c89a87b-0fed-45d4-b8c7-4d5c0b17a22d?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"5c89a87b-0fed-45d4-b8c7-4d5c0b17a22d","status":"Succeeded","startTime":"2022-08-31T06:44:12.663Z"}'
+      string: '{"name":"8a84fb95-3140-476b-90a3-ed51a7bb4275","status":"Succeeded","startTime":"2022-09-26T03:19:07.207Z"}'
     headers:
       cache-control:
       - no-cache
@@ -557,7 +591,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:27 GMT
+      - Mon, 26 Sep 2022 03:19:22 GMT
       expires:
       - '-1'
       pragma:
@@ -589,8 +623,7 @@ interactions:
       ParameterSetName:
       - -g -n --public-access --tier --sku-name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/databases/flexibleserverdb?api-version=2021-12-01-preview
   response:
@@ -604,7 +637,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:28 GMT
+      - Mon, 26 Sep 2022 03:19:22 GMT
       expires:
       - '-1'
       pragma:
@@ -636,13 +669,12 @@ interactions:
       ParameterSetName:
       - -g --name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-08-31T06:41:02Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -651,7 +683,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:28 GMT
+      - Mon, 26 Sep 2022 03:19:22 GMT
       expires:
       - '-1'
       pragma:
@@ -683,13 +715,12 @@ interactions:
       ParameterSetName:
       - -g --name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005?api-version=2022-01-31-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005","name":"identity000005","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","clientId":"ec9e917c-9c00-4b77-a00e-36f26750bdac"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005","name":"identity000005","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","clientId":"b5204580-6888-44c5-a786-35e64b7dd76b"}}'
     headers:
       cache-control:
       - no-cache
@@ -698,11 +729,101 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:32 GMT
+      - Mon, 26 Sep 2022 03:19:27 GMT
       expires:
       - '-1'
       location:
       - /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - identity create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '315'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:19:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"location": "northeurope"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - identity create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '27'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g --name
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006?api-version=2022-01-31-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006","name":"identity000006","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","clientId":"45867bf2-27e6-4dcf-9266-43f9b567cce1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:19:33 GMT
+      expires:
+      - '-1'
+      location:
+      - /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006
       pragma:
       - no-cache
       strict-transport-security:
@@ -728,13 +849,12 @@ interactions:
       ParameterSetName:
       - -g --name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-08-31T06:41:02Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -743,7 +863,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:32 GMT
+      - Mon, 26 Sep 2022 03:19:33 GMT
       expires:
       - '-1'
       pragma:
@@ -775,105 +895,12 @@ interactions:
       ParameterSetName:
       - -g --name
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006?api-version=2022-01-31-preview
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006","name":"identity000006","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","clientId":"42f6622d-528f-417a-8007-85efff45c0b5"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '451'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 06:44:36 GMT
-      expires:
-      - '-1'
-      location:
-      - /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
-    status:
-      code: 201
-      message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - identity create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --name
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-08-31T06:41:02Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '315'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 06:44:36 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"location": "northeurope"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - identity create
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '27'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g --name
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-msi/6.1.0 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007?api-version=2022-01-31-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007","name":"identity000007","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","clientId":"2aa33d41-4e8a-4b11-8112-067988cfe00c"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007","name":"identity000007","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"73742897-6cb3-4ae2-9415-e5d140213385","clientId":"bc28f46f-3d7f-4872-a5f6-b56a2109e032"}}'
     headers:
       cache-control:
       - no-cache
@@ -882,7 +909,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:39 GMT
+      - Mon, 26 Sep 2022 03:19:39 GMT
       expires:
       - '-1'
       location:
@@ -912,23 +939,22 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1019'
+      - '1074'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:40 GMT
+      - Mon, 26 Sep 2022 03:19:40 GMT
       expires:
       - '-1'
       pragma:
@@ -960,8 +986,7 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
@@ -975,7 +1000,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:40 GMT
+      - Mon, 26 Sep 2022 03:19:42 GMT
       expires:
       - '-1'
       pragma:
@@ -1012,28 +1037,27 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T06:44:44.077Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:19:43.85Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/079d93f7-4a64-4651-9bfd-5516b2abef36?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '88'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:44:43 GMT
+      - Mon, 26 Sep 2022 03:19:43 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/079d93f7-4a64-4651-9bfd-5516b2abef36?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1061,22 +1085,21 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/079d93f7-4a64-4651-9bfd-5516b2abef36?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"079d93f7-4a64-4651-9bfd-5516b2abef36","status":"Succeeded","startTime":"2022-08-31T06:44:44.077Z"}'
+      string: '{"name":"dc5e1b21-75f4-44f6-b881-0775cb0fb602","status":"Succeeded","startTime":"2022-09-26T03:19:43.85Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:45:44 GMT
+      - Mon, 26 Sep 2022 03:20:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1108,23 +1131,22 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1449'
+      - '1504'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:45:44 GMT
+      - Mon, 26 Sep 2022 03:20:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1156,23 +1178,22 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1449'
+      - '1504'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:45:45 GMT
+      - Mon, 26 Sep 2022 03:20:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1204,8 +1225,7 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/North%20Europe/capabilities?api-version=2021-12-01-preview
   response:
@@ -1219,7 +1239,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:45:46 GMT
+      - Mon, 26 Sep 2022 03:20:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1259,16 +1279,15 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1276,11 +1295,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:45:48 GMT
+      - Mon, 26 Sep 2022 03:20:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1290,7 +1309,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -1308,13 +1327,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"InProgress","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1323,7 +1341,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:46:48 GMT
+      - Mon, 26 Sep 2022 03:21:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1355,13 +1373,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"InProgress","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1370,7 +1387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:47:49 GMT
+      - Mon, 26 Sep 2022 03:22:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1402,13 +1419,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"InProgress","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1417,7 +1433,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:48:50 GMT
+      - Mon, 26 Sep 2022 03:23:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1449,13 +1465,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"InProgress","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1464,7 +1479,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:49:50 GMT
+      - Mon, 26 Sep 2022 03:24:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1496,13 +1511,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"InProgress","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1511,7 +1525,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:50:51 GMT
+      - Mon, 26 Sep 2022 03:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1543,13 +1557,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/43fdfd1f-8299-441b-9e99-48cd627a6faa?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"43fdfd1f-8299-441b-9e99-48cd627a6faa","status":"Succeeded","startTime":"2022-08-31T06:45:49.117Z"}'
+      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"Succeeded","startTime":"2022-09-26T03:20:52.383Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1558,7 +1571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:51 GMT
+      - Mon, 26 Sep 2022 03:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1590,23 +1603,22 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:51 GMT
+      - Mon, 26 Sep 2022 03:26:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1638,8 +1650,7 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
   response:
@@ -1653,7 +1664,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:52 GMT
+      - Mon, 26 Sep 2022 03:27:00 GMT
       expires:
       - '-1'
       pragma:
@@ -1685,23 +1696,22 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:53 GMT
+      - Mon, 26 Sep 2022 03:27:01 GMT
       expires:
       - '-1'
       pragma:
@@ -1733,23 +1743,22 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:54 GMT
+      - Mon, 26 Sep 2022 03:27:04 GMT
       expires:
       - '-1'
       pragma:
@@ -1781,23 +1790,22 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1451'
+      - '1506'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:54 GMT
+      - Mon, 26 Sep 2022 03:27:05 GMT
       expires:
       - '-1'
       pragma:
@@ -1829,23 +1837,22 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1551'
+      - '1579'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:55 GMT
+      - Mon, 26 Sep 2022 03:27:06 GMT
       expires:
       - '-1'
       pragma:
@@ -1882,16 +1889,15 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T06:51:56.817Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:27:09.057Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/80134123-a137-4a49-b29a-d8cab2cd44c7?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1899,11 +1905,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:51:56 GMT
+      - Mon, 26 Sep 2022 03:27:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/80134123-a137-4a49-b29a-d8cab2cd44c7?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1931,13 +1937,12 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/80134123-a137-4a49-b29a-d8cab2cd44c7?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"80134123-a137-4a49-b29a-d8cab2cd44c7","status":"Succeeded","startTime":"2022-08-31T06:51:56.817Z"}'
+      string: '{"name":"e858763b-81e7-4b7d-8951-0790ac392e05","status":"Succeeded","startTime":"2022-09-26T03:27:09.057Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1946,7 +1951,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:52:56 GMT
+      - Mon, 26 Sep 2022 03:28:09 GMT
       expires:
       - '-1'
       pragma:
@@ -1978,23 +1983,22 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1896'
+      - '1951'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:52:57 GMT
+      - Mon, 26 Sep 2022 03:28:09 GMT
       expires:
       - '-1'
       pragma:
@@ -2031,28 +2035,27 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T06:52:59.263Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:28:11.54Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c7f5c09e-c961-40a5-943f-6b4b9678baa0?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '88'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:52:58 GMT
+      - Mon, 26 Sep 2022 03:28:10 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/c7f5c09e-c961-40a5-943f-6b4b9678baa0?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2080,22 +2083,21 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c7f5c09e-c961-40a5-943f-6b4b9678baa0?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"c7f5c09e-c961-40a5-943f-6b4b9678baa0","status":"Succeeded","startTime":"2022-08-31T06:52:59.263Z"}'
+      string: '{"name":"87739bae-ed4d-4ed2-8f40-58fdddba80ec","status":"Succeeded","startTime":"2022-09-26T03:28:11.54Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:53:59 GMT
+      - Mon, 26 Sep 2022 03:29:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2127,23 +2129,22 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1716'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:53:59 GMT
+      - Mon, 26 Sep 2022 03:29:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2163,7 +2164,7 @@ interactions:
       message: OK
 - request:
     body: '{"properties": {"administratorType": "ActiveDirectory", "login": "alanenriqueo@microsoft.com",
-      "sid": "894ef8da-7971-4f68-972c-f561441eb329", "tenantId": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      "sid": "894ef8da-7971-4f68-972c-f561441eb329", "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
       "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"}}'
     headers:
       Accept:
@@ -2181,16 +2182,15 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertActiveDirectoryAdministratorManagementOperation","startTime":"2022-08-31T06:54:00.933Z"}'
+      string: '{"operation":"UpsertActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-26T03:29:15.063Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/80b459f6-9be9-4205-af5a-5c4411248d7b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -2198,11 +2198,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:54:00 GMT
+      - Mon, 26 Sep 2022 03:29:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/80b459f6-9be9-4205-af5a-5c4411248d7b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2230,13 +2230,12 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/80b459f6-9be9-4205-af5a-5c4411248d7b?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"80b459f6-9be9-4205-af5a-5c4411248d7b","status":"Succeeded","startTime":"2022-08-31T06:54:00.933Z"}'
+      string: '{"name":"20846a7a-6017-4eea-aee3-cc20db5c0a9b","status":"Succeeded","startTime":"2022-09-26T03:29:15.063Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2245,7 +2244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:00 GMT
+      - Mon, 26 Sep 2022 03:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2277,13 +2276,12 @@ interactions:
       ParameterSetName:
       - -g -s -u -i --identity
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
+      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
     headers:
       cache-control:
       - no-cache
@@ -2292,55 +2290,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1716'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 06:55:01 GMT
+      - Mon, 26 Sep 2022 03:30:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2372,13 +2322,12 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators/ActiveDirectory?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
+      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
     headers:
       cache-control:
       - no-cache
@@ -2387,7 +2336,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:02 GMT
+      - Mon, 26 Sep 2022 03:30:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2419,71 +2368,115 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1896'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 06:55:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server replica create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g --replica-name --source-server
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1716'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:03 GMT
+      - Mon, 26 Sep 2022 03:30:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators/ActiveDirectory?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '644'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:30:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1951'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:30:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2515,8 +2508,54 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1771'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:30:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server replica create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --replica-name --source-server
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/North%20Europe/capabilities?api-version=2021-12-01-preview
   response:
@@ -2530,7 +2569,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:05 GMT
+      - Mon, 26 Sep 2022 03:30:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2571,16 +2610,15 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -2588,11 +2626,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:55:06 GMT
+      - Mon, 26 Sep 2022 03:30:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2602,7 +2640,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -2620,13 +2658,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"InProgress","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2635,7 +2672,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:56:07 GMT
+      - Mon, 26 Sep 2022 03:31:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2667,13 +2704,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"InProgress","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2682,7 +2718,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:57:08 GMT
+      - Mon, 26 Sep 2022 03:32:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2714,13 +2750,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"InProgress","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2729,7 +2764,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:58:08 GMT
+      - Mon, 26 Sep 2022 03:33:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2761,13 +2796,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"InProgress","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2776,7 +2810,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 06:59:09 GMT
+      - Mon, 26 Sep 2022 03:34:30 GMT
       expires:
       - '-1'
       pragma:
@@ -2808,13 +2842,12 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"InProgress","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2823,7 +2856,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:00:10 GMT
+      - Mon, 26 Sep 2022 03:35:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2855,13 +2888,58 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/fac42aaf-85ff-4e6b-9ad2-b8e4914586cc?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"fac42aaf-85ff-4e6b-9ad2-b8e4914586cc","status":"Succeeded","startTime":"2022-08-31T06:55:07.64Z"}'
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:36:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server replica create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --replica-name --source-server
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"Succeeded","startTime":"2022-09-26T03:30:29.06Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2870,7 +2948,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:09 GMT
+      - Mon, 26 Sep 2022 03:37:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2902,23 +2980,22 @@ interactions:
       ParameterSetName:
       - -g --replica-name --source-server
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1896'
+      - '1951'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:10 GMT
+      - Mon, 26 Sep 2022 03:37:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2950,13 +3027,12 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
+      string: '{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}'
     headers:
       cache-control:
       - no-cache
@@ -2965,7 +3041,297 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:11 GMT
+      - Mon, 26 Sep 2022 03:37:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "ON", "source": "user-override"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T03:37:39.05Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:37:38 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"93dc33a4-88a4-4490-8b94-81d0e888e76a","status":"Succeeded","startTime":"2022-09-26T03:37:39.05Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:37:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:37:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "ON", "source": "user-override"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T03:37:57.533Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '95'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:37:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"f8f6225e-c69d-4ed7-83c8-9cf638146fe5","status":"Succeeded","startTime":"2022-09-26T03:37:57.533Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:38:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n -v
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '569'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 03:38:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2997,23 +3363,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1716'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:11 GMT
+      - Mon, 26 Sep 2022 03:38:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3045,23 +3410,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1716'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:12 GMT
+      - Mon, 26 Sep 2022 03:38:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3093,13 +3457,12 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}]}'
+      string: '{"value":[{"properties":{"administratorType":"ActiveDirectory","login":"alanenriqueo@microsoft.com","sid":"894ef8da-7971-4f68-972c-f561441eb329","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","identityResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory","name":"ActiveDirectory","type":"Microsoft.DBforMySQL/flexibleServers/administrators"}]}'
     headers:
       cache-control:
       - no-cache
@@ -3108,7 +3471,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:12 GMT
+      - Mon, 26 Sep 2022 03:38:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3140,23 +3503,22 @@ interactions:
       ParameterSetName:
       - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1896'
+      - '1951'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:13 GMT
+      - Mon, 26 Sep 2022 03:38:17 GMT
       expires:
       - '-1'
       pragma:
@@ -3188,23 +3550,22 @@ interactions:
       ParameterSetName:
       - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1716'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:14 GMT
+      - Mon, 26 Sep 2022 04:08:34 GMT
       expires:
       - '-1'
       pragma:
@@ -3238,28 +3599,27 @@ interactions:
       ParameterSetName:
       - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"DropActiveDirectoryAdministratorManagementOperation","startTime":"2022-08-31T07:01:14.783Z"}'
+      string: '{"operation":"DropActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-26T04:08:37.19Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dcc90a4a-859c-4f22-8280-65d6f06ffe47?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '105'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:01:13 GMT
+      - Mon, 26 Sep 2022 04:08:37 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/dcc90a4a-859c-4f22-8280-65d6f06ffe47?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3287,22 +3647,21 @@ interactions:
       ParameterSetName:
       - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dcc90a4a-859c-4f22-8280-65d6f06ffe47?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"dcc90a4a-859c-4f22-8280-65d6f06ffe47","status":"Succeeded","startTime":"2022-08-31T07:01:14.783Z"}'
+      string: '{"name":"054fe86e-6220-4f7f-9a11-14227fce3228","status":"Succeeded","startTime":"2022-09-26T04:08:37.19Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:02:14 GMT
+      - Mon, 26 Sep 2022 04:09:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3334,10 +3693,9 @@ interactions:
       ParameterSetName:
       - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/dcc90a4a-859c-4f22-8280-65d6f06ffe47?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
   response:
     body:
       string: ''
@@ -3347,7 +3705,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Wed, 31 Aug 2022 07:02:14 GMT
+      - Mon, 26 Sep 2022 04:09:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3369,219 +3727,29 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server ad-admin list
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -s
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:02:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:02:16 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/administrators?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"value":[]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '12'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:02:17 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity assign
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s -n
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1716'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:02:18 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity assign
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s -n
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3621'
+      - '3677'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:02:18 GMT
+      - Mon, 26 Sep 2022 04:09:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3600,46 +3768,189 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":
-      {}}}}'
+    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
     headers:
       Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity assign
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       Content-Length:
-      - '231'
+      - '59'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -s -n
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:02:20.15Z"}'
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:09:41.917Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/19372101-9e26-439a-95f3-b13feda515cd?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '95'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:02:20 GMT
+      - Mon, 26 Sep 2022 04:09:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/19372101-9e26-439a-95f3-b13feda515cd?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"08524351-7013-43f8-b9ed-a4a821450456","status":"Succeeded","startTime":"2022-09-26T04:09:41.917Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:09:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:09:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:09:58.607Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '95'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:09:58 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3661,28 +3972,27 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity assign
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -s -n
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/19372101-9e26-439a-95f3-b13feda515cd?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"19372101-9e26-439a-95f3-b13feda515cd","status":"Succeeded","startTime":"2022-08-31T07:02:20.15Z"}'
+      string: '{"name":"6ca07923-b5db-42ce-9f2b-22b40ca313ee","status":"Succeeded","startTime":"2022-09-26T04:09:58.607Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:03:20 GMT
+      - Mon, 26 Sep 2022 04:10:13 GMT
       expires:
       - '-1'
       pragma:
@@ -3708,29 +4018,28 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity assign
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -s -n
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2161'
+      - '571'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:03:20 GMT
+      - Mon, 26 Sep 2022 04:10:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3749,46 +4058,44 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":
-      {}}}}'
+    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
     headers:
       Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity assign
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       Content-Length:
-      - '231'
+      - '59'
       Content-Type:
       - application/json
       ParameterSetName:
-      - -g -s -n
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:03:28.83Z"}'
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:10:15.37Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/68a39132-8926-407d-8b0a-30f2b6103f16?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '94'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:03:28 GMT
+      - Mon, 26 Sep 2022 04:10:15 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/68a39132-8926-407d-8b0a-30f2b6103f16?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3810,19 +4117,18 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity assign
+      - mysql flexible-server ad-admin delete
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -s -n
+      - -g -s --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/68a39132-8926-407d-8b0a-30f2b6103f16?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"68a39132-8926-407d-8b0a-30f2b6103f16","status":"Succeeded","startTime":"2022-08-31T07:03:28.83Z"}'
+      string: '{"name":"557a4cfd-340d-42e3-a48e-38ee48ccf667","status":"Succeeded","startTime":"2022-09-26T04:10:15.37Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3831,7 +4137,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:04:28 GMT
+      - Mon, 26 Sep 2022 04:10:30 GMT
       expires:
       - '-1'
       pragma:
@@ -3857,29 +4163,402 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:10:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:10:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/administrators?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:10:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/administrators?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:10:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:11:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:11:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server parameter show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
+        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '571'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:11:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
       - mysql flexible-server identity assign
       Connection:
       - keep-alive
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2161'
+      - '1771'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:04:29 GMT
+      - Mon, 26 Sep 2022 04:11:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3677'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:11:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3916,16 +4595,15 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:04:32.147Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:11:22.573Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/adbf23ce-2708-4b46-b8b1-0f718762f4d2?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -3933,11 +4611,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:04:31 GMT
+      - Mon, 26 Sep 2022 04:11:22 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/adbf23ce-2708-4b46-b8b1-0f718762f4d2?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3965,13 +4643,12 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/adbf23ce-2708-4b46-b8b1-0f718762f4d2?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"adbf23ce-2708-4b46-b8b1-0f718762f4d2","status":"Succeeded","startTime":"2022-08-31T07:04:32.147Z"}'
+      string: '{"name":"3f6e12d3-8ed5-419d-a567-931032b67ad5","status":"Succeeded","startTime":"2022-09-26T04:11:22.573Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3980,7 +4657,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:32 GMT
+      - Mon, 26 Sep 2022 04:12:22 GMT
       expires:
       - '-1'
       pragma:
@@ -4012,119 +4689,121 @@ interactions:
       ParameterSetName:
       - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1981'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:05:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '2161'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:05:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity list
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2161'
+      - '2216'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:33 GMT
+      - Mon, 26 Sep 2022 04:12:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":
+      {}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:12:25.823Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:12:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"05eec2de-8aaf-47dc-9b58-7d6e35123e5e","status":"Succeeded","startTime":"2022-09-26T04:12:25.823Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:13:26 GMT
       expires:
       - '-1'
       pragma:
@@ -4146,33 +4825,319 @@ interactions:
     body: null
     headers:
       Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:13:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":
+      {}}}}'
+    headers:
+      Accept:
       - application/json
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - mysql flexible-server identity remove
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:13:29.123Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:13:29 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
       Connection:
       - keep-alive
       ParameterSetName:
-      - -g -s -n --yes
+      - -g -s -n
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93","status":"Succeeded","startTime":"2022-09-26T04:13:29.123Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity assign
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1981'
+      - '2036'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:34 GMT
+      - Mon, 26 Sep 2022 04:14:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:35 GMT
       expires:
       - '-1'
       pragma:
@@ -4204,23 +5169,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1981'
+      - '2036'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:34 GMT
+      - Mon, 26 Sep 2022 04:14:37 GMT
       expires:
       - '-1'
       pragma:
@@ -4252,8 +5216,54 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2036'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
   response:
@@ -4267,7 +5277,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:35 GMT
+      - Mon, 26 Sep 2022 04:14:38 GMT
       expires:
       - '-1'
       pragma:
@@ -4299,24 +5309,23 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4151'
+      - '4207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:35 GMT
+      - Mon, 26 Sep 2022 04:14:41 GMT
       expires:
       - '-1'
       pragma:
@@ -4355,17 +5364,16 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
       string: '{"error":{"code":"FailedIdentityOperation","message":"Identity operation
-        for resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003''
+        for resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004''
         failed with error ''Failed to perform resource identity operation. Status:
         ''BadRequest''. Response: ''{\"error\":{\"code\":\"BadRequest\",\"message\":\"Removal
-        of all user-assigned identities assigned to resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003''
+        of all user-assigned identities assigned to resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004''
         with type ''UserAssigned'' is invalid.\"}}''.''."}}'
     headers:
       cache-control:
@@ -4375,7 +5383,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:36 GMT
+      - Mon, 26 Sep 2022 04:14:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4403,23 +5411,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1981'
+      - '2036'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:37 GMT
+      - Mon, 26 Sep 2022 04:14:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4451,23 +5458,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1981'
+      - '2036'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:37 GMT
+      - Mon, 26 Sep 2022 04:14:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4499,8 +5505,7 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators?api-version=2021-12-01-preview
   response:
@@ -4514,7 +5519,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:37 GMT
+      - Mon, 26 Sep 2022 04:14:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4546,24 +5551,23 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"caa9b3eb-bc8d-45b9-a303-60132b784208","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"0a97c35e-aaa7-432b-99f9-63ff80ab7723","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4151'
+      - '4207'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:38 GMT
+      - Mon, 26 Sep 2022 04:14:48 GMT
       expires:
       - '-1'
       pragma:
@@ -4601,28 +5605,174 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:14:50.46Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:14:50 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"4c50edab-4a08-4397-9d6a-9d9c8784283b","status":"Succeeded","startTime":"2022-09-26T04:14:50.46Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:15:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1686'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Sep 2022 04:15:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
+      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
+      null}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '400'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:05:40.803Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:15:53.67Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/be1f4b46-e323-4f27-9a15-5edee7434a94?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '88'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:05:40 GMT
+      - Mon, 26 Sep 2022 04:15:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/be1f4b46-e323-4f27-9a15-5edee7434a94?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -4650,22 +5800,21 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/be1f4b46-e323-4f27-9a15-5edee7434a94?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"be1f4b46-e323-4f27-9a15-5edee7434a94","status":"Succeeded","startTime":"2022-08-31T07:05:40.803Z"}'
+      string: '{"name":"c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb","status":"Succeeded","startTime":"2022-09-26T04:15:53.67Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:06:41 GMT
+      - Mon, 26 Sep 2022 04:16:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4697,23 +5846,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:06:41 GMT
+      - Mon, 26 Sep 2022 04:16:54 GMT
       expires:
       - '-1'
       pragma:
@@ -4751,16 +5899,15 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:06:43.177Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:16:57.053Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/7ee94263-56e6-4472-b439-07a8386a6929?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -4768,11 +5915,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:06:43 GMT
+      - Mon, 26 Sep 2022 04:16:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/7ee94263-56e6-4472-b439-07a8386a6929?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -4800,13 +5947,12 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/7ee94263-56e6-4472-b439-07a8386a6929?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"7ee94263-56e6-4472-b439-07a8386a6929","status":"Succeeded","startTime":"2022-08-31T07:06:43.177Z"}'
+      string: '{"name":"70c853df-256f-4486-995c-44e07e09eb56","status":"Succeeded","startTime":"2022-09-26T04:16:57.053Z"}'
     headers:
       cache-control:
       - no-cache
@@ -4815,7 +5961,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:07:42 GMT
+      - Mon, 26 Sep 2022 04:17:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4847,173 +5993,22 @@ interactions:
       ParameterSetName:
       - -g -s -n --yes
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1631'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:07:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
-      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
-      null}}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity remove
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '400'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -s -n --yes
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-08-31T07:07:45.617Z"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b99a6b13-f49f-4366-92b1-a6ee7d28c3e4?api-version=2021-12-01-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '88'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:07:44 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/b99a6b13-f49f-4366-92b1-a6ee7d28c3e4?api-version=2021-12-01-preview
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity remove
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s -n --yes
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b99a6b13-f49f-4366-92b1-a6ee7d28c3e4?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"name":"b99a6b13-f49f-4366-92b1-a6ee7d28c3e4","status":"Succeeded","startTime":"2022-08-31T07:07:45.617Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 31 Aug 2022 07:08:45 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server identity remove
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s -n --yes
-      User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:41:11.7700816Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:43:27.3998942+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1451'
+      - '1506'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:08:45 GMT
+      - Mon, 26 Sep 2022 04:17:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5045,23 +6040,22 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:45:56.6629828Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:49:00.5074164+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:08:46 GMT
+      - Mon, 26 Sep 2022 04:18:07 GMT
       expires:
       - '-1'
       pragma:
@@ -5093,23 +6087,22 @@ interactions:
       ParameterSetName:
       - -g -s
       User-Agent:
-      - AZURECLI/2.39.0 azsdk-python-mgmt-rdbms/10.2.0b3 Python/3.10.6 (Linux-5.15.0-1017-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"f38a5db5-6352-4060-97e3-aad3e77c1984","tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-08-31T06:55:14.9068840Z"},"properties":{"administratorLogin":"bouncybongo2","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-08-31T06:58:26.9830035+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled"}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1631'
+      - '1686'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 31 Aug 2022 07:08:47 GMT
+      - Mon, 26 Sep 2022 04:18:26 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
@@ -2123,24 +2123,18 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
                             JMESPathCheck('sid', sid)]
 
             self.cmd('{} flexible-server ad-admin create -g {} -s {} -u {} -i {} --identity {}'
-                     .format(database_engine, resource_group, server, login, sid, identity_id[1]),
-                     checks=admin_checks)
+                     .format(database_engine, resource_group, server, login, sid, identity_id[1]))
 
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, server),
-                     checks=[
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1]))])
+            for server_name in [server, replica[0]]:
+                self.cmd('{} flexible-server ad-admin show -g {} -s {}'
+                        .format(database_engine, resource_group, server_name),
+                        checks=admin_checks)
 
-            self.cmd('{} flexible-server ad-admin show -g {} -s {}'
-                     .format(database_engine, resource_group, replica[0]),
-                     checks=admin_checks)
-
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, replica[0]),
-                     checks=[
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1]))])
+                self.cmd('{} flexible-server identity list -g {} -s {}'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1]))])
 
             # create replica 2
             self.cmd('{} flexible-server replica create -g {} --replica-name {} --source-server {}'
@@ -2152,6 +2146,12 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
             self.cmd('{} flexible-server ad-admin show -g {} -s {}'
                      .format(database_engine, resource_group, replica[1]),
                      checks=admin_checks)
+
+            # set aad_auth_only=ON in primary server and replica 2
+            for server_name in [server, replica[1]]:
+                self.cmd('{} flexible-server parameter set -g {} -s {} -n aad_auth_only -v ON'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[JMESPathCheck('value', 'ON')])
 
             # try to remove identity 2 from primary server
             self.cmd('{} flexible-server identity remove -g {} -s {} -n {} --yes'
@@ -2167,39 +2167,28 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
             self.cmd('{} flexible-server ad-admin delete -g {} -s {} --yes'
                      .format(database_engine, resource_group, server))
 
-            admins = self.cmd('{} flexible-server ad-admin list -g {} -s {}'
-                              .format(database_engine, resource_group, server)).get_output_in_json()
-            self.assertEqual(0, len(admins))
+            for server_name in [server, replica[0], replica[1]]:
+                admins = self.cmd('{} flexible-server ad-admin list -g {} -s {}'
+                                .format(database_engine, resource_group, server_name)).get_output_in_json()
+                self.assertEqual(0, len(admins))
 
-            admins = self.cmd('{} flexible-server ad-admin list -g {} -s {}'
-                              .format(database_engine, resource_group, replica[0])).get_output_in_json()
-            self.assertEqual(0, len(admins))
-
-            admins = self.cmd('{} flexible-server ad-admin list -g {} -s {}'
-                              .format(database_engine, resource_group, replica[1])).get_output_in_json()
-            self.assertEqual(0, len(admins))
+            # verify that aad_auth_only=OFF in primary server and all replicas
+            for server_name in [server, replica[0], replica[1]]:
+                self.cmd('{} flexible-server parameter show -g {} -s {} -n aad_auth_only'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[JMESPathCheck('value', 'OFF')])
 
             # add identity 3 to primary server
             self.cmd('{} flexible-server identity assign -g {} -s {} -n {}'
-                     .format(database_engine, resource_group, server, identity_id[2]),
-                     checks=[
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
+                     .format(database_engine, resource_group, server, identity_id[2]))
 
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, replica[0]),
-                     checks=[
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
-
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, replica[1]),
-                     checks=[
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
+            for server_name in [server_name, replica[0], replica[1]]:
+                self.cmd('{} flexible-server identity list -g {} -s {}'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[0])),
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1])),
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
 
             # try to remove all identities from primary server
             self.cmd('{} flexible-server identity remove -g {} -s {} -n {} {} {} --yes'
@@ -2208,22 +2197,12 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
 
             # remove identities 1 and 2 from primary server
             self.cmd('{} flexible-server identity remove -g {} -s {} -n {} {} --yes'
-                     .format(database_engine, resource_group, server, identity_id[0], identity_id[1]),
-                     checks=[
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
+                     .format(database_engine, resource_group, server, identity_id[0], identity_id[1]))
 
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, replica[0]),
-                     checks=[
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
-
-            self.cmd('{} flexible-server identity list -g {} -s {}'
-                     .format(database_engine, resource_group, replica[1]),
-                     checks=[
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
-                        JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
-                        JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
+            for server_name in [replica[0], replica[1]]:
+                self.cmd('{} flexible-server identity list -g {} -s {}'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[
+                            JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
+                            JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
+                            JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])


### PR DESCRIPTION
**Related command**
`az mysql flexible-server ad-admin delete`

**Description**
When dropping the AAD admin for a MySQL flexible sever, we should disable automatically **AAD authentication only** because customer won't be able to connect again to the server using username and password. He can disable it manually by setting `aad_auth_only` to `OFF` and connect again, but the idea is to do this automatically to avoid confusion.

**Testing Guide**
- Create an AAD admin for an existing server: `az mysql flexible-server ad-admin create -g resourceGroup -s serverName -u login -i sid --identity userIdentity`
- Enable AAD authentication only: `az mysql flexible-server parameter set -g resourceGroup -s serverName -n aad_auth_only -v ON`
- Delete the AAD admin: `az mysql flexible-server ad-admin delete -g resourceGroup -s serverName`
- Verify that server has MySQL authentication only (`aad_auth_only` should be `OFF`): `az mysql flexible-server parameter show -g resourceGroup -s serverName -n aad_auth_only`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
