### PR TITLE
[AKS] Fix #23779: `az aks install-cli` support to determine the arch of binaries based on system information

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2514,12 +2514,16 @@ def k8s_install_cli(cmd, client_version='latest', install_location=None, base_sr
 # the results returned here may be inaccurate if the installed python is translated (e.g. by Rosetta)
 def get_arch_for_cli_binary():
     arch = platform.processor().lower()
-    logger.warning(
-        "The detected arch is %s, which may not match the actual situation due to translation and other reasons. "
-        "If there is any problem, please download the appropriate binary by yourself.", arch)
+    formatted_arch = "amd64"
     if "arm" in arch:
-        return "arm64"
-    return "amd64"
+        formatted_arch == "arm64"
+    logger.warning(
+        "The detected arch is %s, would be treated as %s, which may not match the actual situation due to translation "
+        "and other reasons. If there is any problem, please download the appropriate binary by yourself.",
+        arch,
+        formatted_arch,
+    )
+    return formatted_arch
 
 
 # install kubectl

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -2516,7 +2516,7 @@ def get_arch_for_cli_binary():
     arch = platform.processor().lower()
     formatted_arch = "amd64"
     if "arm" in arch:
-        formatted_arch == "arm64"
+        formatted_arch = "arm64"
     logger.warning(
         "The detected arch is %s, would be treated as %s, which may not match the actual situation due to translation "
         "and other reasons. If there is any problem, please download the appropriate binary by yourself.",

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -766,7 +766,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
             # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 3 warnings, one for download result
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -739,8 +739,8 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubectl')
             k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result; 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+            # 2 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -739,7 +739,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubectl')
             k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
             self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
@@ -756,7 +756,6 @@ class AcsCustomCommandTest(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
-    @unittest.skip('Update api version')
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
     def test_k8s_install_kubelogin_emit_warnings(self, logger_mock, mock_url_retrieve):
@@ -766,12 +765,11 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubelogin')
             k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result; 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 2)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 
-    @unittest.skip('Update api version')
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
     def test_k8s_install_kubelogin_create_installation_dir(self, logger_mock, mock_url_retrieve):

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -727,8 +727,8 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubectl')
             k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result; 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+            # 2 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -727,7 +727,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubectl')
             k8s_install_kubectl(mock.MagicMock(), client_version='1.2.3', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
             self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
@@ -744,7 +744,6 @@ class AcsCustomCommandTest(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
-    @unittest.skip('Update api version')
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
     def test_k8s_install_kubelogin_emit_warnings(self, logger_mock, mock_url_retrieve):
@@ -754,12 +753,11 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubelogin')
             k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result; 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 
-    @unittest.skip('Update api version')
     @mock.patch('azure.cli.command_modules.acs.custom._urlretrieve')
     @mock.patch('azure.cli.command_modules.acs.custom.logger')
     def test_k8s_install_kubelogin_create_installation_dir(self, logger_mock, mock_url_retrieve):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks install-cli`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Note: A new warning level log message (to stderr) is added to the command.

Fix issue #23779.

After this change, the binary file corresponding to the arch of kubectl/kubelogin that needs to be downloaded will be determined by the result returned by `platform.processor()`.

Sample screenshot
![image](https://user-images.githubusercontent.com/81607949/192243404-38192ad9-87bf-46ce-bb8d-11760fd9e96f.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
