### PR TITLE
[Packaging] Drop Mariner 1.0 RPM package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -600,21 +600,15 @@ jobs:
     vmImage: 'ubuntu-20.04'
   strategy:
     matrix:
-      1.0:
-        image: cblmariner.azurecr.io/base/core
-        tag: 1.0
       2.0:
-        image: mcr.microsoft.com/cbl-mariner/base/core
-        tag: 2.0
+        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
+        artifact: rpm-mariner2.0
   steps:
   - task: Bash@3
     displayName: 'Build Rpm Package: Mariner'
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline_mariner.sh
-    env:
-      IMAGE: $(image)
-      TAG: $(tag)
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
@@ -625,7 +619,7 @@ jobs:
     displayName: 'Publish Artifact: rpm-mariner'
     inputs:
       TargetPath: $(Build.ArtifactStagingDirectory)
-      ArtifactName: rpm-mariner$(tag)
+      ArtifactName: $(artifact)
 
 # TODO: rpmbuild on Red Hat UBI 8 is slow for unknown reason. Still working with Red Hat to investigate.
 - job: BuildRpmPackages
@@ -662,9 +656,6 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: scripts/release/rpm/pipeline.sh
-    env:
-      IMAGE: $(image)
-      TAG: $(tag)
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'SBOM'
     inputs:

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -1,7 +1,6 @@
-ARG tag=2.0
-ARG image=mcr.microsoft.com/cbl-mariner/base/core
+ARG image=mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-FROM ${image}:${tag} AS build-env
+FROM ${image} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
@@ -19,7 +18,7 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
 
-FROM ${image}:${tag} AS execution-env
+FROM ${image} AS execution-env
 
 RUN tdnf update -y
 RUN tdnf install -y python3 rpm

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -8,7 +8,7 @@ set -exv
 
 # DOCKERFILE should be one of 'ubi' or 'fedora'
 : "${DOCKERFILE:?DOCKERFILE environment variable not set.}"
-# IMAGE should be RHEL or Fedora image url
+# IMAGE should be RHEL or Fedora docker image url
 : "${IMAGE:?IMAGE environment variable not set.}"
 # PYTHON_PACKAGE should be python package name
 : "${PYTHON_PACKAGE:?PYTHON_PACKAGE environment variable not set.}"

--- a/scripts/release/rpm/pipeline_mariner.sh
+++ b/scripts/release/rpm/pipeline_mariner.sh
@@ -5,26 +5,25 @@
 set -exv
 
 : "${BUILD_STAGINGDIRECTORY:?BUILD_STAGINGDIRECTORY environment variable not set.}"
+
+# IMAGE should be Mariner docker image url, such as mcr.microsoft.com/cbl-mariner/base/core:2.0
 : "${IMAGE:?IMAGE environment variable not set.}"
-: "${TAG:?TAG environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 
 # Create a container image that includes the source code and a built RPM using this file.
 docker build \
     --target build-env \
-    --build-arg image=${IMAGE} \
-    --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
+    --build-arg image=${IMAGE} \
     -f ./scripts/release/rpm/mariner.dockerfile \
     -t azure/azure-cli:mariner-builder \
     .
 
 # Continue the previous build, and create a container that has the current azure-cli build but not the source code.
 docker build \
-    --build-arg image=${IMAGE} \
-    --build-arg tag=${TAG} \
     --build-arg cli_version=${CLI_VERSION} \
+    --build-arg image=${IMAGE} \
     -f ./scripts/release/rpm/mariner.dockerfile \
     -t azure/azure-cli:mariner \
     .


### PR DESCRIPTION
**Description**<!--Mandatory-->
Close https://github.com/Azure/azure-cli/issues/22605

Since CBL Mariner 2.0 is now GA, Mariner 1.0 will be fully deprecated roughly by the **end of October**.

We stop building RPM for Mariner 1.0 in 2.41.0 which is a breaking change window.