### PR TITLE
[RDBMS] `az mysql flexible-server identity remove`: Allow removing all identities in a MySQL server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -482,7 +482,8 @@ def flexible_server_identity_remove(cmd, client, resource_group_name, server_nam
     for identity in identities:
         identities_map[identity] = None
 
-    if all(key.lower() in [identity.lower() for identity in identities] for key in instance.identity.user_assigned_identities.keys()):
+    if not (instance.identity and instance.identity.user_assigned_identities) or \
+       all(key.lower() in [identity.lower() for identity in identities] for key in instance.identity.user_assigned_identities.keys()):
         parameters = {
             'identity': mysql_flexibleservers.models.Identity(
                 type="None")}
@@ -516,7 +517,7 @@ def flexible_server_identity_remove(cmd, client, resource_group_name, server_nam
         cmd.cli_ctx, 'Removing identities from server {}'.format(server_name)
     )
 
-    return result.identity
+    return result.identity or mysql_flexibleservers.models.Identity()
 
 
 def flexible_server_identity_list(client, resource_group_name, server_name):
@@ -555,7 +556,8 @@ def flexible_server_ad_admin_set(cmd, client, resource_group_name, server_name, 
 
     replicas = replica_operations_client.list_by_server(resource_group_name, server_name)
     for replica in replicas:
-        if not (replica.identity and replica.identity.user_assigned_identities and identity.lower() in [key.lower() for key in replica.identity.user_assigned_identities.keys()]):
+        if not (replica.identity and replica.identity.user_assigned_identities and
+           identity.lower() in [key.lower() for key in replica.identity.user_assigned_identities.keys()]):
             resolve_poller(
                 server_operations_client.begin_update(
                     resource_group_name=resource_group_name,
@@ -564,7 +566,8 @@ def flexible_server_ad_admin_set(cmd, client, resource_group_name, server_name, 
                 cmd.cli_ctx, 'Adding identity {} to replica {}'.format(identity, replica.name)
             )
 
-    if not (instance.identity and instance.identity.user_assigned_identities and identity.lower() in [key.lower() for key in instance.identity.user_assigned_identities.keys()]):
+    if not (instance.identity and instance.identity.user_assigned_identities and
+       identity.lower() in [key.lower() for key in instance.identity.user_assigned_identities.keys()]):
         resolve_poller(
             server_operations_client.begin_update(
                 resource_group_name=resource_group_name,

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -482,10 +482,15 @@ def flexible_server_identity_remove(cmd, client, resource_group_name, server_nam
     for identity in identities:
         identities_map[identity] = None
 
-    parameters = {
-        'identity': mysql_flexibleservers.models.Identity(
-            user_assigned_identities=identities_map,
-            type="UserAssigned")}
+    if all(key.lower() in [identity.lower() for identity in identities] for key in instance.identity.user_assigned_identities.keys()):
+        parameters = {
+            'identity': mysql_flexibleservers.models.Identity(
+                type="None")}
+    else:
+        parameters = {
+            'identity': mysql_flexibleservers.models.Identity(
+                user_assigned_identities=identities_map,
+                type="UserAssigned")}
 
     if isinstance(client, MySqlServersOperations):
         replica_operations_client = cf_mysql_flexible_replica(cmd.cli_ctx, '_')
@@ -516,7 +521,7 @@ def flexible_server_identity_remove(cmd, client, resource_group_name, server_nam
 
 def flexible_server_identity_list(client, resource_group_name, server_name):
     server = client.get(resource_group_name, server_name)
-    return server.identity
+    return server.identity or mysql_flexibleservers.models.Identity()
 
 
 def flexible_server_identity_show(client, resource_group_name, server_name, identity):
@@ -550,7 +555,7 @@ def flexible_server_ad_admin_set(cmd, client, resource_group_name, server_name, 
 
     replicas = replica_operations_client.list_by_server(resource_group_name, server_name)
     for replica in replicas:
-        if identity.lower() not in [key.lower() for key in replica.identity.user_assigned_identities.keys()]:
+        if not (replica.identity and replica.identity.user_assigned_identities and identity.lower() in [key.lower() for key in replica.identity.user_assigned_identities.keys()]):
             resolve_poller(
                 server_operations_client.begin_update(
                     resource_group_name=resource_group_name,
@@ -559,7 +564,7 @@ def flexible_server_ad_admin_set(cmd, client, resource_group_name, server_name, 
                 cmd.cli_ctx, 'Adding identity {} to replica {}'.format(identity, replica.name)
             )
 
-    if identity.lower() not in [key.lower() for key in instance.identity.user_assigned_identities.keys()]:
+    if not (instance.identity and instance.identity.user_assigned_identities and identity.lower() in [key.lower() for key in instance.identity.user_assigned_identities.keys()]):
         resolve_poller(
             server_operations_client.begin_update(
                 resource_group_name=resource_group_name,
@@ -616,13 +621,15 @@ def flexible_server_ad_admin_delete(cmd, client, resource_group_name, server_nam
 
     replicas = replica_operations_client.list_by_server(resource_group_name, server_name)
     for replica in replicas:
-        resolve_poller(
-            config_operations_client.begin_update(resource_group_name, replica.name, configuration_name, parameters),
-            cmd.cli_ctx, 'Disabling aad_auth_only in replica {}'.format(replica.name))
+        if config_operations_client.get(resource_group_name, replica.name, configuration_name).value == "ON":
+            resolve_poller(
+                config_operations_client.begin_update(resource_group_name, replica.name, configuration_name, parameters),
+                cmd.cli_ctx, 'Disabling aad_auth_only in replica {}'.format(replica.name))
 
-    resolve_poller(
-        config_operations_client.begin_update(resource_group_name, server_name, configuration_name, parameters),
-        cmd.cli_ctx, 'Disabling aad_auth_only in server {}'.format(server_name))
+    if config_operations_client.get(resource_group_name, server_name, configuration_name).value == "ON":
+        resolve_poller(
+            config_operations_client.begin_update(resource_group_name, server_name, configuration_name, parameters),
+            cmd.cli_ctx, 'Disabling aad_auth_only in server {}'.format(server_name))
 
 
 def flexible_server_ad_admin_list(client, resource_group_name, server_name):

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/recordings/test_mysql_flexible_server_identity_aad_admin_mgmt.yaml
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/recordings/test_mysql_flexible_server_identity_aad_admin_mgmt.yaml
@@ -25,7 +25,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 26 Sep 2022 03:14:51 GMT
+      - Wed, 28 Sep 2022 08:51:35 GMT
       expires:
       - '-1'
       pragma:
@@ -56,7 +56,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-28T08:51:32Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -65,7 +65,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:14:50 GMT
+      - Wed, 28 Sep 2022 08:51:35 GMT
       expires:
       - '-1'
       pragma:
@@ -111,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:14:52 GMT
+      - Wed, 28 Sep 2022 08:51:38 GMT
       expires:
       - '-1'
       pragma:
@@ -159,7 +159,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:14:54 GMT
+      - Wed, 28 Sep 2022 08:51:40 GMT
       expires:
       - '-1'
       pragma:
@@ -205,7 +205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:14:56 GMT
+      - Wed, 28 Sep 2022 08:51:40 GMT
       expires:
       - '-1'
       pragma:
@@ -225,8 +225,8 @@ interactions:
       message: OK
 - request:
     body: '{"location": "northeurope", "sku": {"name": "Standard_D2ds_v4", "tier":
-      "GeneralPurpose"}, "properties": {"administratorLogin": "amusedrice1", "administratorLoginPassword":
-      "a5CcnpdqddCJhoN5kVdc9A", "version": "5.7", "createMode": "Create", "storage":
+      "GeneralPurpose"}, "properties": {"administratorLogin": "selfishpepper0", "administratorLoginPassword":
+      "5jqdyaEvMhfuiQLR0PXqEw", "version": "5.7", "createMode": "Create", "storage":
       {"storageSizeGB": 32, "iops": 396, "autoGrow": "Enabled"}, "backup": {"backupRetentionDays":
       7, "geoRedundantBackup": "Disabled"}, "highAvailability": {"mode": "Disabled"},
       "network": {}}}'
@@ -240,7 +240,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '440'
+      - '443'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -251,10 +251,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:15:01.333Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T08:51:45.563Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -262,11 +262,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:15:01 GMT
+      - Wed, 28 Sep 2022 08:51:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -296,10 +296,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
+      string: '{"name":"a72ff600-2cfc-4008-894d-e2c97d66f269","status":"InProgress","startTime":"2022-09-28T08:51:45.563Z"}'
     headers:
       cache-control:
       - no-cache
@@ -308,7 +308,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:16:01 GMT
+      - Wed, 28 Sep 2022 08:52:45 GMT
       expires:
       - '-1'
       pragma:
@@ -342,10 +342,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
+      string: '{"name":"a72ff600-2cfc-4008-894d-e2c97d66f269","status":"InProgress","startTime":"2022-09-28T08:51:45.563Z"}'
     headers:
       cache-control:
       - no-cache
@@ -354,7 +354,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:17:02 GMT
+      - Wed, 28 Sep 2022 08:53:46 GMT
       expires:
       - '-1'
       pragma:
@@ -388,10 +388,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"InProgress","startTime":"2022-09-26T03:15:01.333Z"}'
+      string: '{"name":"a72ff600-2cfc-4008-894d-e2c97d66f269","status":"InProgress","startTime":"2022-09-28T08:51:45.563Z"}'
     headers:
       cache-control:
       - no-cache
@@ -400,7 +400,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:18:02 GMT
+      - Wed, 28 Sep 2022 08:54:47 GMT
       expires:
       - '-1'
       pragma:
@@ -434,10 +434,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a72ff600-2cfc-4008-894d-e2c97d66f269?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"ab60f3b4-85e3-4b31-bcd2-38b66ae60c7a","status":"Succeeded","startTime":"2022-09-26T03:15:01.333Z"}'
+      string: '{"name":"a72ff600-2cfc-4008-894d-e2c97d66f269","status":"Succeeded","startTime":"2022-09-28T08:51:45.563Z"}'
     headers:
       cache-control:
       - no-cache
@@ -446,7 +446,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:03 GMT
+      - Wed, 28 Sep 2022 08:55:48 GMT
       expires:
       - '-1'
       pragma:
@@ -483,17 +483,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1074'
+      - '1077'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:04 GMT
+      - Wed, 28 Sep 2022 08:55:48 GMT
       expires:
       - '-1'
       pragma:
@@ -534,10 +534,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/databases/flexibleserverdb?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2022-09-26T03:19:07.207Z"}'
+      string: '{"operation":"UpsertServerDatabaseManagementOperation","startTime":"2022-09-28T08:55:50.963Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6d84e0f8-c466-46c1-b1a1-989730efb364?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -545,11 +545,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:06 GMT
+      - Wed, 28 Sep 2022 08:55:50 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/6d84e0f8-c466-46c1-b1a1-989730efb364?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -579,10 +579,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8a84fb95-3140-476b-90a3-ed51a7bb4275?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6d84e0f8-c466-46c1-b1a1-989730efb364?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"8a84fb95-3140-476b-90a3-ed51a7bb4275","status":"Succeeded","startTime":"2022-09-26T03:19:07.207Z"}'
+      string: '{"name":"6d84e0f8-c466-46c1-b1a1-989730efb364","status":"Succeeded","startTime":"2022-09-28T08:55:50.963Z"}'
     headers:
       cache-control:
       - no-cache
@@ -591,7 +591,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:22 GMT
+      - Wed, 28 Sep 2022 08:56:05 GMT
       expires:
       - '-1'
       pragma:
@@ -637,7 +637,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:22 GMT
+      - Wed, 28 Sep 2022 08:56:06 GMT
       expires:
       - '-1'
       pragma:
@@ -674,7 +674,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-28T08:51:32Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -683,7 +683,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:22 GMT
+      - Wed, 28 Sep 2022 08:56:06 GMT
       expires:
       - '-1'
       pragma:
@@ -720,7 +720,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005?api-version=2022-01-31-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005","name":"identity000005","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","clientId":"b5204580-6888-44c5-a786-35e64b7dd76b"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005","name":"identity000005","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","clientId":"e9f18897-f20c-47c5-9758-e75ed76ba500"}}'
     headers:
       cache-control:
       - no-cache
@@ -729,7 +729,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:27 GMT
+      - Wed, 28 Sep 2022 08:56:11 GMT
       expires:
       - '-1'
       location:
@@ -741,7 +741,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 201
       message: Created
@@ -764,7 +764,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-28T08:51:32Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -773,7 +773,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:27 GMT
+      - Wed, 28 Sep 2022 08:56:10 GMT
       expires:
       - '-1'
       pragma:
@@ -810,7 +810,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006?api-version=2022-01-31-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006","name":"identity000006","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","clientId":"45867bf2-27e6-4dcf-9266-43f9b567cce1"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006","name":"identity000006","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","clientId":"3044979e-d43d-4e99-a0e8-c2413991f52e"}}'
     headers:
       cache-control:
       - no-cache
@@ -819,7 +819,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:33 GMT
+      - Wed, 28 Sep 2022 08:56:15 GMT
       expires:
       - '-1'
       location:
@@ -854,7 +854,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-26T03:14:48Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"northeurope","tags":{"product":"azurecli","cause":"automation","date":"2022-09-28T08:51:32Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -863,7 +863,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:33 GMT
+      - Wed, 28 Sep 2022 08:56:15 GMT
       expires:
       - '-1'
       pragma:
@@ -900,7 +900,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007?api-version=2022-01-31-preview
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007","name":"identity000007","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"73742897-6cb3-4ae2-9415-e5d140213385","clientId":"bc28f46f-3d7f-4872-a5f6-b56a2109e032"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007","name":"identity000007","type":"Microsoft.ManagedIdentity/userAssignedIdentities","location":"northeurope","tags":{},"properties":{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","clientId":"35af1d69-023d-460d-b674-ac74ba004bd0"}}'
     headers:
       cache-control:
       - no-cache
@@ -909,7 +909,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:39 GMT
+      - Wed, 28 Sep 2022 08:56:19 GMT
       expires:
       - '-1'
       location:
@@ -944,17 +944,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1074'
+      - '1077'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:40 GMT
+      - Wed, 28 Sep 2022 08:56:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1000,7 +1000,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:42 GMT
+      - Wed, 28 Sep 2022 08:56:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1042,22 +1042,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:19:43.85Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T08:56:23.723Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1ab2fbc6-58bd-4ccc-adb6-60e56699d133?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '88'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:19:43 GMT
+      - Wed, 28 Sep 2022 08:56:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/1ab2fbc6-58bd-4ccc-adb6-60e56699d133?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1087,19 +1087,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/dc5e1b21-75f4-44f6-b881-0775cb0fb602?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1ab2fbc6-58bd-4ccc-adb6-60e56699d133?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"dc5e1b21-75f4-44f6-b881-0775cb0fb602","status":"Succeeded","startTime":"2022-09-26T03:19:43.85Z"}'
+      string: '{"name":"1ab2fbc6-58bd-4ccc-adb6-60e56699d133","status":"Succeeded","startTime":"2022-09-28T08:56:23.723Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:20:44 GMT
+      - Wed, 28 Sep 2022 08:57:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1136,17 +1136,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1504'
+      - '1507'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:20:45 GMT
+      - Wed, 28 Sep 2022 08:57:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1183,17 +1183,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"None","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1504'
+      - '1507'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:20:46 GMT
+      - Wed, 28 Sep 2022 08:57:25 GMT
       expires:
       - '-1'
       pragma:
@@ -1239,7 +1239,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:20:48 GMT
+      - Wed, 28 Sep 2022 08:57:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1261,7 +1261,7 @@ interactions:
     body: '{"location": "North Europe", "identity": {"type": "UserAssigned", "userAssignedIdentities":
       {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
       {}}}, "sku": {"name": "Standard_D2ds_v4", "tier": "GeneralPurpose"}, "properties":
-      {"availabilityZone": "1", "createMode": "Replica", "sourceServerResourceId":
+      {"availabilityZone": "3", "createMode": "Replica", "sourceServerResourceId":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002"}}'
     headers:
       Accept:
@@ -1284,10 +1284,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1295,11 +1295,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:20:51 GMT
+      - Wed, 28 Sep 2022 08:57:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1329,10 +1329,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1341,7 +1341,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:21:53 GMT
+      - Wed, 28 Sep 2022 08:58:31 GMT
       expires:
       - '-1'
       pragma:
@@ -1375,10 +1375,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1387,7 +1387,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:22:53 GMT
+      - Wed, 28 Sep 2022 08:59:32 GMT
       expires:
       - '-1'
       pragma:
@@ -1421,10 +1421,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1433,7 +1433,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:23:54 GMT
+      - Wed, 28 Sep 2022 09:00:33 GMT
       expires:
       - '-1'
       pragma:
@@ -1467,10 +1467,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1479,7 +1479,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:24:56 GMT
+      - Wed, 28 Sep 2022 09:01:34 GMT
       expires:
       - '-1'
       pragma:
@@ -1513,10 +1513,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"InProgress","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1525,7 +1525,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:25:56 GMT
+      - Wed, 28 Sep 2022 09:02:35 GMT
       expires:
       - '-1'
       pragma:
@@ -1559,10 +1559,56 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/52655ee1-693e-4fff-9f90-a931d4b8af24?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"52655ee1-693e-4fff-9f90-a931d4b8af24","status":"Succeeded","startTime":"2022-09-26T03:20:52.383Z"}'
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"InProgress","startTime":"2022-09-28T08:57:31.263Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:03:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server replica create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --replica-name --source-server
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f2a5557f-a26d-4d86-9d28-ed076a451b2b?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"f2a5557f-a26d-4d86-9d28-ed076a451b2b","status":"Succeeded","startTime":"2022-09-28T08:57:31.263Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1571,7 +1617,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:26:56 GMT
+      - Wed, 28 Sep 2022 09:04:36 GMT
       expires:
       - '-1'
       pragma:
@@ -1608,17 +1654,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1689'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:26:56 GMT
+      - Wed, 28 Sep 2022 09:04:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1664,7 +1710,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:00 GMT
+      - Wed, 28 Sep 2022 09:04:40 GMT
       expires:
       - '-1'
       pragma:
@@ -1701,17 +1747,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1689'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:01 GMT
+      - Wed, 28 Sep 2022 09:04:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1748,17 +1794,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1689'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:04 GMT
+      - Wed, 28 Sep 2022 09:04:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1795,17 +1841,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1506'
+      - '1509'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:05 GMT
+      - Wed, 28 Sep 2022 09:04:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1842,17 +1888,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1579'
+      - '1582'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:06 GMT
+      - Wed, 28 Sep 2022 09:04:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1894,10 +1940,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:27:09.057Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:04:52.513Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/aab8f7a0-c46c-49bf-b68d-087b52d89c91?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -1905,11 +1951,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:27:08 GMT
+      - Wed, 28 Sep 2022 09:04:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/aab8f7a0-c46c-49bf-b68d-087b52d89c91?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -1939,10 +1985,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e858763b-81e7-4b7d-8951-0790ac392e05?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/aab8f7a0-c46c-49bf-b68d-087b52d89c91?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e858763b-81e7-4b7d-8951-0790ac392e05","status":"Succeeded","startTime":"2022-09-26T03:27:09.057Z"}'
+      string: '{"name":"aab8f7a0-c46c-49bf-b68d-087b52d89c91","status":"Succeeded","startTime":"2022-09-28T09:04:52.513Z"}'
     headers:
       cache-control:
       - no-cache
@@ -1951,7 +1997,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:28:09 GMT
+      - Wed, 28 Sep 2022 09:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1988,17 +2034,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1951'
+      - '1954'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:28:09 GMT
+      - Wed, 28 Sep 2022 09:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2040,22 +2086,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T03:28:11.54Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:05:55.697Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a4221e6a-2528-4f06-9161-fe0805e42888?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '88'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:28:10 GMT
+      - Wed, 28 Sep 2022 09:05:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/a4221e6a-2528-4f06-9161-fe0805e42888?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2085,19 +2131,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/87739bae-ed4d-4ed2-8f40-58fdddba80ec?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/a4221e6a-2528-4f06-9161-fe0805e42888?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"87739bae-ed4d-4ed2-8f40-58fdddba80ec","status":"Succeeded","startTime":"2022-09-26T03:28:11.54Z"}'
+      string: '{"name":"a4221e6a-2528-4f06-9161-fe0805e42888","status":"Succeeded","startTime":"2022-09-28T09:05:55.697Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:29:11 GMT
+      - Wed, 28 Sep 2022 09:06:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2134,17 +2180,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:29:11 GMT
+      - Wed, 28 Sep 2022 09:06:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2187,22 +2233,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-26T03:29:15.063Z"}'
+      string: '{"operation":"UpsertActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-28T09:06:59.17Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b29cc6e8-8bdf-4359-9d78-16fe583512ee?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '108'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:29:15 GMT
+      - Wed, 28 Sep 2022 09:06:59 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/b29cc6e8-8bdf-4359-9d78-16fe583512ee?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2232,19 +2278,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/20846a7a-6017-4eea-aee3-cc20db5c0a9b?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b29cc6e8-8bdf-4359-9d78-16fe583512ee?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"20846a7a-6017-4eea-aee3-cc20db5c0a9b","status":"Succeeded","startTime":"2022-09-26T03:29:15.063Z"}'
+      string: '{"name":"b29cc6e8-8bdf-4359-9d78-16fe583512ee","status":"Succeeded","startTime":"2022-09-28T09:06:59.17Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:15 GMT
+      - Wed, 28 Sep 2022 09:07:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2290,7 +2336,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:15 GMT
+      - Wed, 28 Sep 2022 09:07:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2336,7 +2382,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:18 GMT
+      - Wed, 28 Sep 2022 09:08:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2373,17 +2419,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:20 GMT
+      - Wed, 28 Sep 2022 09:08:03 GMT
       expires:
       - '-1'
       pragma:
@@ -2429,7 +2475,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:22 GMT
+      - Wed, 28 Sep 2022 09:08:05 GMT
       expires:
       - '-1'
       pragma:
@@ -2466,17 +2512,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1951'
+      - '1954'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:23 GMT
+      - Wed, 28 Sep 2022 09:08:07 GMT
       expires:
       - '-1'
       pragma:
@@ -2513,17 +2559,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:23 GMT
+      - Wed, 28 Sep 2022 09:08:08 GMT
       expires:
       - '-1'
       pragma:
@@ -2569,7 +2615,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:25 GMT
+      - Wed, 28 Sep 2022 09:08:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2592,7 +2638,7 @@ interactions:
       {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
       {}, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
       {}}}, "sku": {"name": "Standard_D2ds_v4", "tier": "GeneralPurpose"}, "properties":
-      {"availabilityZone": "1", "createMode": "Replica", "sourceServerResourceId":
+      {"availabilityZone": "3", "createMode": "Replica", "sourceServerResourceId":
       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002"}}'
     headers:
       Accept:
@@ -2615,10 +2661,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"operation":"CreateReadReplicaManagementOperation","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -2626,11 +2672,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:30:28 GMT
+      - Wed, 28 Sep 2022 09:08:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -2660,10 +2706,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2672,7 +2718,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:31:29 GMT
+      - Wed, 28 Sep 2022 09:09:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2706,10 +2752,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2718,7 +2764,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:32:29 GMT
+      - Wed, 28 Sep 2022 09:10:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2752,10 +2798,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2764,7 +2810,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:33:31 GMT
+      - Wed, 28 Sep 2022 09:11:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2798,10 +2844,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2810,7 +2856,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:34:30 GMT
+      - Wed, 28 Sep 2022 09:12:16 GMT
       expires:
       - '-1'
       pragma:
@@ -2844,10 +2890,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2856,7 +2902,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:35:31 GMT
+      - Wed, 28 Sep 2022 09:13:17 GMT
       expires:
       - '-1'
       pragma:
@@ -2890,10 +2936,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"InProgress","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2902,7 +2948,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:36:32 GMT
+      - Wed, 28 Sep 2022 09:14:18 GMT
       expires:
       - '-1'
       pragma:
@@ -2936,10 +2982,102 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e217a32c-3ce4-40c1-a7e8-250b8690b087?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"e217a32c-3ce4-40c1-a7e8-250b8690b087","status":"Succeeded","startTime":"2022-09-26T03:30:29.06Z"}'
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:15:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server replica create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --replica-name --source-server
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"InProgress","startTime":"2022-09-28T09:08:14.21Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:16:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server replica create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --replica-name --source-server
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/1143ca4a-5748-4515-83a6-dbbfb4c69788?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"1143ca4a-5748-4515-83a6-dbbfb4c69788","status":"Succeeded","startTime":"2022-09-28T09:08:14.21Z"}'
     headers:
       cache-control:
       - no-cache
@@ -2948,7 +3086,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:32 GMT
+      - Wed, 28 Sep 2022 09:17:20 GMT
       expires:
       - '-1'
       pragma:
@@ -2985,17 +3123,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1951'
+      - '1954'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:33 GMT
+      - Wed, 28 Sep 2022 09:17:20 GMT
       expires:
       - '-1'
       pragma:
@@ -3041,7 +3179,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:36 GMT
+      - Wed, 28 Sep 2022 09:17:23 GMT
       expires:
       - '-1'
       pragma:
@@ -3082,22 +3220,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T03:37:39.05Z"}'
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-28T09:17:25.033Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8d5fe3a6-3563-4382-84b6-038cc7bd6741?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '94'
+      - '95'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:38 GMT
+      - Wed, 28 Sep 2022 09:17:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/8d5fe3a6-3563-4382-84b6-038cc7bd6741?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3127,19 +3265,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/93dc33a4-88a4-4490-8b94-81d0e888e76a?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/8d5fe3a6-3563-4382-84b6-038cc7bd6741?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"93dc33a4-88a4-4490-8b94-81d0e888e76a","status":"Succeeded","startTime":"2022-09-26T03:37:39.05Z"}'
+      string: '{"name":"8d5fe3a6-3563-4382-84b6-038cc7bd6741","status":"Succeeded","startTime":"2022-09-28T09:17:25.033Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:53 GMT
+      - Wed, 28 Sep 2022 09:17:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3176,17 +3314,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '569'
+      - '696'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:54 GMT
+      - Wed, 28 Sep 2022 09:17:40 GMT
       expires:
       - '-1'
       pragma:
@@ -3227,10 +3367,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T03:37:57.533Z"}'
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-28T09:17:42.567Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/84ea0ee1-2faa-4b3e-a95e-c0381b506d73?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -3238,11 +3378,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:37:57 GMT
+      - Wed, 28 Sep 2022 09:17:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/84ea0ee1-2faa-4b3e-a95e-c0381b506d73?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3252,7 +3392,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -3272,10 +3412,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/f8f6225e-c69d-4ed7-83c8-9cf638146fe5?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/84ea0ee1-2faa-4b3e-a95e-c0381b506d73?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"f8f6225e-c69d-4ed7-83c8-9cf638146fe5","status":"Succeeded","startTime":"2022-09-26T03:37:57.533Z"}'
+      string: '{"name":"84ea0ee1-2faa-4b3e-a95e-c0381b506d73","status":"Succeeded","startTime":"2022-09-28T09:17:42.567Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3284,7 +3424,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:12 GMT
+      - Wed, 28 Sep 2022 09:17:57 GMT
       expires:
       - '-1'
       pragma:
@@ -3321,17 +3461,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '569'
+      - '696'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:13 GMT
+      - Wed, 28 Sep 2022 09:17:58 GMT
       expires:
       - '-1'
       pragma:
@@ -3368,17 +3510,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:14 GMT
+      - Wed, 28 Sep 2022 09:18:00 GMT
       expires:
       - '-1'
       pragma:
@@ -3415,17 +3557,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:14 GMT
+      - Wed, 28 Sep 2022 09:18:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3471,7 +3613,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:15 GMT
+      - Wed, 28 Sep 2022 09:18:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3508,17 +3650,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1951'
+      - '1954'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 03:38:17 GMT
+      - Wed, 28 Sep 2022 09:18:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3555,17 +3697,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:08:34 GMT
+      - Wed, 28 Sep 2022 09:18:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3604,10 +3746,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/administrators/ActiveDirectory?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"DropActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-26T04:08:37.19Z"}'
+      string: '{"operation":"DropActiveDirectoryAdministratorManagementOperation","startTime":"2022-09-28T09:18:07.55Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/37a6913e-3ba9-44c3-b913-dd348b900a62?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -3615,11 +3757,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:08:37 GMT
+      - Wed, 28 Sep 2022 09:18:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/37a6913e-3ba9-44c3-b913-dd348b900a62?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3649,10 +3791,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/37a6913e-3ba9-44c3-b913-dd348b900a62?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"054fe86e-6220-4f7f-9a11-14227fce3228","status":"Succeeded","startTime":"2022-09-26T04:08:37.19Z"}'
+      string: '{"name":"37a6913e-3ba9-44c3-b913-dd348b900a62","status":"Succeeded","startTime":"2022-09-28T09:18:07.55Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3661,7 +3803,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:09:37 GMT
+      - Wed, 28 Sep 2022 09:19:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3695,7 +3837,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/054fe86e-6220-4f7f-9a11-14227fce3228?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/37a6913e-3ba9-44c3-b913-dd348b900a62?api-version=2021-12-01-preview
   response:
     body:
       string: ''
@@ -3705,7 +3847,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Mon, 26 Sep 2022 04:09:37 GMT
+      - Wed, 28 Sep 2022 09:19:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3738,18 +3880,116 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3677'
+      - '3683'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:09:40 GMT
+      - Wed, 28 Sep 2022 09:19:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"system-default","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '698'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '696'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:11 GMT
       expires:
       - '-1'
       pragma:
@@ -3790,10 +4030,206 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:09:41.917Z"}'
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-28T09:19:12.6Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/5b6bb1b7-7b09-41d6-9088-4fdf004d5d6c?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '93'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:12 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/5b6bb1b7-7b09-41d6-9088-4fdf004d5d6c?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/5b6bb1b7-7b09-41d6-9088-4fdf004d5d6c?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"5b6bb1b7-7b09-41d6-9088-4fdf004d5d6c","status":"Succeeded","startTime":"2022-09-28T09:19:12.6Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '105'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '697'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"properties":{"value":"ON","currentValue":"ON","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '696'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:19:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server ad-admin delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '59'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-28T09:19:29.913Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/11d8a993-58b3-44eb-8e91-72eda256f928?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -3801,11 +4237,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:09:41 GMT
+      - Wed, 28 Sep 2022 09:19:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/11d8a993-58b3-44eb-8e91-72eda256f928?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -3835,10 +4271,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/08524351-7013-43f8-b9ed-a4a821450456?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/11d8a993-58b3-44eb-8e91-72eda256f928?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"08524351-7013-43f8-b9ed-a4a821450456","status":"Succeeded","startTime":"2022-09-26T04:09:41.917Z"}'
+      string: '{"name":"11d8a993-58b3-44eb-8e91-72eda256f928","status":"Succeeded","startTime":"2022-09-28T09:19:29.913Z"}'
     headers:
       cache-control:
       - no-cache
@@ -3847,297 +4283,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:09:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '571'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:09:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '59'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:09:58.607Z"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '95'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:09:58 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/6ca07923-b5db-42ce-9f2b-22b40ca313ee?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"name":"6ca07923-b5db-42ce-9f2b-22b40ca313ee","status":"Succeeded","startTime":"2022-09-26T04:09:58.607Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '107'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:10:13 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '571'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:10:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"properties": {"value": "OFF", "source": "user-override"}}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '59'
-      Content-Type:
-      - application/json
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"operation":"UpdateServerParameterManagementOperation","startTime":"2022-09-26T04:10:15.37Z"}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '94'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:10:15 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - mysql flexible-server ad-admin delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -s --yes
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/557a4cfd-340d-42e3-a48e-38ee48ccf667?api-version=2021-12-01-preview
-  response:
-    body:
-      string: '{"name":"557a4cfd-340d-42e3-a48e-38ee48ccf667","status":"Succeeded","startTime":"2022-09-26T04:10:15.37Z"}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '106'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 26 Sep 2022 04:10:30 GMT
+      - Wed, 28 Sep 2022 09:19:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4174,17 +4320,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '571'
+      - '697'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:10:30 GMT
+      - Wed, 28 Sep 2022 09:19:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4230,7 +4378,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:10:42 GMT
+      - Wed, 28 Sep 2022 09:19:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4276,7 +4424,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:10:43 GMT
+      - Wed, 28 Sep 2022 09:19:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4322,7 +4470,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:10:45 GMT
+      - Wed, 28 Sep 2022 09:19:49 GMT
       expires:
       - '-1'
       pragma:
@@ -4359,17 +4507,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '571'
+      - '697'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:02 GMT
+      - Wed, 28 Sep 2022 09:19:50 GMT
       expires:
       - '-1'
       pragma:
@@ -4406,17 +4556,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"system-default","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '571'
+      - '698'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:07 GMT
+      - Wed, 28 Sep 2022 09:19:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4453,17 +4605,19 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Tell
-        the server to only allow connection with aad auth.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"False"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
+      string: '{"properties":{"value":"OFF","currentValue":"OFF","description":"Setting
+        this to ON sets the authentication to Azure AD authentication only and disable
+        MySQL Authentication. Configure this parameter only when Azure AD authentication
+        is configured.","defaultValue":"OFF","dataType":"Enumeration","allowedValues":"ON,OFF","source":"user-override","isConfigPendingRestart":"False","isDynamicConfig":"True","isReadOnly":"True"},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004/configurations/aad_auth_only","name":"aad_auth_only","type":"Microsoft.DBforMySQL/flexibleServers/configurations"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '571'
+      - '697'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:09 GMT
+      - Wed, 28 Sep 2022 09:19:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4500,17 +4654,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1771'
+      - '1774'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:18 GMT
+      - Wed, 28 Sep 2022 09:19:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4547,18 +4701,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '3677'
+      - '3683'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:20 GMT
+      - Wed, 28 Sep 2022 09:19:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4597,13 +4751,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:11:22.573Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:19:57.153Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/652e0f36-7da0-42dc-94e0-2b507abbf90c?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -4611,11 +4765,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:11:22 GMT
+      - Wed, 28 Sep 2022 09:19:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/652e0f36-7da0-42dc-94e0-2b507abbf90c?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -4645,10 +4799,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3f6e12d3-8ed5-419d-a567-931032b67ad5?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/652e0f36-7da0-42dc-94e0-2b507abbf90c?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"3f6e12d3-8ed5-419d-a567-931032b67ad5","status":"Succeeded","startTime":"2022-09-26T04:11:22.573Z"}'
+      string: '{"name":"652e0f36-7da0-42dc-94e0-2b507abbf90c","status":"Succeeded","startTime":"2022-09-28T09:19:57.153Z"}'
     headers:
       cache-control:
       - no-cache
@@ -4657,7 +4811,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:12:22 GMT
+      - Wed, 28 Sep 2022 09:20:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4691,20 +4845,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2216'
+      - '2219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:12:23 GMT
+      - Wed, 28 Sep 2022 09:20:57 GMT
       expires:
       - '-1'
       pragma:
@@ -4743,13 +4897,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:12:25.823Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:21:00.393Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3eee8770-1c34-4b5e-b4c3-21b2f407b6aa?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -4757,11 +4911,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:12:25 GMT
+      - Wed, 28 Sep 2022 09:20:59 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/3eee8770-1c34-4b5e-b4c3-21b2f407b6aa?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -4791,10 +4945,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/05eec2de-8aaf-47dc-9b58-7d6e35123e5e?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/3eee8770-1c34-4b5e-b4c3-21b2f407b6aa?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"05eec2de-8aaf-47dc-9b58-7d6e35123e5e","status":"Succeeded","startTime":"2022-09-26T04:12:25.823Z"}'
+      string: '{"name":"3eee8770-1c34-4b5e-b4c3-21b2f407b6aa","status":"Succeeded","startTime":"2022-09-28T09:21:00.393Z"}'
     headers:
       cache-control:
       - no-cache
@@ -4803,7 +4957,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:13:26 GMT
+      - Wed, 28 Sep 2022 09:22:00 GMT
       expires:
       - '-1'
       pragma:
@@ -4837,20 +4991,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2216'
+      - '2219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:13:27 GMT
+      - Wed, 28 Sep 2022 09:22:01 GMT
       expires:
       - '-1'
       pragma:
@@ -4892,10 +5046,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:13:29.123Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:22:03.417Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4e2b5dfb-91a2-4aee-bd42-8501a108d938?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -4903,11 +5057,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:13:29 GMT
+      - Wed, 28 Sep 2022 09:22:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/4e2b5dfb-91a2-4aee-bd42-8501a108d938?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -4937,10 +5091,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4e2b5dfb-91a2-4aee-bd42-8501a108d938?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"9a1b8d4f-4ce4-4f80-98fc-cb81c0d5ec93","status":"Succeeded","startTime":"2022-09-26T04:13:29.123Z"}'
+      string: '{"name":"4e2b5dfb-91a2-4aee-bd42-8501a108d938","status":"Succeeded","startTime":"2022-09-28T09:22:03.417Z"}'
     headers:
       cache-control:
       - no-cache
@@ -4949,7 +5103,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:29 GMT
+      - Wed, 28 Sep 2022 09:23:03 GMT
       expires:
       - '-1'
       pragma:
@@ -4986,17 +5140,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2036'
+      - '2039'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:30 GMT
+      - Wed, 28 Sep 2022 09:23:03 GMT
       expires:
       - '-1'
       pragma:
@@ -5030,20 +5184,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2216'
+      - '2039'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:31 GMT
+      - Wed, 28 Sep 2022 09:23:05 GMT
       expires:
       - '-1'
       pragma:
@@ -5080,17 +5234,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2216'
+      - '2219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:32 GMT
+      - Wed, 28 Sep 2022 09:23:06 GMT
       expires:
       - '-1'
       pragma:
@@ -5127,17 +5281,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2216'
+      - '2219'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:35 GMT
+      - Wed, 28 Sep 2022 09:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -5174,17 +5328,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2036'
+      - '2039'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:37 GMT
+      - Wed, 28 Sep 2022 09:23:07 GMT
       expires:
       - '-1'
       pragma:
@@ -5221,17 +5375,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2036'
+      - '2039'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:37 GMT
+      - Wed, 28 Sep 2022 09:23:08 GMT
       expires:
       - '-1'
       pragma:
@@ -5277,7 +5431,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:38 GMT
+      - Wed, 28 Sep 2022 09:23:09 GMT
       expires:
       - '-1'
       pragma:
@@ -5314,18 +5468,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"f484cc31-0e25-45ba-8312-0b5a27419781","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"82ad0c70-ae4f-447f-ae3e-626c216d7237","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4207'
+      - '4213'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:41 GMT
+      - Wed, 28 Sep 2022 09:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -5346,7 +5500,6 @@ interactions:
 - request:
     body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
       null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
-      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":
       null}}}'
     headers:
       Accept:
@@ -5358,7 +5511,154 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '567'
+      - '400'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:23:13.693Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/14c750df-7da0-4279-9866-5b7b69a2e304?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '88'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:23:13 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/14c750df-7da0-4279-9866-5b7b69a2e304?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/14c750df-7da0-4279-9866-5b7b69a2e304?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"14c750df-7da0-4279-9866-5b7b69a2e304","status":"Succeeded","startTime":"2022-09-28T09:23:13.693Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:24:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1689'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:24:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
+      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
+      null}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '400'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -5369,39 +5669,233 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"error":{"code":"FailedIdentityOperation","message":"Identity operation
-        for resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004''
-        failed with error ''Failed to perform resource identity operation. Status:
-        ''BadRequest''. Response: ''{\"error\":{\"code\":\"BadRequest\",\"message\":\"Removal
-        of all user-assigned identities assigned to resource ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004''
-        with type ''UserAssigned'' is invalid.\"}}''.''."}}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:24:16.23Z"}'
     headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9530340e-3a10-4816-a3f9-3cb5dd6d93be?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '653'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:43 GMT
+      - Wed, 28 Sep 2022 09:24:15 GMT
       expires:
       - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/9530340e-3a10-4816-a3f9-3cb5dd6d93be?api-version=2021-12-01-preview
       pragma:
       - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-failure-cause:
-      - gateway
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
     status:
-      code: 400
-      message: Bad Request
+      code: 202
+      message: Accepted
 - request:
     body: null
     headers:
       Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/9530340e-3a10-4816-a3f9-3cb5dd6d93be?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"9530340e-3a10-4816-a3f9-3cb5dd6d93be","status":"Succeeded","startTime":"2022-09-28T09:24:16.23Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:25:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1689'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:25:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
+      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
+      null}}}'
+    headers:
+      Accept:
       - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '400'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:25:19.29Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/59576ab4-3b82-40eb-a2a3-1d30ad89d942?api-version=2021-12-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '87'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:25:19 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/59576ab4-3b82-40eb-a2a3-1d30ad89d942?api-version=2021-12-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1197'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/59576ab4-3b82-40eb-a2a3-1d30ad89d942?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"name":"59576ab4-3b82-40eb-a2a3-1d30ad89d942","status":"Succeeded","startTime":"2022-09-28T09:25:19.29Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '106'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:26:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       CommandName:
@@ -5416,17 +5910,158 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2036'
+      - '1509'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:44 GMT
+      - Wed, 28 Sep 2022 09:26:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:26:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1689'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:26:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1689'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:26:22 GMT
       expires:
       - '-1'
       pragma:
@@ -5463,17 +6098,64 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '2036'
+      - '1509'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:45 GMT
+      - Wed, 28 Sep 2022 09:26:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity remove
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s -n --yes
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1509'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:26:24 GMT
       expires:
       - '-1'
       pragma:
@@ -5519,7 +6201,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:45 GMT
+      - Wed, 28 Sep 2022 09:26:25 GMT
       expires:
       - '-1'
       pragma:
@@ -5556,18 +6238,18 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002/replicas?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":{"principalId":"71fe988b-451c-4edd-a553-f111bd27c3d6","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"},"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":{"principalId":"faeb97d4-95ea-4a7a-91c3-61cc5aa1fc19","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
+      string: '{"value":[{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"},{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"5c3573f4-bf2a-4a79-bbda-4a958a522a18","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '4207'
+      - '3153'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:48 GMT
+      - Wed, 28 Sep 2022 09:26:26 GMT
       expires:
       - '-1'
       pragma:
@@ -5586,9 +6268,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
-      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
-      null}}}'
+    body: '{"identity": {"type": "None"}}'
     headers:
       Accept:
       - application/json
@@ -5599,7 +6279,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '400'
+      - '30'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -5607,13 +6287,13 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:14:50.46Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:26:28.59Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b6e68874-08da-421d-b4d1-71cbc7b6303f?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -5621,11 +6301,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:14:50 GMT
+      - Wed, 28 Sep 2022 09:26:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/b6e68874-08da-421d-b4d1-71cbc7b6303f?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -5655,10 +6335,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/4c50edab-4a08-4397-9d6a-9d9c8784283b?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/b6e68874-08da-421d-b4d1-71cbc7b6303f?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"4c50edab-4a08-4397-9d6a-9d9c8784283b","status":"Succeeded","startTime":"2022-09-26T04:14:50.46Z"}'
+      string: '{"name":"b6e68874-08da-421d-b4d1-71cbc7b6303f","status":"Succeeded","startTime":"2022-09-28T09:26:28.59Z"}'
     headers:
       cache-control:
       - no-cache
@@ -5667,7 +6347,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:15:51 GMT
+      - Wed, 28 Sep 2022 09:27:28 GMT
       expires:
       - '-1'
       pragma:
@@ -5701,20 +6381,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1259'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:15:51 GMT
+      - Wed, 28 Sep 2022 09:27:29 GMT
       expires:
       - '-1'
       pragma:
@@ -5733,9 +6413,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
-      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
-      null}}}'
+    body: '{"identity": {"type": "None"}}'
     headers:
       Accept:
       - application/json
@@ -5746,7 +6424,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '400'
+      - '30'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -5754,25 +6432,25 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: PATCH
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:15:53.67Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:27:31.067Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/401587c6-0c10-4299-aa84-778f18aaa743?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '87'
+      - '88'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:15:53 GMT
+      - Wed, 28 Sep 2022 09:27:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/401587c6-0c10-4299-aa84-778f18aaa743?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -5802,19 +6480,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/401587c6-0c10-4299-aa84-778f18aaa743?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"c98c6ed6-bc36-43a2-bf4c-9eab4f3590eb","status":"Succeeded","startTime":"2022-09-26T04:15:53.67Z"}'
+      string: '{"name":"401587c6-0c10-4299-aa84-778f18aaa743","status":"Succeeded","startTime":"2022-09-28T09:27:31.067Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '106'
+      - '107'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:16:54 GMT
+      - Wed, 28 Sep 2022 09:28:31 GMT
       expires:
       - '-1'
       pragma:
@@ -5848,20 +6526,20 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
-        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1259'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:16:54 GMT
+      - Wed, 28 Sep 2022 09:28:31 GMT
       expires:
       - '-1'
       pragma:
@@ -5880,9 +6558,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"identity": {"type": "UserAssigned", "userAssignedIdentities": {"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000005":
-      null, "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000006":
-      null}}}'
+    body: '{"identity": {"type": "None"}}'
     headers:
       Accept:
       - application/json
@@ -5893,7 +6569,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '400'
+      - '30'
       Content-Type:
       - application/json
       ParameterSetName:
@@ -5904,22 +6580,22 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-26T04:16:57.053Z"}'
+      string: '{"operation":"UpsertServerManagementOperationV2","startTime":"2022-09-28T09:28:34.29Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e4f21e8f-6f88-4bcc-ad70-3c7c2e2ca8bc?api-version=2021-12-01-preview
       cache-control:
       - no-cache
       content-length:
-      - '88'
+      - '87'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:16:57 GMT
+      - Wed, 28 Sep 2022 09:28:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/operationResults/e4f21e8f-6f88-4bcc-ad70-3c7c2e2ca8bc?api-version=2021-12-01-preview
       pragma:
       - no-cache
       server:
@@ -5949,19 +6625,19 @@ interactions:
       User-Agent:
       - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/70c853df-256f-4486-995c-44e07e09eb56?api-version=2021-12-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DBforMySQL/locations/northeurope/azureAsyncOperation/e4f21e8f-6f88-4bcc-ad70-3c7c2e2ca8bc?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"name":"70c853df-256f-4486-995c-44e07e09eb56","status":"Succeeded","startTime":"2022-09-26T04:16:57.053Z"}'
+      string: '{"name":"e4f21e8f-6f88-4bcc-ad70-3c7c2e2ca8bc","status":"Succeeded","startTime":"2022-09-28T09:28:34.29Z"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '107'
+      - '106'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:17:57 GMT
+      - Wed, 28 Sep 2022 09:29:34 GMT
       expires:
       - '-1'
       pragma:
@@ -5998,17 +6674,64 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:15:02.8186454Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:18:07.6599637+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1506'
+      - '1079'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:17:57 GMT
+      - Wed, 28 Sep 2022 09:29:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - mysql flexible-server identity list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -s
+      User-Agent:
+      - AZURECLI/2.40.0 azsdk-python-mgmt-rdbms/10.2.0b4 Python/3.8.10 (Linux-5.10.102.1-microsoft-standard-WSL2-x86_64-with-glibc2.29)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002?api-version=2021-12-01-preview
+  response:
+    body:
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:51:47.6415622Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000002.mysql.database.azure.com","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Source","replicaCapacity":10,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T08:55:09.4377228+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+        Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","name":"azuredbclitest-000002","type":"Microsoft.DBforMySQL/flexibleServers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1079'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Wed, 28 Sep 2022 09:29:36 GMT
       expires:
       - '-1'
       pragma:
@@ -6045,17 +6768,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:21:00.1322536Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:24:29.4369219+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T08:57:40.0132598Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000003.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:01:55.3392901+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000003","name":"azuredbclitest-000003","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1259'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:18:07 GMT
+      - Wed, 28 Sep 2022 09:29:37 GMT
       expires:
       - '-1'
       pragma:
@@ -6092,17 +6815,17 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004?api-version=2021-12-01-preview
   response:
     body:
-      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"identity":{"userAssignedIdentities":{"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity000007":{"principalId":"73742897-6cb3-4ae2-9415-e5d140213385","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"}},"principalId":"00000000-0000-0000-0000-000000000000","type":"UserAssigned","tenantId":"00000000-0000-0000-0000-000000000000"},"systemData":{"createdAt":"2022-09-26T03:30:36.5122017Z"},"properties":{"administratorLogin":"amusedrice1","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"1","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-26T03:34:20.4059593+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
+      string: '{"sku":{"name":"Standard_D2ds_v4","tier":"GeneralPurpose"},"systemData":{"createdAt":"2022-09-28T09:08:22.5195673Z"},"properties":{"administratorLogin":"selfishpepper0","storage":{"storageSizeGB":32,"iops":396,"autoGrow":"Enabled","autoIoScaling":"Disabled","storageSku":"Premium_LRS"},"version":"5.7","state":"Ready","fullyQualifiedDomainName":"azuredbclitest-000004.mysql.database.azure.com","sourceServerResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000002","availabilityZone":"3","maintenanceWindow":{"customWindow":"Disabled","dayOfWeek":0,"startHour":0,"startMinute":0},"replicationRole":"Replica","replicaCapacity":0,"network":{"publicNetworkAccess":"Enabled"},"backup":{"backupRetentionDays":7,"geoRedundantBackup":"Disabled","earliestRestoreDate":"2022-09-28T09:14:10.8378534+00:00"},"highAvailability":{"mode":"Disabled","state":"NotEnabled","standbyAvailabilityZone":""}},"location":"North
         Europe","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.DBforMySQL/flexibleServers/azuredbclitest-000004","name":"azuredbclitest-000004","type":"Microsoft.DBforMySQL/flexibleServers"}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1686'
+      - '1259'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 26 Sep 2022 04:18:26 GMT
+      - Wed, 28 Sep 2022 09:29:38 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands.py
@@ -2182,7 +2182,7 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
             self.cmd('{} flexible-server identity assign -g {} -s {} -n {}'
                      .format(database_engine, resource_group, server, identity_id[2]))
 
-            for server_name in [server_name, replica[0], replica[1]]:
+            for server_name in [server, replica[0], replica[1]]:
                 self.cmd('{} flexible-server identity list -g {} -s {}'
                         .format(database_engine, resource_group, server_name),
                         checks=[
@@ -2190,19 +2190,26 @@ class FlexibleServerIdentityAADAdminMgmtScenarioTest(ScenarioTest):
                             JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[1])),
                             JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
 
-            # try to remove all identities from primary server
-            self.cmd('{} flexible-server identity remove -g {} -s {} -n {} {} {} --yes'
-                     .format(database_engine, resource_group, server, identity_id[0], identity_id[1], identity_id[2]),
-                     expect_failure=True)
-
             # remove identities 1 and 2 from primary server
             self.cmd('{} flexible-server identity remove -g {} -s {} -n {} {} --yes'
                      .format(database_engine, resource_group, server, identity_id[0], identity_id[1]))
 
-            for server_name in [replica[0], replica[1]]:
+            for server_name in [server, replica[0], replica[1]]:
                 self.cmd('{} flexible-server identity list -g {} -s {}'
                         .format(database_engine, resource_group, server_name),
                         checks=[
                             JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
                             JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
                             JMESPathCheckExists('userAssignedIdentities."{}"'.format(identity_id[2]))])
+
+            # remove identity 3 from primary server
+            self.cmd('{} flexible-server identity remove -g {} -s {} -n {} --yes'
+                     .format(database_engine, resource_group, server, identity_id[2]))
+
+            for server_name in [server, replica[0], replica[1]]:
+                self.cmd('{} flexible-server identity list -g {} -s {}'
+                        .format(database_engine, resource_group, server_name),
+                        checks=[
+                            JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[0])),
+                            JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[1])),
+                            JMESPathCheckNotExists('userAssignedIdentities."{}"'.format(identity_id[2]))])


### PR DESCRIPTION
**Related command**
`az mysql flexible-server identity remove`

**Description**<!--Mandatory-->
When customer wants to remove all the user managed identities in a MySQL flexible server, RP will throw an error saying that we can't do that. Instead, when trying to remove all existing identities, we should send only `{"identity": {"type": "None"}}`.

**Testing Guide**
- Assign two identities to an existing server with no identities: `az mysql flexible-server identity assign -g resourceGroup -s serverName --identity testIdentity1 testIdentity2`
- Remove the first identity: `az mysql flexible-server identity remove -g resourceGroup -s serverName --identity testIdentity1`
- Remove the second identity (this now fails but this PR fixes it): `az mysql flexible-server identity remove -g resourceGroup -s serverName --identity testIdentity2`
- Verify that server doesn't have identities: `az mysql flexible-server identity list`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
