### PR TITLE
[Storage] Fix #19311: `az storage remove`: Add support for connection-string

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -1662,7 +1662,7 @@ def validate_azcopy_remove_arguments(cmd, namespace):
                                              'specified'))
     if valid_blob:
         client = blob_data_service_factory(cmd.cli_ctx, {
-            'account_name': namespace.account_name})
+            'account_name': namespace.account_name, 'connection_string': namespace.connection_string})
         if not blob:
             blob = ''
         url = client.make_blob_url(container, blob)

--- a/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators_azure_stack.py
@@ -1131,7 +1131,7 @@ def validate_azcopy_remove_arguments(cmd, namespace):
                                              'specified'))
     if valid_blob:
         client = blob_data_service_factory(cmd.cli_ctx, {
-            'account_name': namespace.account_name})
+            'account_name': namespace.account_name, 'connection_string': namespace.connection_string})
         if not blob:
             blob = ''
         url = client.make_blob_url(container, blob)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/azcopy.py
@@ -59,6 +59,11 @@ def storage_remove(cmd, client, service, target, recursive=None, exclude_pattern
     if exclude_path is not None:
         flags.append('--exclude-path=' + exclude_path)
 
+    if service == 'file':
+        flags.append('--from-to=FileTrash')
+    elif service == 'blob':
+        flags.append('--from-to=BlobTrash')
+
     sas_token = client.sas_token
 
     if not sas_token and client.account_key:


### PR DESCRIPTION
**Related command**
`az storage remove <blob>`

**Description**<!--Mandatory-->
Add/fix support for removing a blob using a connection-string (e.g. from Azurite). See #19311

**Testing Guide**
See reproduce instructions in #19311

**History Notes**

[Storage] Fix #19311: `az storage remove`: Add support for connection-string

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
