### PR TITLE
{Core} Python 3.11: Remove workaround for argparse that breaks on Python 3.11

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------------------------
 
 import difflib
+import sys
 
 import argparse
 import argcomplete
@@ -91,8 +92,10 @@ class AzCliCommandParser(CLICommandParser):
 
             command_verb = command_name.split()[-1]
             # To work around http://bugs.python.org/issue9253, we artificially add any new
-            # parsers we add to the "choices" section of the subparser.
-            subparser.choices[command_verb] = command_verb
+            # parsers we add to the "choices" section of the subparser. This workaround
+            # is no longer required in Python 3.11.
+            if sys.version_info < (3, 11):
+                subparser.choices[command_verb] = command_verb
 
             # inject command_module designer's help formatter -- default is HelpFormatter
             fc = metadata.formatter_class or argparse.HelpFormatter


### PR DESCRIPTION
Fixes the crash inside of argparse when setting up subparsers as described here:

  https://github.com/Azure/azure-cli/issues/23015#issue-1283886050

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

All `az` commands.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

First step on the road to Python 3.11 compatibility.

**Testing Guide**
<!--Example commands with explanations.-->

In a Python 3.11 environment, run `az` (or `azdev test`, though this doesn't fix all tests yet, just the vast majority).

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
