### PR TITLE
{CosmosDB} Make sure analytical-storage-ttl is applied as only argument for Gremlin graphs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -829,7 +829,7 @@ def _populate_gremlin_graph_definition(gremlin_graph_resource,
                                        indexing_policy,
                                        conflict_resolution_policy,
                                        analytical_storage_ttl):
-    if all(arg is None for arg in [partition_key_path, default_ttl, indexing_policy, conflict_resolution_policy]):
+    if all(arg is None for arg in [partition_key_path, default_ttl, indexing_policy, conflict_resolution_policy, analytical_storage_ttl]):
         return False
 
     if partition_key_path is not None:


### PR DESCRIPTION
**Active customer bug**
When creating a Cosmos DB Gremlin graph, the parameter 'analytical-storage-ttl' currently isn't added to the HTTP payload if it is the only container-specific parameter. This PR fixes the issue.
