### PR TITLE
{Core} Python 3.11: Remove uses of deprecated inspect.getargspec

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/utilities.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/scenario_tests/utilities.py
@@ -70,9 +70,9 @@ def trim_kwargs_from_test_function(fn, kwargs):
     # the next function is the actual test function. the kwargs need to be trimmed so
     # that parameters which are not required will not be passed to it.
     if not is_preparer_func(fn):
-        args, _, kw, _ = inspect.getargspec(fn)  # pylint: disable=deprecated-method
-        if kw is None:
-            args = set(args)
+        spec = inspect.getfullargspec(fn)
+        if spec.varkw is None:
+            args = set(spec.args)
             for key in [k for k in kwargs if k not in args]:
                 del kwargs[key]
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/vendored_sdks/azure_keyvault_t1/key_vault_authentication.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/vendored_sdks/azure_keyvault_t1/key_vault_authentication.py
@@ -59,7 +59,7 @@ class KeyVaultAuthBase(AuthBase):
     # for backwards compatibility we need to support callbacks which don't accept the scheme
     def _auth_callback_compat(self, server, resource, scope, scheme):
         return self._user_callback(server, resource, scope) \
-            if len(inspect.getargspec(self._user_callback).args) == 3 \
+            if len(inspect.getfullargspec(self._user_callback).args) == 3 \
             else self._user_callback(server, resource, scope, scheme)
 
     def __call__(self, request):


### PR DESCRIPTION
inspect.getargspec has been deprecated since 3.0 in favor of its replacement inspect.getfullargspec.

This does change "vendored" code, and I couldn't find where that may require special treatment, if at all.

There is [one other use of `inspect.getargspec`](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/azure/cli/core/util.py#L668) that is retained for backward compatibility with Python 2 that I didn't touch, but in reality that clause could also probably be removed since Python 2 is no longer supported.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

All `az` commands.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Another step on the road to Python 3.11 compatibility.  (See also #24109)

**Testing Guide**
<!--Example commands with explanations.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
