### PR TITLE
[Backup] `az backup restore restore-disks`: Update Cross Zonal Restore behaviour for ZRS vaults and primary region CRR scenarios

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1016,7 +1016,7 @@ def _get_trigger_restore_properties(rp_name, vault_location, storage_account_id,
 def _set_trigger_restore_properties(cmd, trigger_restore_properties, target_virtual_machine_name, virtual_network_name,
                                     target_vnet_resource_group, subnet_name, vault_name, resource_group_name,
                                     recovery_point, target_zone, target_rg_id, source_resource_id, restore_mode,
-                                    target_subscription):
+                                    target_subscription, use_secondary_region):
     if restore_mode == "AlternateLocation":
         virtual_network = _get_vnet_object(cmd.cli_ctx, target_subscription, virtual_network_name,
                                            target_vnet_resource_group)
@@ -1038,7 +1038,7 @@ def _set_trigger_restore_properties(cmd, trigger_restore_properties, target_virt
         trigger_restore_properties.subnet_id = subnet_id
     if target_zone:
         backup_config_response = backup_storage_configs_non_crr_cf(cmd.cli_ctx).get(vault_name, resource_group_name)
-        validators.validate_czr(backup_config_response, recovery_point)
+        validators.validate_czr(backup_config_response, recovery_point, use_secondary_region)
         trigger_restore_properties.zones = [target_zone]
 
 
@@ -1160,7 +1160,7 @@ def restore_disks(cmd, client, resource_group_name, vault_name, container_name, 
     _set_trigger_restore_properties(cmd, trigger_restore_properties, target_vm_name, target_vnet_name,
                                     target_vnet_resource_group, target_subnet_name, vault_name, resource_group_name,
                                     recovery_point, target_zone, target_rg_id, _source_resource_id, restore_mode,
-                                    target_subscription)
+                                    target_subscription, use_secondary_region)
 
     trigger_restore_request = RestoreRequestResource(properties=trigger_restore_properties)
 


### PR DESCRIPTION
- Adds use_secondary_region to czr validation call
- Allows CZR for all scenarios in ZRS.
- Disallows CZR for zone-pinned primary region CRR restore.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az backup restore restore-disks`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Cross Zonal Restore is now allowed on all ZRS vaults regardless of zone-pinning, and is disallowed for all primary region CRR restores (regardless of zone pinning). Update on CLI end to reflect the same.

**Testing Guide**
<!--Example commands with explanations.-->
- Cross zonal restore should work for
  - Non-zone pinned and zone-pinned VMs in a ZRS vault
  - Zone-pinned VMs in a Cross-region restore, on restoring to the secondary region (whether zones are supported in the secondary region or not - in the case of not, the zone defaults to NoZone)
- Cross zonal restore will not work in any other scenario.

The general command in all cases is `az backup restore restore-disks ...`, where for Cross-zonal restore we add the `--target-zone 1/2/3` parameter, and for cross region restore we use the `--use-secondary-region` in a vault where CRR is enabled.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

`az backup restore restore-disks`: The `--target-zone` argument can now be used with non zone pinned ZRS vaults, and is not allowed for CRR vaults in primary region restore scenario with zone pinned vaults either.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
