### PR TITLE
{Core} Bump MSAL to 1.20.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -51,7 +51,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.10.0',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.20.0b1',
+    'msal[broker]==1.20.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9,<22.0',
     'paramiko>=2.0.8,<3.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -109,7 +109,7 @@ jsondiff==2.0.0
 knack==0.10.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0b1
+msal[broker]==1.20.0
 msrest==0.7.1
 msrestazure==0.6.4
 mycli==1.22.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -110,7 +110,7 @@ jsondiff==2.0.0
 knack==0.10.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0b1
+msal[broker]==1.20.0
 msrest==0.7.1
 msrestazure==0.6.4
 mycli==1.22.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -109,7 +109,7 @@ jsondiff==2.0.0
 knack==0.10.0
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0b1
+msal[broker]==1.20.0
 msrest==0.7.1
 msrestazure==0.6.4
 mycli==1.22.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Use the latest MSAL 1.20.0 which has GA broker/WAM support (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/502).
