### PR TITLE
{HDInsight}Remove the allowed TLS version 1.0 and 1.1 in --minimal-tls-version help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/hdinsight/_params.py
@@ -75,7 +75,7 @@ def load_arguments(self, _):
         c.argument('idbroker', arg_group='Cluster', action='store_true',
                    help='Specify to create ESP cluster with HDInsight ID Broker. If omitted, '
                         'creating ESP cluster with HDInsight ID Broker will not not allowed.')
-        c.argument('minimal_tls_version', arg_type=get_enum_type(['1.0', '1.1', '1.2']),
+        c.argument('minimal_tls_version', arg_type=get_enum_type(['1.2']),
                    arg_group='Cluster', help='The minimal supported TLS version.')
 
         # HTTP


### PR DESCRIPTION
Remove the allowed TLS version 1.0 and 1.1 in --minimal-tls-version help message

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
only affect the output of  `az hdinsight create -h`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Azure ARM has enforced TLS 1.2, but in az hdinsight create help message, we still have the allowed version 1.0 and 1.1, we need to remove it from help message. There is not customer impact.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[az hdinsight] BREAKING CHANGE: `az hdinsight create`: Remove the enum value 1.0 and 1.1 from the --minimal-tls-version, HDInsight doesn't support TLS version which is less than 1.2 now.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
