### PR TITLE
{Core} Explicitly set `enable_msa_passthrough` to `True` to allow WAM+MSA login 

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -154,6 +154,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             scopes, prompt='select_account', port=8400 if self._is_adfs else None,
             success_template=success_template, error_template=error_template,
             parent_window_handle=self._msal_app.CONSOLE_WINDOW_HANDLE, on_before_launching_ui=_prompt_launching_ui,
+            enable_msa_passthrough=True,
             **kwargs)
         return check_result(result)
 


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
MSAL 1.20.0b1 implicitly sets `enable_msa_passthrough` to `True` for Azure CLI's client ID `04b07795-8ddb-461a-bbee-02f9e1bf7b46` (along with Visual Studio's client ID `04f0c124-f2bc-4f59-8241-bf6df9866bbd`):

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.20.0b1/msal/application.py#L1746-L1760

```py
            enable_msa_passthrough = kwargs.pop(
                "enable_msa_passthrough",  # Keep it as a hidden param, for now.
                    # OPTIONAL. MSA-Passthrough is a legacy configuration,
                    # needed by a small amount of Microsoft first-party apps,
                    # which would login MSA accounts via ".../organizations" authority.
                    # If you app belongs to this category, AND you are enabling broker,
                    # you would want to enable this flag. Default value is equivalent to False.
                self.client_id in [
                    # Experimental: Automatically enable MSA-PT mode for known MSA-PT apps
                    # More background of MSA-PT is available from this internal docs:
                    # https://microsoft.sharepoint.com/:w:/t/Identity-DevEx/EatIUauX3c9Ctw1l7AQ6iM8B5CeBZxc58eoQCE0IuZ0VFw?e=tgc3jP&CID=39c853be-76ea-79d7-ee73-f1b2706ede05
                    "04b07795-8ddb-461a-bbee-02f9e1bf7b46",  # Azure CLI
                    "04f0c124-f2bc-4f59-8241-bf6df9866bbd",  # Visual Studio
                    ] and data.get("token_type") != "ssh-cert"  # Work around a known issue as of PyMsalRuntime 0.8
                )
```

MSAL 1.20.0 removed this behavior and now requires manually setting `enable_msa_passthrough` to `True` to allow WAM+MSA login (https://github.com/AzureAD/microsoft-authentication-library-for-python/commit/28b45a394cec06ebea4dcd4ff165f2938af8cd96):

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.20.0/msal/application.py#L1782-L1792

```py
        enable_msa_passthrough = kwargs.pop(  # MUST remove it from kwargs
            "enable_msa_passthrough",  # Keep it as a hidden param, for now.
                # OPTIONAL. MSA-Passthrough is a legacy configuration,
                # needed by a small amount of Microsoft first-party apps,
                # which would login MSA accounts via ".../organizations" authority.
                # If you app belongs to this category, AND you are enabling broker,
                # you would want to enable this flag. Default value is False.
                # More background of MSA-PT is available from this internal docs:
                # https://microsoft.sharepoint.com/:w:/t/Identity-DevEx/EatIUauX3c9Ctw1l7AQ6iM8B5CeBZxc58eoQCE0IuZ0VFw?e=tgc3jP&CID=39c853be-76ea-79d7-ee73-f1b2706ede05
            False
            ) and data.get("token_type") != "ssh-cert"  # Work around a known issue as of PyMsalRuntime 0.8
```

MSAL's scenario test demonstrates how to use it:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.20.0/tests/msaltest.py#L84-L89

```py
    result = app.acquire_token_interactive(
        scopes,
        parent_window_handle=app.CONSOLE_WINDOW_HANDLE,  # This test app is a console app
        enable_msa_passthrough=app.client_id in [  # Apps are expected to set this right
            AZURE_CLI, VISUAL_STUDIO,
            ],  # Here this test app mimics the setting for some known MSA-PT apps
```

**Testing Guide**
```
az config set core.allow_broker=true
az login
```

Without setting `enable_msa_passthrough` to `True`, only AAD account is listed:

![image](https://user-images.githubusercontent.com/4003950/195533131-898924e1-6505-4d0c-9014-d874d01a9fd7.png)

If you choose "Use another account" and type in an MSA outlook.com account, it fails:

![image](https://user-images.githubusercontent.com/4003950/195533227-aac974e9-5b5f-4f4b-ac9e-5b86afa756fc.png)

By setting `enable_msa_passthrough` to `True`, MSA outlook.com accounts that are logged in to Windows are automatically listed:

![image](https://user-images.githubusercontent.com/4003950/195532843-c803b741-26e4-4fac-acba-003239cf7949.png)

You may also log in another MSA account by selecting "Microsoft account":

![image](https://user-images.githubusercontent.com/4003950/195535033-d5c5fb8f-e5fa-4f8f-8ffe-57a19cf790bd.png)
