### PR TITLE
{AzureCosmosDB} fixes Azure/azure-cli#24156

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -389,7 +389,8 @@ def cli_cosmosdb_update(client,
         from azure.cli.core.azclierror import InvalidArgumentValueError
         for resource_id in network_acl_bypass_resource_ids:
             if not is_valid_resource_id(resource_id):
-                raise InvalidArgumentValueError(f'{resource_id} is not a valid resource ID for --network-acl-bypass-resource-ids')
+                raise InvalidArgumentValueError(
+                    f'{resource_id} is not a valid resource ID for --network-acl-bypass-resource-ids')
 
     if max_staleness_prefix is None:
         max_staleness_prefix = existing.consistency_policy.max_staleness_prefix

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -386,9 +386,9 @@ def cli_cosmosdb_update(client,
 
     if network_acl_bypass_resource_ids is not None:
         from msrestazure.tools import is_valid_resource_id
-            for resource_id in network_acl_bypass_resource_ids:
-                if not is_valid_resource_id(resource_id):
-                    raise CLIError('--network_acl_bypass_resource_ids is not a valid resource ID.')
+        for resource_id in network_acl_bypass_resource_ids:
+            if not is_valid_resource_id(resource_id):
+                raise CLIError('--network_acl_bypass_resource_ids is not a valid resource ID.')
 
     if max_staleness_prefix is None:
         max_staleness_prefix = existing.consistency_policy.max_staleness_prefix

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -388,7 +388,7 @@ def cli_cosmosdb_update(client,
         from msrestazure.tools import is_valid_resource_id
         for resource_id in network_acl_bypass_resource_ids:
             if not is_valid_resource_id(resource_id):
-                raise CLIError('--network_acl_bypass_resource_ids is not a valid resource ID.')
+                raise CLIError(f'{resource_id} is not a valid resource ID for --network-acl-bypass-resource-ids')
 
     if max_staleness_prefix is None:
         max_staleness_prefix = existing.consistency_policy.max_staleness_prefix

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -386,9 +386,10 @@ def cli_cosmosdb_update(client,
 
     if network_acl_bypass_resource_ids is not None:
         from msrestazure.tools import is_valid_resource_id
+        from azure.cli.core.azclierror import InvalidArgumentValueError
         for resource_id in network_acl_bypass_resource_ids:
             if not is_valid_resource_id(resource_id):
-                raise CLIError(f'{resource_id} is not a valid resource ID for --network-acl-bypass-resource-ids')
+                raise InvalidArgumentValueError(f'{resource_id} is not a valid resource ID for --network-acl-bypass-resource-ids')
 
     if max_staleness_prefix is None:
         max_staleness_prefix = existing.consistency_policy.max_staleness_prefix

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -385,7 +385,7 @@ def cli_cosmosdb_update(client,
         update_consistency_policy = True
 
     if network_acl_bypass_resource_ids is not None:
-            from msrestazure.tools import is_valid_resource_id
+        from msrestazure.tools import is_valid_resource_id
             for resource_id in network_acl_bypass_resource_ids:
                 if not is_valid_resource_id(resource_id):
                     raise CLIError('--network_acl_bypass_resource_ids is not a valid resource ID.')

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -384,6 +384,12 @@ def cli_cosmosdb_update(client,
             default_consistency_level is not None:
         update_consistency_policy = True
 
+    if network_acl_bypass_resource_ids is not None:
+            from msrestazure.tools import is_valid_resource_id
+            for resource_id in network_acl_bypass_resource_ids:
+                if not is_valid_resource_id(resource_id):
+                    raise CLIError('--network_acl_bypass_resource_ids is not a valid resource ID.')
+
     if max_staleness_prefix is None:
         max_staleness_prefix = existing.consistency_policy.max_staleness_prefix
 


### PR DESCRIPTION
fixes Azure/azure-cli#24156

It's possible to input resource id without leading '/' in URI, and this cause Cosmos DB Analytical Store to be unable to identify the mentioned resources and by-pass on network acl checking. Without the leading '/' in resource URI, CLI execution won't report any errors or indicate it's actually an invalid format. Cosmos DB can still store the invalid URI at last, but no help to allow querying from Synapse.

To Reproduce
az cosmosdb update --name MyCosmosDBDatabaseAccount--resource-group MyResourceGroup--network-acl-bypass AzureServices --network-acl-bypass-resource-ids "subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Synapse/workspaces/wsName"

This PR validates the input values of --network-acl-bypass-resource-ids, to ensure customer configuring their resource correctly.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
