### PR TITLE
[Backup] Updated subtask duration handling in `backup job show` commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1290,18 +1290,10 @@ def show_job(cmd, client, resource_group_name, vault_name, name, use_secondary_r
         vault_location = vault.location
         azure_region = secondary_region_map[vault_location]
         client = backup_crr_job_details_cf(cmd.cli_ctx)
-        return client.get(azure_region, CrrJobRequest(resource_id=vault.id, job_name=name))
+        response = client.get(azure_region, CrrJobRequest(resource_id=vault.id, job_name=name))
+        return cust_help.replace_min_value_in_subtask(response)
     response = client.get(vault_name, resource_group_name, name)
-
-    # Task in progress: replace min_value in start and end times with null.
-    tasks_list = response.properties.extended_info.tasks_list
-    for task in tasks_list:
-        if task.start_time == datetime.min:
-            task.start_time = None
-        if task.end_time == datetime.min:
-            task.end_time = None
-
-    return response
+    return cust_help.replace_min_value_in_subtask(response)
 
 
 def stop_job(client, resource_group_name, vault_name, name, use_secondary_region=None):

--- a/src/azure-cli/azure/cli/command_modules/backup/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom.py
@@ -1291,7 +1291,17 @@ def show_job(cmd, client, resource_group_name, vault_name, name, use_secondary_r
         azure_region = secondary_region_map[vault_location]
         client = backup_crr_job_details_cf(cmd.cli_ctx)
         return client.get(azure_region, CrrJobRequest(resource_id=vault.id, job_name=name))
-    return client.get(vault_name, resource_group_name, name)
+    response = client.get(vault_name, resource_group_name, name)
+
+    # Task in progress: replace min_value in start and end times with null.
+    tasks_list = response.properties.extended_info.tasks_list
+    for task in tasks_list:
+        if task.start_time == datetime.min:
+            task.start_time = None
+        if task.end_time == datetime.min:
+            task.end_time = None
+
+    return response
 
 
 def stop_job(client, resource_group_name, vault_name, name, use_secondary_region=None):

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_help.py
@@ -221,6 +221,17 @@ def get_sub_protection_policy(policy, sub_policy_type):
     return None
 
 
+def replace_min_value_in_subtask(response):
+    # For a task in progress: replace min_value in start and end times with null.
+    tasks_list = response.properties.extended_info.tasks_list
+    for task in tasks_list:
+        if task.start_time == datetime.min:
+            task.start_time = None
+        if task.end_time == datetime.min:
+            task.end_time = None
+    return response
+
+
 def validate_container(container):
     validate_object(container, "Container not found. Please provide a valid container_name.")
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az backup job show`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The backup job command returns the details of the main task, along with any subtasks that were run. So far, we only received the details of task start and end times, and duration, for the main task. Now in certain scenarios the subtasks contain this information as well (where they used to be `null` in the case of start and end times, and `0` in the case of duration). As there are no explicit flags of when the subtask duration will be returned, the service returns a value instead of `null` for the start and end times - when the task has not started or has not completed, the value will be a minimum value. We do not want to show customers the minimum value, and during such cases it will be replaced with `null` again when displaying the output.

**Testing Guide**
<!--Example commands with explanations.-->
Run the `az backup job show -n <task name> -v <vault name> -g <resource group>` command for an ongoing backup job task in the `eastuseuap` region.

Without the change, for an ongoing (sub)task, the end time will be `0001-01-01T00:00:00`. With the change, the end time will be `null`. For a subtask that hasn't started, both start and end time will go from `0001-01-01T00:00:00` to `null`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] `az backup job show`: Change subtask start/end time from minimum value to null for ongoing or yet-to-start operation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
