### PR TITLE
[IoT] Enforce default IoT Hub data residency setting for qatarcentral

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -519,12 +519,11 @@ def iot_hub_create(cmd, client, hub_name, resource_group_name, location=None,
             raise ArgumentUsageError('User identity [--mi-user-assigned] must be added in order to use it for file upload')
     location = _ensure_location(cli_ctx, resource_group_name, location)
 
-    if location == 'qatarcentral':
-        if enable_data_residency is False:
-            raise InvalidArgumentValueError('Data Residency enforcement cannot be disabled in this region.')
-        if not enable_data_residency:
-            logger.warning('Setting "--enforce-data-residency" argument to "True" - Data Residency enforcement must be enabled in this region.')
-        enable_data_residency = True
+    if location == 'qatarcentral' and not enable_data_residency:
+        raise InvalidArgumentValueError(
+            "Data Residency enforcement must be enabled for IoT Hubs created in this region. Please use the '--enforce-data-residency' (--edr) argument "
+            "to enable it. Check command help (-h) for more information on this property's usage and implications."
+        )
 
     sku = IotHubSkuInfo(name=sku, capacity=unit)
 

--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -468,6 +468,7 @@ def iot_hub_certificate_verify(client, hub_name, certificate_name, certificate_p
     return client.certificates.verify(resource_group_name, hub_name, certificate_name, etag, certificate_verify_body)
 
 
+# pylint: disable=too-many-statements
 def iot_hub_create(cmd, client, hub_name, resource_group_name, location=None,
                    sku=IotHubSku.s1.value,
                    unit=1,
@@ -517,6 +518,14 @@ def iot_hub_create(cmd, client, hub_name, resource_group_name, location=None,
         if fileupload_storage_identity and fileupload_storage_identity != SYSTEM_ASSIGNED_IDENTITY and not user_identities:
             raise ArgumentUsageError('User identity [--mi-user-assigned] must be added in order to use it for file upload')
     location = _ensure_location(cli_ctx, resource_group_name, location)
+
+    if location == 'qatarcentral':
+        if enable_data_residency is False:
+            raise InvalidArgumentValueError('Data Residency enforcement cannot be disabled in this region.')
+        if not enable_data_residency:
+            logger.warning('Setting "--enforce-data-residency" argument to "True" - Data Residency enforcement must be enabled in this region.')
+        enable_data_residency = True
+
     sku = IotHubSkuInfo(name=sku, capacity=unit)
 
     event_hub_dic = {}

--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -519,7 +519,7 @@ def iot_hub_create(cmd, client, hub_name, resource_group_name, location=None,
             raise ArgumentUsageError('User identity [--mi-user-assigned] must be added in order to use it for file upload')
     location = _ensure_location(cli_ctx, resource_group_name, location)
 
-    if location == 'qatarcentral' and not enable_data_residency:
+    if location.lower() == 'qatarcentral' and not enable_data_residency:
         raise InvalidArgumentValueError(
             "Data Residency enforcement must be enabled for IoT Hubs created in this region. Please use the '--enforce-data-residency' (--edr) argument "
             "to enable it. Check command help (-h) for more information on this property's usage and implications."

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -39,6 +39,7 @@ class IoTHubTest(ScenarioTest):
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --fn true --fc containerName'
                  .format(hub, rg), expect_failure=True)
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --mintls 2.5'.format(hub, rg), expect_failure=True)
+        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral --edr false'.format(hub, rg), expect_failure=True)
         self.cmd('iot hub create -n {0} -g {1} --retention-day 3'
                  ' --c2d-ttl 23 --c2d-max-delivery-count 89 --feedback-ttl 29 --feedback-lock-duration 35'
                  ' --feedback-max-delivery-count 40 --fileupload-notification-max-delivery-count 79'

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -39,7 +39,9 @@ class IoTHubTest(ScenarioTest):
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --fn true --fc containerName'
                  .format(hub, rg), expect_failure=True)
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --mintls 2.5'.format(hub, rg), expect_failure=True)
-        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral --edr false'.format(hub, rg), expect_failure=True)
+        # qatar region data-residency enforcement must be enabled
+        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral --enforce-data-residency false'.format(hub, rg), expect_failure=True)
+        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral'.format(hub, rg), expect_failure=True)
         self.cmd('iot hub create -n {0} -g {1} --retention-day 3'
                  ' --c2d-ttl 23 --c2d-max-delivery-count 89 --feedback-ttl 29 --feedback-lock-duration 35'
                  ' --feedback-max-delivery-count 40 --fileupload-notification-max-delivery-count 79'

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -41,7 +41,7 @@ class IoTHubTest(ScenarioTest):
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --mintls 2.5'.format(hub, rg), expect_failure=True)
         # qatar region data-residency enforcement must be enabled
         self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral --enforce-data-residency false'.format(hub, rg), expect_failure=True)
-        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location qatarcentral'.format(hub, rg), expect_failure=True)
+        self.cmd('iot hub create -n {0} -g {1} --sku S1 --location QATARCENTRAL'.format(hub, rg), expect_failure=True)
         self.cmd('iot hub create -n {0} -g {1} --retention-day 3'
                  ' --c2d-ttl 23 --c2d-max-delivery-count 89 --feedback-ttl 29 --feedback-lock-duration 35'
                  ' --feedback-max-delivery-count 40 --fileupload-notification-max-delivery-count 79'


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az iot hub create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

This PR adds a more user-friendly error when the user does not add the `--enforce-data-residency` property for `iot hub create`  in the `qatarcentral` region.

In all other regions, the default value of `None` or `False` is accepted.

For creates in `qatarcentral`, we will fail the command at the client level if the user does not add this parameter to enable the setting.


**Testing Guide**
<!--Example commands with explanations.-->

- `az iot hub create --sku s1 --location qatarcentral -g rg --name test-hub` will fail with an error.
- `az iot hub create --sku s1 --location qatarcentral -g rg --name test-hub --edr False` will fail with an error.
- `az iot hub create --sku s1 --location qatarcentral -g rg --name test-hub --edr [True]` will succeed.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
[IoT] `az iot hub create`: Enforce data residency property on hubs created in `qatarcentral`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
