### PR TITLE
{Core} Log showing survey message info in telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/intercept_survey.py
+++ b/src/azure-cli-core/azure/cli/core/intercept_survey.py
@@ -88,6 +88,9 @@ def prompt_survey_message(cli):
     ])
     print_styled_text((SURVEY_STYLE, NEW_LINE))
 
+    from azure.cli.core import telemetry
+    telemetry.set_survey_info(show_survey_message=True)
+
     # log prompt time
     next_prompt_time = datetime.utcnow() + timedelta(days=PROMPT_INTERVAL_IN_DAYS)
     survey_note = {

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -50,6 +50,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.feedback = None
         self.extension_management_detail = None
         self.raw_command = None
+        self.show_survey_message = False
         self.mode = 'default'
         # The AzCLIError sub-class name
         self.error_type = 'None'
@@ -204,6 +205,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'PollStartTime', str(self.poll_start_time))
         set_custom_properties(result, 'PollEndTime', str(self.poll_end_time))
         set_custom_properties(result, 'CloudName', _get_cloud_name())
+        set_custom_properties(result, 'ShowSurveyMessage', str(self.show_survey_message))
 
         return result
 
@@ -415,6 +417,12 @@ def set_module_correlation_data(correlation_data):
 def set_raw_command_name(command):
     # the raw command name user inputs
     _session.raw_command = command
+
+
+@decorators.suppress_all_exceptions()
+def set_survey_info(show_survey_message):
+    # whether showed the intercept survey message or not
+    _session.show_survey_message = show_survey_message
 
 
 @decorators.suppress_all_exceptions()


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We have implemented intercept survey in https://github.com/Azure/azure-cli/pull/23460. Now PM wants to log how many times the intercept message has been shown to customers in telemetry.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
