### PR TITLE
[Core] Prioritize extension's modle path

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -501,7 +501,7 @@ def reload_extension(extension_name, extension_module=None):
 
 def add_extension_to_path(extension_name, ext_dir=None):
     ext_dir = ext_dir or get_extension(extension_name).path
-    sys.path.append(ext_dir)
+    sys.path.insert(0, ext_dir)
     # If this path update should have made a new "azure" module available,
     # extend the existing module with its path. This allows extensions to
     # include (or depend on) Azure SDK modules that are not yet part of


### PR DESCRIPTION
**Related command**
az interactive

**Description**<!--Mandatory-->
With current implementation, module path for extension is appended by sys.append(). Some module like interactive need old module so we need to prioritize to import modules under extension's directory instead of default directory. This patch will fix problem like #24213

**Testing Guide**
az interactive

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
