### PR TITLE
[Storage] `az storage account show-connection-string/keys renew`: Update options for `--key` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_validators.py
@@ -26,7 +26,7 @@ from knack.log import get_logger
 from knack.util import CLIError
 from ._client_factory import cf_blob_service, cf_share_service, cf_share_client
 
-storage_account_key_options = {'primary': 'key1', 'secondary': 'key2'}
+storage_account_key_options = {'primary': '1', 'secondary': '2', 'key1': '1', 'key2': '2'}
 logger = get_logger(__name__)
 
 
@@ -846,13 +846,15 @@ def validate_included_datasets_validator(include_class):
 
 
 def validate_key_name(namespace):
-    key_options = {'primary': '1', 'secondary': '2'}
-    if hasattr(namespace, 'key_type') and namespace.key_type:
-        namespace.key_name = namespace.key_type + key_options[namespace.key_name]
-    else:
-        namespace.key_name = storage_account_key_options[namespace.key_name]
+    key_type = 'key'
     if hasattr(namespace, 'key_type'):
+        key_type = namespace.key_type or 'key'
         del namespace.key_type
+
+    if namespace.key_name in ['primary', 'secondary']:
+        logger.warning("The 'primary' and 'secondary' options for --key are deprecated and "
+                       "will be removed in future release, please use 'key1' and 'key2' instead.")
+    namespace.key_name = key_type + storage_account_key_options[namespace.key_name]
 
 
 def validate_metadata(namespace):

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -103,6 +103,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('storage account', storage_account_sdk, resource_type=ResourceType.MGMT_STORAGE,
                             custom_command_type=storage_account_custom_type) as g:
+        from ._validators import validate_key_name
         g.custom_command('check-name', 'check_name_availability')
         g.custom_command('create', 'create_storage_account')
         g.command('delete', 'delete', confirmation=True)
@@ -113,7 +114,8 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
         g.custom_command(
             'show-usage', 'show_storage_account_usage_no_location', max_api='2017-10-01')
         g.custom_command('show-connection-string',
-                         'show_storage_account_connection_string')
+                         'show_storage_account_connection_string',
+                         validator=validate_key_name)
         g.generic_update_command('update', getter_name='get_properties', setter_name='update',
                                  custom_func_name='update_storage_account', min_api='2016-12-01')
         failover_confirmation = """
@@ -131,7 +133,6 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
     with self.command_group('storage account', storage_account_sdk_keys, resource_type=ResourceType.MGMT_STORAGE,
                             custom_command_type=storage_account_custom_type) as g:
-        from ._validators import validate_key_name
         g.custom_command('keys renew', 'regenerate_key', validator=validate_key_name,
                          transform=lambda x: getattr(x, 'keys', x))
         g.command('keys list', 'list_keys',

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -281,7 +281,7 @@ def list_storage_accounts(cmd, resource_group_name=None):
 
 def show_storage_account_connection_string(cmd, resource_group_name, account_name, protocol='https', blob_endpoint=None,
                                            file_endpoint=None, queue_endpoint=None, table_endpoint=None, sas_token=None,
-                                           key_name='primary'):
+                                           key_name='key1'):
 
     endpoint_suffix = cmd.cli_ctx.cloud.suffixes.storage_endpoint
     connection_string = 'DefaultEndpointsProtocol={};EndpointSuffix={}'.format(protocol, endpoint_suffix)
@@ -308,7 +308,7 @@ def show_storage_account_connection_string(cmd, resource_group_name, account_nam
         connection_string = '{}{}{}'.format(
             connection_string,
             ';AccountName={}'.format(account_name),
-            ';AccountKey={}'.format(keys[0] if key_name == 'primary' else keys[1]))  # pylint: disable=no-member
+            ';AccountKey={}'.format(keys[0] if key_name == 'key1' else keys[1]))  # pylint: disable=no-member
 
     connection_string = '{}{}'.format(connection_string,
                                       ';BlobEndpoint={}'.format(blob_endpoint) if blob_endpoint else '')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account show-connection-string`
`az storage account keys renew`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
[Storage account REST API for regenerating keys](https://learn.microsoft.com/en-us/rest/api/storagerp/storage-accounts/regenerate-key?tabs=HTTP) is using `key1/key2` as `keyName`'s value

CLI command `az storage account keys renew` is using `primary/secondary` as `--key`'s value

To make things consistent, CLI would allow both `primary/secondary` and `key1/key2` for several sprints and then remove `primary/secondary` in next breaking change window.

**Testing Guide**
<!--Example commands with explanations.-->
`az storage account show-connection-string --key key1/key2/primary/secondary -n {storage_account_name} -g {resource_group_name}`
`az storage account keys renew --key key1/key2/primary/secondary -n {storage_account_name} -g {resource_group_name}`


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
