### PR TITLE
[ACR] `acr task update`: Fix logic issue for updating encoded task

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -411,7 +411,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
     else:
         branch = _get_branch_name(context_path)
 
-    # When update encoded task, existing encoded_task_content in the step cannot be updated.
+    # When update encoded task, existing encoded_task_content in the step cannot be decoded for update.
     if context_path is None:
         if cmd_value is not None or timeout is not None or file is not None:
             raise CLIError(
@@ -537,6 +537,7 @@ def update_task_step(step,
             operation_group='tasks')
     arguments = _get_all_override_arguments(arg, secret_arg)
     set_values = _get_all_override_arguments(set_value, set_secret)
+    # If context_path is not None, check if file is provided
     if context_path:
         if file:
             if file.endswith(ALLOWED_TASK_FILE_TYPES):
@@ -558,6 +559,7 @@ def update_task_step(step,
                     context_access_token=git_access_token,
                     target=target
                 )
+        # If file is not provided, use the existing step
         elif step:
             if hasattr(step, 'docker_file_path'):
                 step = DockerBuildStepUpdateParameters(
@@ -579,6 +581,7 @@ def update_task_step(step,
                     context_access_token=git_access_token,
                     values=set_values
                 )
+    # If context_path is None, update the encoded task
     else:
         step = EncodedTaskStepUpdateParameters(
             encoded_task_content=step.encoded_task_content,

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -407,7 +407,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
     if context_path is None:
         context_path = step.context_path
     elif context_path.lower() == ACR_NULL_CONTEXT:
-        context_path = None 
+        context_path = None
     else:
         branch = _get_branch_name(context_path)
 
@@ -421,7 +421,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
         git_access_token = step.context_access_token
 
     step = update_task_step(
-        step=step, # Need exisiting step for update
+        step=step,  # Need exisiting step for update
         context_path=context_path,
         cmd=cmd,
         file=file,
@@ -514,6 +514,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
     )
     return client.begin_update(resource_group_name, registry_name, task_name, taskUpdateParameters)
 
+
 def update_task_step(step,
                      context_path,
                      cmd,
@@ -530,10 +531,10 @@ def update_task_step(step,
                      target):
     DockerBuildStepUpdateParameters, EncodedTaskStepUpdateParameters, \
         FileTaskStepUpdateParameters = cmd.get_models(
-        'DockerBuildStepUpdateParameters',
-        'EncodedTaskStepUpdateParameters',
-        'FileTaskStepUpdateParameters',
-        operation_group='tasks')
+            'DockerBuildStepUpdateParameters',
+            'EncodedTaskStepUpdateParameters',
+            'FileTaskStepUpdateParameters',
+            operation_group='tasks')
     arguments = _get_all_override_arguments(arg, secret_arg)
     set_values = _get_all_override_arguments(set_value, set_secret)
     if context_path:
@@ -586,6 +587,7 @@ def update_task_step(step,
             values=(set_value if set_value else []) + (set_secret if set_secret else [])
         )
     return step
+
 
 def acr_task_identity_assign(cmd,
                              client,

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -373,16 +373,12 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
         cmd, registry_name, resource_group_name, TASK_NOT_SUPPORTED)
 
     AgentProperties, AuthInfoUpdateParameters, BaseImageTriggerUpdateParameters, \
-        DockerBuildStepUpdateParameters, EncodedTaskStepUpdateParameters, \
-        FileTaskStepUpdateParameters, PlatformUpdateParameters, SourceControlType, \
-        SourceUpdateParameters, SourceTriggerUpdateParameters, TaskUpdateParameters, \
+        PlatformUpdateParameters, SourceControlType, SourceUpdateParameters, \
+        SourceTriggerUpdateParameters, TaskUpdateParameters, \
         TriggerStatus, TriggerUpdateParameters = cmd.get_models(
             'AgentProperties',
             'AuthInfoUpdateParameters',
             'BaseImageTriggerUpdateParameters',
-            'DockerBuildStepUpdateParameters',
-            'EncodedTaskStepUpdateParameters',
-            'FileTaskStepUpdateParameters',
             'PlatformUpdateParameters',
             'SourceControlType',
             'SourceUpdateParameters',

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -448,7 +448,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
                     context_access_token=git_access_token,
                     target=target
                 )
-        else:
+        elif step:
             if hasattr(step, 'docker_file_path'):
                 step = DockerBuildStepUpdateParameters(
                     image_names=image_names,

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -411,8 +411,8 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
     else:
         branch = _get_branch_name(context_path)
 
+    encoded_task_content = None
     if context_path is None:
-        encoded_task_content = None
         # When cmd_value is given or file is given,
         # regenerate encoded_task_content
         if cmd_value is not None or file is not None:

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -9,6 +9,7 @@ from msrest.exceptions import ValidationError
 from knack.log import get_logger
 from knack.util import CLIError
 from azure.cli.core.commands import LongRunningOperation
+from azure.cli.core.parser import IncorrectUsageError
 from azure.cli.core.util import user_confirmation
 from ._utils import (
     get_registry_by_name,
@@ -424,7 +425,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
         # When only timeout is given,
         # encoded_task_content cannot be patched
         elif timeout is not None:
-            raise CLIError(
+            raise IncorrectUsageError(
                 "cannot update the task with change of 'timeout' only, please use create instead")
 
     if git_access_token is None:
@@ -558,7 +559,7 @@ def update_task_step(step,
                     values_file_path=values,
                     context_path=context_path,
                     context_access_token=git_access_token,
-                    values=(set_value if set_value else []) + (set_secret if set_secret else [])
+                    values=set_values
                 )
             else:
                 step = DockerBuildStepUpdateParameters(
@@ -566,7 +567,7 @@ def update_task_step(step,
                     is_push_enabled=not no_push,
                     no_cache=no_cache,
                     docker_file_path=file,
-                    arguments=(arg if arg else []) + (secret_arg if secret_arg else []),
+                    arguments=arguments,
                     context_path=context_path,
                     context_access_token=git_access_token,
                     target=target
@@ -602,7 +603,7 @@ def update_task_step(step,
             encoded_task_content=encoded_task_content,
             context_path=context_path,
             context_access_token=git_access_token,
-            values=(set_value if set_value else []) + (set_secret if set_secret else [])
+            values=set_values
         )
     return step
 

--- a/src/azure-cli/azure/cli/command_modules/acr/task.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/task.py
@@ -404,9 +404,11 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
 
     step = task.step
     branch = None
-    # If context is not given, use the existing context
+
     if context_path is None:
         context_path = step.context_path
+    elif context_path.lower() == ACR_NULL_CONTEXT:
+        context_path = None 
     else:
         branch = _get_branch_name(context_path)
 
@@ -415,8 +417,7 @@ def acr_task_update(cmd,  # pylint: disable=too-many-locals, too-many-statements
     arguments = _get_all_override_arguments(arg, secret_arg)
     set_values = _get_all_override_arguments(set_value, set_secret)
 
-    # If context is None or user inputs "/dev/null" as new context
-    if context_path is None or context_path.lower() == ACR_NULL_CONTEXT:
+    if context_path is None:
         yaml_template = get_yaml_template(
             cmd_value, timeout, file)
         import base64


### PR DESCRIPTION
This PR changes the logic for task update. It resolves the following issues:

1. The update process missed the `EncodedTaskStepUpdateParameters` to update the values for `EncodedTask`. Issue [#497](https://github.com/Azure/acr/issues/497).

2. If our update cmd has a file arg, then CLI makes the assumption that the step is a FileTaskStep or DuckerBuildTaskStep regardless the existing or intended context [here](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/acr/task.py#L414). If we want to update the file for an `EncodedTask`, we will get an error in [#313](https://github.com/Azure/acr/issues/313). The reason is the following: 
In `TasksController`, we will first update the `exisitingTaskRecord` with all of the updated parameters [here](https://msazure.visualstudio.com/AzureContainerRegistry/_git/Build?path=/src/ACR.BuildRP/src/v18_09_GA/Controllers/TasksController.cs&version=GBmain&line=502&lineEnd=503&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents). As described above, the `EncodedTaskStep` now has been changed to `FileTaskStep`. Then we will call `ValidateContextProperty()` with the updated `FileTaskStep`. If the step were still `EncodedTaskStep`, there should have been no validation for context at all, because of [this](https://msazure.visualstudio.com/AzureContainerRegistry/_git/Build?path=/src/ACR.BuildRP/src/v18_09_GA/Models/Validation.Tasks.cs&version=GBmain&line=531&lineEnd=532&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) logic. But with the unintended change of task type (from Encoded to File), the validation would fail. 

After the change, the update logics follows the create logics.

To test: run
`az acr task create -r wjucr001 -n task123 --cmd localhost:12900/test:latest -c /dev/null --schedule \*/3\ \*\ \*\ \*\ \* `
`az acr task update -r wjucr001 -n task123 --set foo=bar `
Observe the value is changed.

`az acr task create -r wjucr001 -n task1 -f acb.yaml -c /dev/null`
`acr task update -r wjucr001 -n task1 -f acb.yaml`
Observe no error thrown.

Signed-off-by: Jun <wju@microsoft.com>

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
