### PR TITLE
[Compute] `az vm run-command`: Change help messages and add examples for `--output-blob-uri` parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -2616,6 +2616,8 @@ parameters:
     short-summary: "Specify the script download location."
   - name: --command-id
     short-summary: "Specify a commandId of predefined built-in script."
+  - name: --output-blob-uri
+    short-summary: "Specify the Azure storage blob (SAS URI) where script output stream will be uploaded."
   - name: --parameters
     short-summary: "The parameters used by the script."
     long-summary: |
@@ -2631,6 +2633,11 @@ examples:
 --async-execution false --parameters arg1=param1 arg2=value1 --run-as-password "<runAsPassword>" \
 --run-as-user "user1" --script "Write-Host Hello World!" --timeout-in-seconds 3600 \
 --run-command-name "myRunCommand" --vm-name "myVM"
+  - name: Create a run command with uploading script output stream to Azure storage blob (SAS URI).
+    text: |-
+           az vm run-command create --resource-group "myResourceGroup" --location "West US" \
+--script "Write-Host Hello World!" --run-command-name "myRunCommand" --vm-name "myVM" --output-blob-uri \
+https://mystorageaccount.blob.core.windows.net/mycontainer/RuncommandOutput.txt?sp=racw&st=2022-10-17T19:02:15Z&se=2022-10-18T03:02:15Z&spr=https&sv=2021-06-08&sr=b&sig=3BxtEasfdasdfasdfdYki9yvYsqc60V0%3D
 """
 
 helps['vm run-command update'] = """

--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -2637,7 +2637,7 @@ examples:
     text: |-
            az vm run-command create --resource-group "myResourceGroup" --location "West US" \
 --script "Write-Host Hello World!" --run-command-name "myRunCommand" --vm-name "myVM" --output-blob-uri \
-https://mystorageaccount.blob.core.windows.net/mycontainer/RuncommandOutput.txt?sp=racw&st=2022-10-17T19:02:15Z&se=2022-10-18T03:02:15Z&spr=https&sv=2021-06-08&sr=b&sig=3BxtEasfdasdfasdfdYki9yvYsqc60V0%3D
+"https://mystorageaccount.blob.core.windows.net/mycontainer/RuncommandOutput.txt?sp=racw&st=2022-10-17T19:02:15Z&se=2022-10-18T03:02:15Z&spr=https&sv=2021-06-08&sr=b&sig=3BxtEasfdasdfasdfdYki9yvYsqc60V0%3D"
 """
 
 helps['vm run-command update'] = """
@@ -2650,6 +2650,8 @@ parameters:
     short-summary: "Specify the script download location."
   - name: --command-id
     short-summary: "Specify a commandId of predefined built-in script."
+  - name: --output-blob-uri
+    short-summary: "Specify the Azure storage blob (SAS URI) where script output stream will be uploaded."
   - name: --parameters
     short-summary: "The parameters used by the script."
     long-summary: |
@@ -2665,6 +2667,11 @@ examples:
 --async-execution false --parameters arg1=param1 arg2=value1 --run-as-password "<runAsPassword>" \
 --run-as-user "user1" --script "Write-Host Hello World!" --timeout-in-seconds 3600 \
 --run-command-name "myRunCommand" --vm-name "myVM"
+  - name: Update a run command with uploading script output stream to Azure storage blob (SAS URI).
+    text: |-
+           az vm run-command update --resource-group "myResourceGroup" --location "West US" \
+--script "Write-Host Hello World!" --run-command-name "myRunCommand" --vm-name "myVM" --output-blob-uri \
+"https://mystorageaccount.blob.core.windows.net/mycontainer/RuncommandOutput.txt?sp=racw&st=2022-10-17T19:02:15Z&se=2022-10-18T03:02:15Z&spr=https&sv=2021-06-08&sr=b&sig=3BxtEasfdasdfasdfdYki9yvYsqc60V0%3D"
 """
 
 helps['vm run-command delete'] = """

--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -863,7 +863,7 @@ def load_arguments(self, _):
             c.argument('run_as_user', help='By default script process runs under system/root user. Specify custom user to host the process.')
             c.argument('run_as_password', help='Password if needed for using run-as-user parameter. It will be encrypted and not logged. ')
             c.argument('timeout_in_seconds', type=int, help='The timeout in seconds to execute the run command.')
-            c.argument('output_blob_uri', help='Specify the Azure storage blob where script output stream will be uploaded.')
+            c.argument('output_blob_uri', help='Specify the Azure storage blob (SAS URI) where script output stream will be uploaded.')
             c.argument('error_blob_uri', help='Specify the Azure storage blob where script error stream will be uploaded.')
 
     with self.argument_context('vm run-command delete') as c:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az vm run-command create`
`az vm run-command update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
User used `--output-blob-uri` parameter to upload the output of executing a script on a VM to a Blob Storage, this solution worked properly for the past 4 months but something happened and for the past 2 weeks the upload to the --output-blob-uri is not working anymore.

Service team replied that user will need to use SAS URIs for --output-blob-uri to work. This is a recent change since Sep 20 or so. They've stopped auto-generating SAS URIs on behalf of users due to security concerns. Users need to use SAS URI with racw permissions (Read, Append, Create, Write)

Close #24095

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Compute] `az vm run-command create/update`: Change help messages and add examples for `--output-blob-uri` parameter to illustrate that `--output-blob-uri` must be SAS URI

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
