### PR TITLE
{Core} Log allow_broker configuration in telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -858,6 +858,8 @@ def _create_identity_instance(cli_ctx, *args, **kwargs):
 
     # PREVIEW: On Windows, use core.allow_broker=true to use broker (WAM) for authentication.
     allow_broker = cli_ctx.config.getboolean('core', 'allow_broker', fallback=False)
+    from .telemetry import set_wam_info
+    set_wam_info(allow_broker=allow_broker)
 
     return Identity(*args, encrypt=encrypt, use_msal_http_cache=use_msal_http_cache, allow_broker=allow_broker,
                     **kwargs)

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -67,6 +67,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.suppress_new_event = False
         self.poll_start_time = None
         self.poll_end_time = None
+        self.allow_broker = None
 
     def add_event(self, name, properties):
         for key in self.instrumentation_key:
@@ -206,6 +207,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'PollEndTime', str(self.poll_end_time))
         set_custom_properties(result, 'CloudName', _get_cloud_name())
         set_custom_properties(result, 'ShowSurveyMessage', str(self.show_survey_message))
+        set_custom_properties(result, 'AllowBroker', str(self.allow_broker))
 
         return result
 
@@ -423,6 +425,12 @@ def set_raw_command_name(command):
 def set_survey_info(show_survey_message):
     # whether showed the intercept survey message or not
     _session.show_survey_message = show_survey_message
+
+
+@decorators.suppress_all_exceptions()
+def set_wam_info(allow_broker):
+    # whether customer has configured `allow_broker` to enable WAM(Web Account Manager) login for authentication
+    _session.allow_broker = allow_broker
 
 
 @decorators.suppress_all_exceptions()


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #23956

This PR adds `allow_broker` configuration in telemetry when it's loaded and used for calling `msal`

**Testing Guide**
<!--Example commands with explanations.-->
Scenario 1: Test telemetry logging when no `allow_broker` is configured
- Run commands:
  `az login`
  `az group show -g {resource_group_name}`

- Open `$home_dir/.azure/telemetry/cache` file and check the record data, you will find `"Context.Default.AzureCLI.AllowBroker": "None"` for both commands

Scenario 2: Test telemetry logging when `allow_broker` is configured as `true`
- Config with `az config set core.allow_broker=true`
- Run commands:
  `az version`
  `az login`
  `az group show -g {resource_group_name}`

- Open `$home_dir/.azure/telemetry/cache` file and check the record data, you will find
  `"Context.Default.AzureCLI.AllowBroker": "None"` for the first command, as `az version` doesn't need auth, no msal call stack
  `"Context.Default.AzureCLI.AllowBroker": "True"` for the other two commands, this configuration is used for calling msal auth

Scenario 3: Test telemetry logging when `allow_broker` is configured as `false`
- Config with `az config set core.allow_broker=false`
- Run commands:
  `az version`
  `az login`
  `az group show -g {resource_group_name}`

- Open `$home_dir/.azure/telemetry/cache` file and check the record data, you will find
  `"Context.Default.AzureCLI.AllowBroker": "None"` for the first command, as `az version` doesn't need auth, no msal call stack
  `"Context.Default.AzureCLI.AllowBroker": "False"` for the other two commands, this configuration is used for calling msal auth



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
