### PR TITLE
[Role] `az role assignment create`: Support bring-your-own role assignment name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -690,7 +690,7 @@ examples:
     text: az role assignment create --assignee sp_name --role a_role
   - name: Create role assignment for an assignee with description and condition.
     text: >-
-        az role assignment create --role "Owner" --assignee "Jhon.Doe@Contoso.com"
+        az role assignment create --role "Owner" --assignee "John.Doe@Contoso.com"
         --description "Role assignment foo to check on bar"
         --condition "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name] stringEquals 'foo'"
         --condition-version "2.0"
@@ -699,6 +699,8 @@ examples:
     text: |
         az role assignment create --assignee 00000000-0000-0000-0000-000000000000 --role "Storage Account Key Operator Service Role" --scope $id
     crafted: true
+  - name: Create role assignment with your own assignment name.
+    text: az role assignment create --assignee-object-id 00000000-0000-0000-0000-000000000000 --assignee-principal-type ServicePrincipal --role Reader --scope /subscriptions/00000000-0000-0000-0000-000000000000 --name 00000000-0000-0000-0000-000000000000
 """
 
 

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -316,6 +316,8 @@ def load_arguments(self, _):
         c.argument('description', is_preview=True, min_api='2020-04-01-preview', help='Description of role assignment.')
         c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
         c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')
+        c.argument('assignment_name', name_arg_type,
+                   help='Name of the role assignment. If omitted, a new GUID is generetd.')
 
     time_help = ('The {} of the query in the format of %Y-%m-%dT%H:%M:%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}')
     with self.argument_context('role assignment list-changelogs') as c:

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -146,7 +146,7 @@ def _search_role_definitions(cli_ctx, definitions_client, name, scopes, custom_r
 
 def create_role_assignment(cmd, role, assignee=None, assignee_object_id=None, resource_group_name=None,
                            scope=None, assignee_principal_type=None, description=None,
-                           condition=None, condition_version=None):
+                           condition=None, condition_version=None, assignment_name=None):
     """Check parameters are provided correctly, then call _create_role_assignment."""
     if bool(assignee) == bool(assignee_object_id):
         raise CLIError('usage error: --assignee STRING | --assignee-object-id GUID')
@@ -178,7 +178,8 @@ def create_role_assignment(cmd, role, assignee=None, assignee_object_id=None, re
     try:
         return _create_role_assignment(cmd.cli_ctx, role, object_id, resource_group_name, scope, resolve_assignee=False,
                                        assignee_principal_type=principal_type, description=description,
-                                       condition=condition, condition_version=condition_version)
+                                       condition=condition, condition_version=condition_version,
+                                       assignment_name=assignment_name)
     except Exception as ex:  # pylint: disable=broad-except
         if _error_caused_by_role_assignment_exists(ex):  # for idempotent
             return list_role_assignments(cmd, assignee, role, resource_group_name, scope)[0]
@@ -187,8 +188,9 @@ def create_role_assignment(cmd, role, assignee=None, assignee_object_id=None, re
 
 def _create_role_assignment(cli_ctx, role, assignee, resource_group_name=None, scope=None,
                             resolve_assignee=True, assignee_principal_type=None, description=None,
-                            condition=None, condition_version=None):
+                            condition=None, condition_version=None, assignment_name=None):
     """Prepare scope, role ID and resolve object ID from Graph API."""
+    assignment_name = assignment_name or _gen_guid()
     factory = _auth_client_factory(cli_ctx, scope)
     assignments_client = factory.role_assignments
     definitions_client = factory.role_definitions
@@ -198,7 +200,7 @@ def _create_role_assignment(cli_ctx, role, assignee, resource_group_name=None, s
     role_id = _resolve_role_id(role, scope, definitions_client)
     object_id = _resolve_object_id(cli_ctx, assignee) if resolve_assignee else assignee
     worker = MultiAPIAdaptor(cli_ctx)
-    return worker.create_role_assignment(assignments_client, _gen_guid(), role_id, object_id, scope,
+    return worker.create_role_assignment(assignments_client, assignment_name, role_id, object_id, scope,
                                          assignee_principal_type, description=description,
                                          condition=condition, condition_version=condition_version)
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -22,6 +22,9 @@ from ..util import retry
 from .test_graph import GraphScenarioTestBase
 
 
+TEST_TENANT_DOMAIN = '@azuresdkteam.onmicrosoft.com'
+
+
 class RoleScenarioTestBase(GraphScenarioTestBase):
 
     def run_under_service_principal(self):
@@ -258,7 +261,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             user = self.create_random_name('testuser', 15)
             self.kwargs.update({
-                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'upn': user + TEST_TENANT_DOMAIN,
                 'nsg': 'nsg1'
             })
 
@@ -331,11 +334,29 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
                          checks=self.check("length([])", 1))
                 self.cmd('role assignment delete --assignee {upn} --role reader')
 
-                # test role assignment on empty scope
+                # Test bring-your-own assignment name
+                self.kwargs['assignment_name'] = self.create_guid()
+                # Directly use GUID to avoid querying definition ID and reduce recording YAML size
+                # https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+                self.kwargs['reader_guid'] = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
+                result = self.cmd('role assignment create --assignee {upn} '
+                                  '--role {reader_guid} --name {assignment_name}').get_output_in_json()
+                self.kwargs['assignment_id'] = result['id']
+                # Should be idempotent
+                self.cmd('role assignment create --assignee {upn} --role {reader_guid} --name {assignment_name}')
+                self.cmd('role assignment list --assignee {upn} --role {reader_guid}',
+                         checks=[self.check("length([])", 1), self.check("[0].name", '{assignment_name}')])
+                # Delete by assignment id
+                self.cmd('role assignment delete --ids {assignment_id}')
+
+                # test create role assignment for invalid assignee
                 with self.assertRaisesRegex(CLIError, "Cannot find user or service principal in graph database for 'fake'."):
                     self.cmd('role assignment create --assignee fake --role contributor')
             finally:
-                self.cmd('ad user delete --id {upn}')
+                try:
+                    self.cmd('ad user delete --id {upn}')
+                except:
+                    pass
 
     @ResourceGroupPreparer(name_prefix='cli_role_assign')
     @AllowLargeResponse()
@@ -390,7 +411,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             # User
             user = self.create_random_name('testuser', 15)
-            self.kwargs['upn'] = user + '@azuresdkteam.onmicrosoft.com'
+            self.kwargs['upn'] = user + TEST_TENANT_DOMAIN
 
             result = self.cmd('ad user create --display-name tester123 --password Test123456789 '
                               '--user-principal-name {upn}').get_output_in_json()
@@ -439,7 +460,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             user = self.create_random_name('testuser', 15)
             self.kwargs.update({
-                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'upn': user + TEST_TENANT_DOMAIN,
                 'rg': resource_group,
                 'description': "Role assignment foo to check on bar",
                 'condition': "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:Name] stringEquals 'foo'",
@@ -512,7 +533,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             user = self.create_random_name('testuser', 15)
             self.kwargs.update({
-                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'upn': user + TEST_TENANT_DOMAIN,
                 'nsg': 'nsg1'
             })
 
@@ -565,7 +586,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
             user = self.create_random_name('testuser', 15)
             mgmt_grp = self.create_random_name('mgmt_grp', 15)
             self.kwargs.update({
-                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'upn': user + TEST_TENANT_DOMAIN,
                 'mgmt_grp': mgmt_grp
             })
 
@@ -606,7 +627,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
         with mock.patch('azure.cli.command_modules.role.custom._gen_guid', side_effect=self.create_guid):
             user = self.create_random_name('testuser', 15)
             self.kwargs.update({
-                'upn': user + '@azuresdkteam.onmicrosoft.com',
+                'upn': user + TEST_TENANT_DOMAIN,
             })
 
             self.cmd('ad user create --display-name tester123 --password Test123456789 --user-principal-name {upn}')


### PR DESCRIPTION
Close #23770

**Related command**
`az role assignment create`

**Description**<!--Mandatory-->
As reported in #23770, `az role assignment create` internally calls ARM RBAC API [Role Assignments - Create](https://learn.microsoft.com/en-us/rest/api/authorization/role-assignments/create?tabs=HTTP).

Even though Azure CLI generates a new GUID each time with Python's built-in [`uuid.uuid4()`](https://docs.python.org/3/library/uuid.html#uuid.uuid4) function:

https://github.com/Azure/azure-cli/blob/98f7865402569ec9a6ae05ccdd0d27d5ea20927c/src/azure-cli/azure/cli/command_modules/role/custom.py#L1563-L1564

RBAC API randomly fails with:

```
ERROR: A hash conflict was encountered for the role Assignment ID. Please use a new Guid.
```

This has been identified as a service issue and RBAC team is working on a fix.

Meanwhile, this PR makes it possible to bring your own role assignment name. User can now use a constant assignment name each time, thus making the entire flow rock-solid.

**Testing Guide**
```
az role assignment create --assignee-object-id 00000000-0000-0000-0000-000000000000 --assignee-principal-type ServicePrincipal --role Reader --scope /subscriptions/00000000-0000-0000-0000-000000000000 --name 00000000-0000-0000-0000-000000000000
```

**Additional information**
Once `az role assignment create` supports bring your own assignment name, `az role assignment show` can be implemented to show exact one assignment. Similarly, `az role assignment delete` should be extended to support `--scope` + `--name` as well (https://github.com/Azure/azure-cli/issues/24317).

