### PR TITLE
{CI} pytest: `--boxed` argument is deprecated, use `--forked` instead

### DIFF
--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -10,7 +10,7 @@ import subprocess
 root_dir = '/opt/az/lib/python3.10/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --boxed -p no:warnings --log-level=WARN'
+pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
 

--- a/scripts/release/homebrew/test_homebrew_package.py
+++ b/scripts/release/homebrew/test_homebrew_package.py
@@ -17,7 +17,7 @@ python_version = sys.argv[2]
 root_dir = '{}/lib/{}/site-packages/azure/cli/command_modules'.format(az_base, python_version)
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --boxed -p no:warnings --log-level=WARN'.format(az_base, python_version)
+pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --forked -p no:warnings --log-level=WARN'.format(az_base, python_version)
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -11,7 +11,7 @@ python_version = os.listdir('/usr/lib64/az/lib/')[0]
 root_dir = f'/usr/lib64/az/lib/{python_version}/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -x -v --boxed -p no:warnings --log-level=WARN'
+pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -x -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
 


### PR DESCRIPTION
The latest pytest-xdist 3.0.2 (2022-10-25) has [removed](https://pytest-xdist.readthedocs.io/en/latest/changelog.html#removals) `--boxed` argument.
But we still need this functionality, install [pytest-forked](https://pypi.org/project/pytest-forked) separately and use `--forked` instead.
Error log:
```
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --boxed
  inifile: None
  rootdir: /mnt/vss/_work/1/s/src/azure-cli-core
```
Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/197946163-206d4c2b-3aa9-480f-a61f-b2113a858c05.png)
![image](https://user-images.githubusercontent.com/18628534/197946207-c57f8e73-7463-484e-8a8b-dcbd525b8d28.png)
