### PR TITLE
[Network] `az network bastion rdp`: Allow rdp session customization

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_params.py
@@ -2146,6 +2146,7 @@ def load_arguments(self, _):
         c.argument('ssh_key', help='SSH key file location for SSH connections.', options_list=['--ssh-key'])
     with self.argument_context('network bastion rdp') as c:
         c.argument('disable_gateway', arg_type=get_three_state_flag(), help='Flag to disable access through RD gateway.')
+        c.argument('configure', help='Flag to configure RDP session.', action='store_true')
     with self.argument_context('network bastion tunnel') as c:
         c.argument('port', help='Local port to use for the tunneling.', options_list=['--port'])
         c.argument('timeout', help='Timeout for connection to bastion host tunnel.', options_list=['--timeout'])

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8271,7 +8271,7 @@ def ssh_bastion_host(cmd, auth_type, target_resource_id, resource_group_name, ba
         tunnel_server.cleanup()
 
 
-def rdp_bastion_host(cmd, target_resource_id, resource_group_name, bastion_host_name, resource_port=None, disable_gateway=False):
+def rdp_bastion_host(cmd, target_resource_id, resource_group_name, bastion_host_name, resource_port=None, disable_gateway=False, configure=False):
     from azure.cli.core._profile import Profile
     import os
     from ._process_helper import launch_and_wait
@@ -8307,7 +8307,10 @@ def rdp_bastion_host(cmd, target_resource_id, resource_group_name, bastion_host_
             with open("conn.rdp", "w") as f:
                 f.write(response.text)
             rdpfilepath = os.getcwd() + "/conn.rdp"
-            command = [_get_rdp_path(), rdpfilepath]
+            command = [_get_rdp_path()]
+            if (configure):
+                command.append("/edit")
+            command.append(rdpfilepath)
             launch_and_wait(command)
     else:
         raise UnrecognizedArgumentError("Platform is not supported for this command. Supported platforms: Windows")

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -8308,7 +8308,7 @@ def rdp_bastion_host(cmd, target_resource_id, resource_group_name, bastion_host_
                 f.write(response.text)
             rdpfilepath = os.getcwd() + "/conn.rdp"
             command = [_get_rdp_path()]
-            if (configure):
+            if configure:
                 command.append("/edit")
             command.append(rdpfilepath)
             launch_and_wait(command)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az network bastion rdp --name {} --resource-group {} --target-resource-id {}
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

When connecting to bastion via RDP using Native Client, the session defaults to using all available monitors. But this may not always be the prefered by customers as mentioned in #23866.

Currently, customers have to disconnect from the session, either manually edit the RDP file or edit it using the Remote Desktop Connection UI, and then reconnect.

This PR adds a flag, `--configure`, which opens the Remote Desktop Connection UI instead of connecting directly, allowing customers to customize the session as required.

resolves #23866 

**Testing Guide**
<!--Example commands with explanations.-->

```sh
az network bastion rdp --name {} --resource-group {} --target-resource-id {} --configure
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
