### PR TITLE
{CI} Revert #24407 pytest: `--boxed` argument is deprecated, use `--forked` instead

### DIFF
--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -10,7 +10,7 @@ import subprocess
 root_dir = '/opt/az/lib/python3.10/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --forked -p no:warnings --log-level=WARN'
+pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --boxed -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
 

--- a/scripts/release/homebrew/test_homebrew_package.py
+++ b/scripts/release/homebrew/test_homebrew_package.py
@@ -17,7 +17,7 @@ python_version = sys.argv[2]
 root_dir = '{}/lib/{}/site-packages/azure/cli/command_modules'.format(az_base, python_version)
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --forked -p no:warnings --log-level=WARN'.format(az_base, python_version)
+pytest_base_cmd = 'PYTHONPATH={}/lib/{}/site-packages python -m pytest -x -v --boxed -p no:warnings --log-level=WARN'.format(az_base, python_version)
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 
 for mod_name in mod_list:

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -11,7 +11,7 @@ python_version = os.listdir('/usr/lib64/az/lib/')[0]
 root_dir = f'/usr/lib64/az/lib/{python_version}/site-packages/azure/cli/command_modules'
 mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path.join(root_dir, mod)) and mod != '__pycache__']
 
-pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -x -v --forked -p no:warnings --log-level=WARN'
+pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -x -v --boxed -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
 serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
 


### PR DESCRIPTION
Reverts Azure/azure-cli#24407
It seems we run these scripts in docker.

- scripts/release/debian/test_deb_package.py

- scripts/release/homebrew/test_homebrew_package.py

- scripts/release/rpm/test_rpm_package.py

And we need revert #24407 unless we use the latest pytest-xdist in docker images.
![image](https://user-images.githubusercontent.com/18628534/198196429-c04fdb54-11b5-4b91-b7dd-435b0f9de699.png)
![image](https://user-images.githubusercontent.com/18628534/198196506-c093823a-c6d3-4049-b60d-0098ffaee1aa.png)
