### PR TITLE
{CI} Install pytest-forked for docker image

### DIFF
--- a/scripts/release/debian/test_deb_in_docker.sh
+++ b/scripts/release/debian/test_deb_in_docker.sh
@@ -26,6 +26,7 @@ ln -sf /opt/az/bin/python3 /usr/bin/python
 
 /opt/az/bin/python3 -m pip install pytest
 /opt/az/bin/python3 -m pip install pytest-xdist
+/opt/az/bin/python3 -m pip install pytest-forked
 
 find /azure-cli/artifacts/build -name "azure_cli_testsdk*" | xargs /opt/az/bin/python3 -m pip install --upgrade --ignore-installed
 find /azure-cli/artifacts/build -name "azure_cli_fulltest*" | xargs /opt/az/bin/python3 -m pip install --upgrade --ignore-installed --no-deps

--- a/scripts/release/homebrew/test_homebrew_package.sh
+++ b/scripts/release/homebrew/test_homebrew_package.sh
@@ -18,6 +18,7 @@ pip install wheel
 ./scripts/ci/build.sh
 pip install pytest --prefix $AZ_BASE
 pip install pytest-xdist --prefix $AZ_BASE
+pip install pytest-forked --prefix $AZ_BASE
 
 find ./artifacts/build -name "azure_cli_testsdk*" | xargs pip install --prefix $AZ_BASE --upgrade --ignore-installed
 find ./artifacts/build -name "azure_cli_fulltest*" | xargs pip install --prefix $AZ_BASE --upgrade --ignore-installed --no-deps

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -25,6 +25,7 @@ export RPM_BUILD_ROOT=/
 
 pip install pytest --prefix /usr/lib64/az
 pip install pytest-xdist --prefix /usr/lib64/az
+pip install pytest-forked --prefix /usr/lib64/az
 
 find /azure-cli/artifacts/build -name "azure_cli_testsdk*" | xargs pip install --prefix /usr/lib64/az --upgrade --ignore-installed
 find /azure-cli/artifacts/build -name "azure_cli_fulltest*" | xargs pip install --prefix /usr/lib64/az --upgrade --ignore-installed --no-deps


### PR DESCRIPTION
The CI pipeline error is as follows:
![image](https://user-images.githubusercontent.com/18628534/198196429-c04fdb54-11b5-4b91-b7dd-435b0f9de699.png)
![image](https://user-images.githubusercontent.com/18628534/198196506-c093823a-c6d3-4049-b60d-0098ffaee1aa.png)

We run these test scripts in docker.
- scripts/releases/debian/test_deb_package.py
- scripts/release/homebrew/test_homebrew_package.py
- scripts/releases/rpm/test_rpm_package.py

But I only have the latest pytest-forked installed in azdev(Azure/azure-cli-dev-tools#347), which only works when using the `azdev test` command.
We also need to install the latest pytest-forked in docker as well.
Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/198220742-d550ed77-746b-4570-b1a5-8fb55f58c15f.png)
