### PR TITLE
{CI} Fix template not found error: Use absolute path for variable template

### DIFF
--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: AutomationTest20200901

--- a/azure-pipelines-full-tests.yml
+++ b/azure-pipelines-full-tests.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: AutomationTest20200901

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: $(Pipeline.Workspace)/azure-cli/.azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/azure-cli/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: CheckPullRequest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: script/live_test/../../.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: CheckPullRequest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: CheckPullRequest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: script/live_test/../../.azure-pipelines/templates/variables.yml
+- template: $(Pipeline.Workspace)/azure-cli/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: CheckPullRequest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/azure-cli/.azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: CheckPullRequest

--- a/scripts/live_test/CLITest.yml
+++ b/scripts/live_test/CLITest.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ../../.azure-pipelines/templates/variables.yml
 
 #schedules:
 #- cron: "0 18 * * 5"

--- a/scripts/live_test/CLITest.yml
+++ b/scripts/live_test/CLITest.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
 
 variables:
-- template: ../../.azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 #schedules:
 #- cron: "0 18 * * 5"

--- a/scripts/live_test/CLITest.yml
+++ b/scripts/live_test/CLITest.yml
@@ -12,7 +12,7 @@ trigger:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 #schedules:
 #- cron: "0 18 * * 5"

--- a/scripts/live_test/gen.yml
+++ b/scripts/live_test/gen.yml
@@ -4,7 +4,7 @@ trigger:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: Gen

--- a/scripts/live_test/gen.yml
+++ b/scripts/live_test/gen.yml
@@ -4,7 +4,7 @@ trigger:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: Gen

--- a/scripts/live_test/monitor.yml
+++ b/scripts/live_test/monitor.yml
@@ -4,7 +4,7 @@ trigger:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: Monitor

--- a/scripts/live_test/monitor.yml
+++ b/scripts/live_test/monitor.yml
@@ -4,7 +4,7 @@ trigger:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: Monitor

--- a/scripts/live_test/template.yml
+++ b/scripts/live_test/template.yml
@@ -6,7 +6,7 @@ trigger:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 schedules:
 - cron: "0 18 * * 5"

--- a/scripts/live_test/template.yml
+++ b/scripts/live_test/template.yml
@@ -6,7 +6,7 @@ trigger:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 schedules:
 - cron: "0 18 * * 5"

--- a/scripts/regression_test/regression_test.yml
+++ b/scripts/regression_test/regression_test.yml
@@ -9,7 +9,7 @@ trigger:
     - '*'
 
 variables:
-- template: .azure-pipelines/templates/variables.yml
+- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: UpdateVersionFiles

--- a/scripts/regression_test/regression_test.yml
+++ b/scripts/regression_test/regression_test.yml
@@ -9,7 +9,7 @@ trigger:
     - '*'
 
 variables:
-- template: ${{variables['Pipeline.Workspace']}}/.azure-pipelines/templates/variables.yml
+- template: ${{ variables.Pipeline.Workspace }}/.azure-pipelines/templates/variables.yml
 
 jobs:
 - job: UpdateVersionFiles


### PR DESCRIPTION
Azure CLI Live Test pipeline will report an error:
```
/scripts/live_test/CLITest.yml: Could not find /scripts/live_test/.azure-pipelines/templates/variables.yml in repository self hosted on https://github.com/ using commit 8444d8686d50a1c1378273efbd05101e02d2c36d. GitHub reported the error, "Not Found"
```
Because the template path uses **relative path by default**, so except for the pipeline script in the root directory, other pipeline scripts cannot find the variable template.
This PR will use absolute path for variable template in all pipeline scripts


![image](https://user-images.githubusercontent.com/18628534/198234174-5091eea6-1389-4525-acbd-8a555ef23a08.png)
Test screenshot:

![image](https://user-images.githubusercontent.com/18628534/198234367-ef0d08a7-6e2d-43d8-bd86-832e6636696f.png)
