### PR TITLE
{Extension} `az extension add`: Enable `--upgrade` when install extension from `--source`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -308,6 +308,7 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
                   pip_extra_index_urls=None, pip_proxy=None, system=None,
                   version=None, cli_ctx=None, upgrade=None):
     ext_sha256 = None
+    update_to_latest = version == 'latest' and not source
 
     version = None if version == 'latest' else version
     cmd_cli_ctx = cli_ctx or cmd.cli_ctx
@@ -332,7 +333,8 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
             if not upgrade:
                 return
             if ext_version == ext.get_version():
-                logger.warning("Latest version of '%s' is already installed.", extension_name)
+                if update_to_latest:
+                    logger.warning("Latest version of '%s' is already installed.", extension_name)
                 return
 
             logger.warning("It will be overridden with version %s.", ext_version)

--- a/src/azure-cli-core/azure/cli/core/extension/operations.py
+++ b/src/azure-cli-core/azure/cli/core/extension/operations.py
@@ -313,32 +313,32 @@ def add_extension(cmd=None, source=None, extension_name=None, index_url=None, ye
     cmd_cli_ctx = cli_ctx or cmd.cli_ctx
     if extension_name:
         cmd_cli_ctx.get_progress_controller().add(message='Searching')
-        ext = None
-        set_extension_management_detail(extension_name, version)
-        try:
-            ext = get_extension(extension_name)
-        except ExtensionNotInstalledException:
-            pass
-        if ext:
-            if isinstance(ext, WheelExtension):
-                if not upgrade:
-                    logger.warning("Extension '%s' is already installed.", extension_name)
-                    return
-                logger.warning("Extension '%s' %s is already installed.", extension_name, ext.get_version())
-                if version and version == ext.get_version():
-                    return
-                logger.warning("It will be overridden with version {}.".format(version) if version else "It will be updated if available.")
-                update_extension(cmd=cmd, extension_name=extension_name, index_url=index_url, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, cli_ctx=cli_ctx, version=version)
-                return
-            logger.warning("Overriding development version of '%s' with production version.", extension_name)
         try:
             source, ext_sha256 = resolve_from_index(extension_name, index_url=index_url, target_version=version, cli_ctx=cmd_cli_ctx)
         except NoExtensionCandidatesError as err:
             logger.debug(err)
             err = "{}\n\nUse --debug for more information".format(err.args[0])
             raise CLIError(err)
-    ext_name, ext_version = _get_extension_info_from_source(source)
-    set_extension_management_detail(extension_name if extension_name else ext_name, ext_version)
+    extension_name, ext_version = _get_extension_info_from_source(source)
+    set_extension_management_detail(extension_name, ext_version)
+    ext = None
+    try:
+        ext = get_extension(extension_name)
+    except ExtensionNotInstalledException:
+        pass
+    if ext:
+        if isinstance(ext, WheelExtension):
+            logger.warning("Extension '%s' %s is already installed.", extension_name, ext.get_version())
+            if not upgrade:
+                return
+            if ext_version == ext.get_version():
+                logger.warning("Latest version of '%s' is already installed.", extension_name)
+                return
+
+            logger.warning("It will be overridden with version %s.", ext_version)
+            update_extension(cmd=cmd, extension_name=extension_name, index_url=index_url, pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, cli_ctx=cli_ctx, version=ext_version, download_url=source, ext_sha256=ext_sha256)
+            return
+        logger.warning("Overriding development version of '%s' with production version.", extension_name)
     extension_name = _add_whl_ext(cli_ctx=cmd_cli_ctx, source=source, ext_sha256=ext_sha256,
                                   pip_extra_index_urls=pip_extra_index_urls, pip_proxy=pip_proxy, system=system)
     try:
@@ -387,13 +387,14 @@ def show_extension(extension_name):
         raise CLIError(e)
 
 
-def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_index_urls=None, pip_proxy=None, cli_ctx=None, version=None):
+def update_extension(cmd=None, extension_name=None, index_url=None, pip_extra_index_urls=None, pip_proxy=None, cli_ctx=None, version=None, download_url=None, ext_sha256=None):
     try:
         cmd_cli_ctx = cli_ctx or cmd.cli_ctx
         ext = get_extension(extension_name, ext_type=WheelExtension)
         cur_version = ext.get_version()
         try:
-            download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url, target_version=version, cli_ctx=cmd_cli_ctx)
+            if not download_url:
+                download_url, ext_sha256 = resolve_from_index(extension_name, cur_version=cur_version, index_url=index_url, target_version=version, cli_ctx=cmd_cli_ctx)
             _, ext_version = _get_extension_info_from_source(download_url)
             set_extension_management_detail(extension_name, ext_version)
         except NoExtensionCandidatesError as err:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az extension add`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Currently, `--upgrade` is ignored when install extension from source. It raises `the extension already exists` rather than upgrade the extension.

I change the logic of `add_extension` to make sure `update_extension` is executed regardless of using `name` or `source`.

Fix https://github.com/Azure/azure-cli-extensions/issues/5491

**Testing Guide**
` az extension add --name azurestackhci --version "0.2.3"  --upgrade`
` az extension add --source "https://hybridaksstorage.z13.web.core.windows.net/SelfServiceVM/CLI/azurestackhci-0.2.5-py3-none-any.whl" --verbose --yes --upgrade`
`0.2.5` should be installed now.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
