### PR TITLE
[ARM] `az group lock list`: Mark the `--resource-group` as required in help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -539,6 +539,9 @@ def load_arguments(self, _):
     with self.argument_context('group lock') as c:
         c.argument('resource_group', resource_group_name_type, validator=validate_group_lock, id_part=None)
 
+    with self.argument_context('group lock list') as c:
+        c.argument('resource_group', resource_group_name_type, id_part=None, required=True)
+
     with self.argument_context('group lock create') as c:
         c.argument('resource_group', required=True)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -278,6 +278,10 @@ def load_arguments(self, _):
         c.argument('tags', tags_type)
         c.argument('resource_group_name', resource_group_name_type, options_list=['--name', '-n', '--resource-group', '-g'])
 
+    with self.argument_context('group update') as c:
+        c.argument('properties_to_add', deprecate_info=c.deprecate(hide=True))
+        c.argument('properties_to_remove', deprecate_info=c.deprecate(hide=True))
+
     with self.argument_context('group deployment') as c:
         c.argument('resource_group_name', arg_type=resource_group_name_type, completer=get_resource_group_completion_list)
         c.argument('deployment_name', arg_type=deployment_name_type)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az group lock list`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Issue -close: #24452

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
