### PR TITLE
{Core} Make parser compatible with Python 3.11's `argparse`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/parser.py
+++ b/src/azure-cli-core/azure/cli/core/parser.py
@@ -90,9 +90,6 @@ class AzCliCommandParser(CLICommandParser):
                 continue
 
             command_verb = command_name.split()[-1]
-            # To work around http://bugs.python.org/issue9253, we artificially add any new
-            # parsers we add to the "choices" section of the subparser.
-            subparser.choices[command_verb] = command_verb
 
             # inject command_module designer's help formatter -- default is HelpFormatter
             fc = metadata.formatter_class or argparse.HelpFormatter


### PR DESCRIPTION
**Description**<!--Mandatory-->

Fix https://github.com/Azure/azure-cli/issues/23015
A rework of #24109

Python 3.11 updated `argparse`'s behavior:

https://docs.python.org/3.11/whatsnew/changelog.html#id50

> bpo-39716: Raise an ArgumentError when the same subparser name is added twice to an `argparse.ArgumentParser`. This is consistent with the (default) behavior when the same option string is added twice to an ArgumentParser.

The PR for this change is https://github.com/python/cpython/pull/18605

Per Git blame,

- `subparser.choices[command_verb] = command_verb` was renamed from `subparser.choices[command_name] = command_name` by https://github.com/Azure/azure-cli/commit/517872af1912ba7a2cd251999e7675546fbd495f
- `subparser.choices[command_name] = command_name` was introduced as early as https://github.com/Azure/azure-cli/commit/2a6f545aee7b29afd90e01af28356507f0f0f606

Running this line makes `subparser.choices` a `str:str` mapping.

In `argparse._SubParsersAction`, `self.choices` is the same `dict` object as `self._name_parser_map`:

https://github.com/python/cpython/blob/v3.10.8/Lib/argparse.py#L1159

```py
class _SubParsersAction(Action):
    ...
    def __init__(self,
        ....
        super(_SubParsersAction, self).__init__(
            ...
            choices=self._name_parser_map,
```

https://github.com/python/cpython/blob/v3.10.8/Lib/argparse.py#L769

```py
class Action(_AttributeHolder):
    ...
    def __init__(self,
        ...
        self.choices = choices
```

Later, in `argparse._SubParsersAction.add_parser`, `self._name_parser_map`'s `command_verb` key is overwritten as a `str:parser` mapping:

https://github.com/Azure/azure-cli/blob/110f7b402020f3d3ebd2bfb923ac5a01d026cdd1/src/azure-cli-core/azure/cli/core/parser.py#L100

https://github.com/python/cpython/blob/v3.10.8/Lib/argparse.py#L1179

```py
    def add_parser(self, name, **kwargs):
        ...
        self._name_parser_map[name] = parser
```

Before running this line:

![image](https://user-images.githubusercontent.com/4003950/198928678-f8b75788-a057-4c9d-9b9f-e65d1dc0a831.png)

After running this line:

![image](https://user-images.githubusercontent.com/4003950/198928714-e1284925-04b2-4f73-89a6-a3d31eca842f.png)

So `subparser.choices[command_verb] = command_verb` is basically a no-op, but it starts to cause failure in Python 3.11 due to the new duplication check.

I am not sure why `subparser.choices[command_verb] = command_verb` was introduced by https://github.com/Azure/azure-cli/commit/2a6f545aee7b29afd90e01af28356507f0f0f606 6 years ago, possibly due to some Python 2 `argparse`'s limitation?

I checked http://bugs.python.org/issue9253 mentioned in the comment, but didn't see how it is related to this workaround.

We can think it in another way. Since Python 3.11's `argparse` has no functionality change (only an additional check), if this line should removed for Python 3.11, it should also be removed for Python 3.10-.

