### PR TITLE
{CI} Add resolve issues logic

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -732,6 +732,407 @@
           "operator": "and",
           "operands": [
             {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Resolve Workflow] Issue Addressed Label Applied",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}.  Thank you for opening this issue and giving us the opportunity to assist.  We believe that this has been addressed.  If you feel that further discussion is needed, please add a comment with the text “`/unresolve`” to remove the “issue-addressed” label and continue the conversation."
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-triage"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-team-triage"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "needs-author-feedback"
+            }
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "no-recent-activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              0,
+              6,
+              12,
+              18
+            ],
+            "timezoneOffset": -4
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          }
+        ],
+        "taskName": "[Resolve Workflow] Close Addressed Issues",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${issueAuthor}, since you haven’t asked that we “`/unresolve`” the issue, we’ll close this out. If you believe further discussion is needed, please add a comment “`/unresolve`” to reopen the issue."
+            }
+          },
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "name": "commentContains",
+              "parameters": {
+                "commentPattern": "/unresolve"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "isActivitySender",
+                  "parameters": {
+                    "user": {
+                      "type": "author"
+                    }
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve Command by Author",
+        "actions": [
+          {
+            "name": "reopenIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "needs-team-attention"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "name": "commentContains",
+              "parameters": {
+                "commentPattern": "/unresolve"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "isActivitySender",
+                      "parameters": {
+                        "user": {
+                          "type": "author"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "admin"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "activitySenderHasPermissions",
+                      "parameters": {
+                        "permissions": "write"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve Command Without Permissions",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi ${contextualAuthor}, only the original author of the issue can ask that it be unresolved.  Please open a new issue with your scenario and details if you would like to discuss this topic with the team."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": "issue-addressed"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-team-attention"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-author-feedback"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "Service Attention"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-triage"
+                  }
+                },
+                {
+                  "name": "labelAdded",
+                  "parameters": {
+                    "label": "needs-team-triage"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[Resolve Workflow] Unresolve on WIP Labels",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "issue-addressed"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
               "name": "isOpen",
               "parameters": {}
             },

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -218,49 +218,49 @@
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
             "hours": [
               1
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -315,7 +315,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -325,7 +325,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -335,7 +335,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -345,7 +345,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -355,7 +355,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -365,7 +365,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -375,7 +375,7 @@
               13,
               19
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -800,7 +800,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -810,7 +810,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -820,7 +820,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -830,7 +830,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -840,7 +840,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -850,7 +850,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -860,7 +860,7 @@
               12,
               18
             ],
-            "timezoneOffset": -4
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -1185,7 +1185,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -1199,7 +1199,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -1213,7 +1213,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -1227,7 +1227,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -1241,7 +1241,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -1255,7 +1255,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -1269,7 +1269,7 @@
               19,
               22
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [
@@ -1324,7 +1324,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 1,
@@ -1338,7 +1338,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 2,
@@ -1352,7 +1352,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 3,
@@ -1366,7 +1366,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 4,
@@ -1380,7 +1380,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 5,
@@ -1394,7 +1394,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           },
           {
             "weekDay": 6,
@@ -1408,7 +1408,7 @@
               20,
               23
             ],
-            "timezoneOffset": -7
+            "timezoneOffset": 8
           }
         ],
         "searchTerms": [


### PR DESCRIPTION
Add [automated workflows](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/490/Resolving-Issues) to align with the .NET SDK repo：

1. When work on an issue is believed to be complete, the Azure SDK team member responsible for communicating that status may apply the issue-addressed label.

2. When the bot that monitors the repository detects the issue-addressed label, it will respond with the message:
“Hi @issue-author. Thank you for opening this issue and giving us the opportunity to assist. We believe that this has been resolved. If you believe that further discussion is needed, please add a comment with the text “/unresolve” to remove the "issue-addressed” label and continue the conversation.”

3. For issues where the issue-addressed label was applied:
    a. If no action is taken, the issue is closed by the bot after 7 days of no activity with the message:
“Hi @issue-author, since you haven’t asked that we “/unresolve” the issue, we’ll close this out. If you believe further discussion is needed, please add a comment “/unresolve” to reopen the issue.”

    b. If the original author of the issue uses the /unresolve command to remove the issue-addressed label, the issue is left open for continued discussion and the “needs-team-attention” label is applied.

    c. If a comment is left with the /unresolve command by a person other than the original author of the issue or an internal team member, the bot responds with the message:
“Please open a new issue with your scenario and details if you would like to discuss this topic with the team.”

    d. If the issue-addressed label is removed by an Azure SDK team member directly, the issue is left open but no additional label is applied.

    e. If an Azure SDK team member adds a label that indicates work is ongoing for the issue, the issue-addressed label is removed. The following labels are considered:
         -  needs-team-attention
         - needs-author-feedback
         - Service Attention
         - needs-triage
         - needs-team-triage