### PR TITLE
[Backup] `az backup restore restore-disks`: Documentation to get storage account ARM ID for CRR restore

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/backup/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/_params.py
@@ -348,7 +348,7 @@ def load_arguments(self, _):
         c.argument('rp_name', rp_name_type, id_part='child_name_4')
 
     with self.argument_context('backup restore restore-disks') as c:
-        c.argument('storage_account', help='Name or ID of the staging storage account. The VM configuration will be restored to this storage account. See the help for --restore-to-staging-storage-account parameter for more info.')
+        c.argument('storage_account', help='Name or ID of the staging storage account. The VM configuration will be restored to this storage account. See the help for --restore-to-staging-storage-account parameter for more info. The ID might be needed for cross-region restores where the storage account and vault are not on the same resource group. In order to get the ID, use the storage account show command as specified here (https://learn.microsoft.com/en-us/azure/storage/common/storage-account-get-info?tabs=azure-cli#get-the-resource-id-for-a-storage-account).')
         c.argument('restore_to_staging_storage_account', arg_type=get_three_state_flag(), help='Use this flag when you want disks to be restored to the staging storage account using the --storage-account parameter. When not specified, disks will be restored to their original storage accounts. Default: false.')
         c.argument('target_resource_group', options_list=['--target-resource-group', '-t'], help='Use this to specify the target resource group in which the restored disks will be saved')
         c.argument('diskslist', diskslist_type)


### PR DESCRIPTION
In the restore-disks documentation, we now specify how to get ARM resoure ID for a storage account and outline the CRR Restore scenario in which this might be needed, so users do not get stuck in such scenarios.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az backup restore restore-disks -h`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Adds a line to the help text for the command (specifically the `--storage-account` parameter), clarifying to users how to trigger a cross-region restore when the target storage account is not in the same resource group as the vault.

**Testing Guide**
<!--Example commands with explanations.-->
Run `az backup restore restore-disks -h`. The help text under Arguments>--storage-account should be:
```
--storage-account [Required] : Name or ID of the staging storage account. The VM
                               configuration will be restored to this storage account.
                               See the help for --restore-to-staging-storage-account
                               parameter for more info. The ID might be needed for
                               cross-region restores where the storage account and vault
                               are not on the same resource group. In order to get the
                               ID, use the storage account show command as specified
                               here (https://learn.microsoft.com/en-
                               us/azure/storage/common/storage-account-get-
                               info?tabs=azure-cli#get-the-resource-id-for-a-storage-
                               account).
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Restore-disks] `az backup restore restore-disks -h`: Add documentation.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
