### PR TITLE
{CI} Pin Python version to 3.10 in Test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
 
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3'
+    displayName: 'Use Python 3.10'
     inputs:
       versionSpec: 3.10
 
@@ -110,7 +110,7 @@ jobs:
 
   steps:
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3'
+    displayName: 'Use Python 3.10'
     inputs:
       versionSpec: 3.10
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3'
     inputs:
-      versionSpec: 3.x
+      versionSpec: 3.10
 
   - bash: ./scripts/ci/dependency_check.sh
     displayName: 'Verify src/azure-cli/requirements.py3.Linux.txt'
@@ -112,7 +112,7 @@ jobs:
   - task: UsePythonVersion@0
     displayName: 'Use Python 3'
     inputs:
-      versionSpec: 3.x
+      versionSpec: 3.10
 
   - bash: ./scripts/ci/dependency_check.sh
     displayName: 'Verify src/azure-cli/requirements.py3.Darwin.txt'


### PR DESCRIPTION
macOS starts to use 3.11, but Azure-cli is not compatible with 3.11. Pin python version to 3.10 in both macOS and Linux.
```
Found tool in cache: Python 3.11.0 x64
Prepending PATH environment variable with directory: /Users/runner/hostedtoolcache/Python/3.11.0/x64
```

Related failed test: https://dev.azure.com/azclitools/public/_build/results?buildId=12468&view=logs&jobId=537f1e04-c6d5-53b2-3a1f-f7387cc6e02d&j=537f1e04-c6d5-53b2-3a1f-f7387cc6e02d&t=cae9a690-b596-5b1d-0d0e-9efe890cb6db