### PR TITLE
{IoT} Fix certificate filename conflict in test

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_dps_commands.py
@@ -129,10 +129,11 @@ class IoTDpsTest(ScenarioTest):
         chain_name = self.create_random_name(prefix='certificate-', length=48)
 
         # Set up cert file for test
-        verification_file = "verify.cer"
-        cert_file = "testcert.cer"
-        key_file = "testkey.pvk"
-        chain_file = "testcert-chain.pem"
+        random_suffix = self.create_random_name(prefix='_', length=6)
+        verification_file = f"verify{random_suffix}.cer"
+        cert_file = f"testcert{random_suffix}.cer"
+        key_file = f"testkey{random_suffix}.pvk"
+        chain_file = f"testcert-chain{random_suffix}.pem"
         max_int = 9223372036854775807
         _create_test_cert(cert_file, key_file, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, max_int))
         _create_fake_chain_cert(cert_file, chain_file)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In `test_dps_certificate_lifecycle` and `test_certificate_lifecycle`, they use same filenames:
```py
VERIFICATION_FILE = "verify.cer"
CERT_FILE = "testcert.cer"
KEY_FILE = "testkey.pvk"
CHAIN_FILE = "testcert-chain.pem"
```
These files will be removed after test. When executed in parallel, the `FileNotFoundError` error sometimes occurs.

Failed test: https://dev.azure.com/azclitools/public/_build/results?buildId=12783&view=logs&j=00feeef1-2e9b-5ce6-e2c5-a2c5a43245ee&t=317d23de-79ee-5aa1-a23a-e6710a3e515f

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
