### PR TITLE
[Network] `az network private-endpoint-connection`: Enable private link support for provider `Microsoft.DesktopVirtualization/hostpools` and `Microsoft.DesktopVirtualization/workspaces`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/private_link_resource_and_endpoint_connections/custom.py
@@ -31,6 +31,8 @@ def register_providers():
     _register_one_provider('Microsoft.DBforMySQL/servers', '2018-06-01', False, '2017-12-01-preview')
     _register_one_provider('Microsoft.DBforMariaDB/servers', '2018-06-01', False)
     _register_one_provider('Microsoft.DBforPostgreSQL/servers', '2018-06-01', False, '2017-12-01-preview')
+    _register_one_provider("Microsoft.DesktopVirtualization/hostpools", '2021-04-01-preview', True)
+    _register_one_provider("Microsoft.DesktopVirtualization/workspaces", '2021-04-01-preview', True)
     _register_one_provider('Microsoft.Devices/IotHubs', '2020-03-01', True)
     _register_one_provider('Microsoft.DeviceUpdate/accounts', '2020-03-01-preview', True)
     _register_one_provider('Microsoft.DocumentDB/databaseAccounts', '2019-08-01-preview', False, '2020-03-01')

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -3671,6 +3671,144 @@ class NetworkPrivateLinkDeviceUpdateScenarioTest(ScenarioTest):
         self.cmd('network private-endpoint-connection show --id {private-endpoint-connection-id}',
                  expect_failure=True)
 
+class NetworkPrivateLinkDesktopVirtualizationScenarioTest(ScenarioTest):
+    @live_only()
+    @ResourceGroupPreparer(name_prefix='cli_test_desktopvirtual_pe', random_name_length=40, location ="westus2")
+    def test_desktopvirtualization_private_endpoint(self, resource_group):
+        self.kwargs.update({
+            'rg': resource_group,
+            'location': "westus2"
+            'vnet': self.create_random_name('cli-vnet-dv', 20),
+            'subnet': self.create_random_name('cli-subnet-dv', 20),
+            'hostpoolName': self.create_random_name('cli-test-dv-hp', 20),
+            'workspaceName': self.create_random_name('cli-test-dv-ws', 20),
+            'hostpoolType': "Pooled",
+            'loadBalancerType': "BreadthFirst",
+            'preferredAppGroupType': "Desktop",
+            'hp_pe1_name': self.create_random_name('cli-test-dv-hp-pe1', 20),
+            'hp_pec1_name': self.create_random_name('cli-test-dv-hp-pec1', 20),
+            'hp_pe2_name': self.create_random_name('cli-test-dv-hp-pe2', 20),
+            'hp_pec2_name': self.create_random_name('cli-test-dv-hp-pec2', 20),
+            'ws_pe1_name': self.create_random_name('cli-test-dv-ws-pe1', 20),
+            'ws_pec1_name': self.create_random_name('cli-test-dv-ws-pec1', 20),
+            'ws_pe2_name': self.create_random_name('cli-test-dv-ws-pe2', 20),
+            'ws_pec2_name': self.create_random_name('cli-test-dv-ws-pec2', 20),
+            'approve_description_msg': 'Approved!',
+            'reject_description_msg': 'Rejected!'
+        })
+
+        # DesktopVirtualzation is an extension
+        self.cmd('extension add --name desktopvirtualization')
+
+        #Create hostpool and workspace
+        hostpool = self.cmd('desktopvirtualization hostpool create --name {hostpoolName} --resource-group {rg} --location {location} '
+        '--host-pool-type {hostpoolType} --load-balancer-type {loadBalancerType} --preferred-app-group-type {preferredAppGroupType}').get_output_in_json()
+        self.kwargs['hostpool_id'] = hostpool['id']
+
+        workspace = self.cmd('desktopvirtualization workspace create --name {workspaceName} --resource-group {rg} --location {location}').get_output_in_json()
+        self.kwargs['workspace_id'] = workspace['id']
+
+        # Create vnet and subnet for private endpoint connection
+        self.cmd('network vnet create -g {rg} -n {vnet} --subnet-name {subnet}')
+        self.cmd('network vnet subnet update -g {rg} --vnet-name {vnet} --name {subnet} '
+                 '--disable-private-endpoint-network-policies true',
+                 checks=self.check('privateEndpointNetworkPolicies', 'Disabled'))
+
+        # List hostpool private link resources
+        dv_hostpool_private_link_resources = self.cmd(
+            'network private-link-resource list --id {hostpool_id}').get_output_in_json()
+        self.kwargs['hp_group_id'] = dv_hostpool_private_link_resources[0]['properties']['groupId']
+
+        # List workspace private link resources
+        dv_workspace_private_link_resources = self.cmd(
+            'network private-link-resource list --id {workspace_id}').get_output_in_json()
+        self.kwargs['ws_group_id'] = dv_workspace_private_link_resources[0]['properties']['groupId']
+
+        # Create auto-approved private endpoint for hostpool
+        peHostpoolCreation = self.cmd(
+            'network private-endpoint create -g {rg} -n {hp_pe1_name} --vnet-name {vnet} --subnet {subnet} '
+            '--private-connection-resource-id {hostpool_id} --connection-name {hp_pec1_name} '
+            '--group-id {hp_group_id}').get_output_in_json()
+        self.assertTrue(self.kwargs['hp_pe1_name'].lower() in peHostpoolCreation['name'].lower())
+
+        # Create auto-approved private endpoint for workspace
+        peWorkspaceCreation = self.cmd(
+            'network private-endpoint create -g {rg} -n {ws_pe1_name} --vnet-name {vnet} --subnet {subnet} '
+            '--private-connection-resource-id {workspace_id} --connection-name {ws_pec1_name} '
+            '--group-id {ws_group_id}').get_output_in_json()
+        self.assertTrue(self.kwargs['ws_pe1_name'].lower() in peWorkspaceCreation['name'].lower())
+
+        # Get private endpoint connection for hostpool
+        pecsHostpool = self.cmd('network private-endpoint-connection list --id {hostpool_id}',
+                                                checks=[
+                                                    self.check(
+                                                        '@[0].properties.privateLinkServiceConnectionState.status',
+                                                        'Approved'),
+                                                ]).get_output_in_json()
+        self.kwargs['pecsHostpool-id'] = pecsHostpool[0]['id']
+
+        # Get private endpoint connection for workpace
+        pecsWorkspace = self.cmd('network private-endpoint-connection list --id {workspace_id}',
+                                                checks=[
+                                                    self.check(
+                                                        '@[0].properties.privateLinkServiceConnectionState.status',
+                                                        'Approved'),
+                                                ]).get_output_in_json()
+
+        self.kwargs['pecsWorkspace-id'] = pecsWorkspace[0]['id']
+
+        # Reject private endpoint connection on hostpool using resource id
+        self.cmd(
+            'network private-endpoint-connection reject --id {pecsHostpool-id}'
+            ' --description {reject_description_msg}', checks=[
+                  self.check('properties.privateLinkServiceConnectionState.status', 'Rejected')
+            ])
+
+        # Reject private endpoint connection on workspace using resource id
+        self.cmd(
+            'network private-endpoint-connection reject --id {pecsWorkspace-id}'
+            ' --description {reject_description_msg}', checks=[
+                  self.check('properties.privateLinkServiceConnectionState.status', 'Rejected')
+            ])
+
+        # Manually create an endpoint for hostpool and approve it using resourceGroup/name/type
+        pe2HostpoolCreation = self.cmd(
+            'network private-endpoint create -g {rg} -n {hp_pe2_name} --vnet-name {vnet} --subnet {subnet} '
+            '--private-connection-resource-id {hostpool_id} --connection-name {hp_pec2_name} '
+            '--group-id {hp_group_id}').get_output_in_json()
+        self.assertTrue(self.kwargs['hp_pe2_name'].lower() in pe2HostpoolCreation['name'].lower())
+
+        self.cmd('network private-endpoint-connection approve -g {rg} -n {hp_pec2_name} --type Microsoft.DesktopVirtualization/hostpools --description {approve_description_msg}',
+        checks=[
+            self.check('properties.privateLinkServiceConnectionState.status', 'Approved'),
+            self.check('properties.privateLinkServiceConnectionState.description', '{approve_description_msg}')
+        ])
+
+        # Manually create an endpoint for workspace and approve it using resourceGroup/name/type
+        pe2WorkspaceCreation = self.cmd(
+            'network private-endpoint create -g {rg} -n {ws_pe2_name} --vnet-name {vnet} --subnet {subnet} '
+            '--private-connection-resource-id {workspace_id} --connection-name {ws_pec2_name} '
+            '--group-id {ws_group_id} --manual-request').get_output_in_json()
+        self.assertTrue(self.kwargs['ws_pe2_name'].lower() in pe2WorkspaceCreation['name'].lower())
+
+        self.cmd('network private-endpoint-connection approve -g {rg} -n {ws_pec2_name} --type Microsoft.DesktopVirtualization/workspaces --description {approve_description_msg}',
+        checks=[
+            self.check('properties.privateLinkServiceConnectionState.status', 'Approved'),
+            self.check('properties.privateLinkServiceConnectionState.description', '{approve_description_msg}')
+        ])
+
+        # Delete the autoapproved private endpoint connections for hostpool and workspace using resource id
+        self.cmd('az network private-endpoint-connection delete --id {pecHostpool-id} -y')
+        self.cmd('az network private-endpoint-connection delete --id {pecsWorkspace-id} -y')
+        import time
+        time.sleep(90)
+        self.cmd('az network private-endpoint-connection list --id {pecHostpool-id}', checks=[
+            self.check('length(@)', '1'),
+        ])
+        self.cmd('az network private-endpoint-connection list --id {pecsWorkspace-id}', checks=[
+            self.check('length(@)', '1'),
+        ])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/test_private_endpoint_commands.py
@@ -3677,7 +3677,7 @@ class NetworkPrivateLinkDesktopVirtualizationScenarioTest(ScenarioTest):
     def test_desktopvirtualization_private_endpoint(self, resource_group):
         self.kwargs.update({
             'rg': resource_group,
-            'location': "westus2"
+            'location': "westus2",
             'vnet': self.create_random_name('cli-vnet-dv', 20),
             'subnet': self.create_random_name('cli-subnet-dv', 20),
             'hostpoolName': self.create_random_name('cli-test-dv-hp', 20),


### PR DESCRIPTION
**Related command**
az network commands should support Microsoft.DesktopVirtualization/hostpools and Microsoft.DesktopVirtualization/workspaces resources for the private Endpoint Types

**Description**<!--Mandatory-->
This adds Microsoft.DesktopVirtualization/hostpools and Microsoft.DesktopVirtualization/workspaces to the az network supported provider by 
- Registering the service into generic implementation
- Adding test case for new command

**Testing Guide**
Added relevant test cases as per: https://github.com/Azure/azure-cli/blob/dev/doc/private_endpoint_connection_command_guideline.md

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
