### PR TITLE
[Static web app] `az staticwebapp hostname show`: Fix txt validation command to show correct command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -130,7 +130,7 @@ def set_staticsite_domain(cmd, name, hostname, resource_group_name=None, no_wait
                                                                     name, hostname, domain_envelope)
 
     if validation_method.lower() == "dns-txt-token":
-        validation_cmd = ("az staticwebapp hostname get -n {} -g {} "
+        validation_cmd = ("az staticwebapp hostname show -n {} -g {} "
                           "--hostname {} --query \"validationToken\"".format(name,
                                                                              resource_group_name,
                                                                              hostname))


### PR DESCRIPTION
az staticwebapp hostname get does not exist. Instead users should use hostname show

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az staticwebapp hostname show

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Validation command shows the wrong command to run. az staticwebapp hostname does not support a 'get' command but rather users should use the 'show' command to retrieve the validation token when using dns-txt-token as the validation method

**Testing Guide**
<!--Example commands with explanations.-->

![image](https://user-images.githubusercontent.com/9285242/200424669-9424a2af-a777-463e-8c2d-da25e2a8089d.png)


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
