### PR TITLE
{CI} Add extension dependency check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -474,6 +474,25 @@ jobs:
   - bash: ./scripts/ci/test_extensions.sh
     displayName: 'Load extensions'
 
+- job: TestExtensionsDependency
+  displayName: Test Extensions Dependency
+  condition: succeeded()
+  timeoutInMinutes: 40
+
+  pool:
+    name: ${{ variables.ubuntu_pool }}
+  strategy:
+    matrix:
+      Python310:
+        python.version: '3.10'
+  steps:
+  - task: UsePythonVersion@0
+    displayName: 'Use Python $(python.version)'
+    inputs:
+      versionSpec: '$(python.version)'
+  - bash: ./scripts/ci/test_extensions_dependency.sh
+    displayName: 'Install extensions'
+
 - job: BuildHomebrewFormula
   displayName: Build Homebrew Formula
 

--- a/scripts/ci/test_extensions_dependency.sh
+++ b/scripts/ci/test_extensions_dependency.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+pwd
+python3 -m venv env
+source env/bin/activate
+pip install --upgrade pip
+source /scripts/install_full.sh
+
+echo "Listing Available Extensions:"
+az extension list-available -otable
+
+# turn off telemetry as it crowds output
+export AZURE_CLI_DIAGNOSTICS_TELEMETRY=
+
+output=$(az extension list-available --query [].name -otsv)
+
+exit_code=0
+for ext in $output; do
+    echo
+    # Use regex to detect if $ext is in $ignore_list
+
+    echo "Verifying extension:" $ext
+    url=$(python -c 'from azure.cli.core.extension._resolve import  resolve_from_index;print(resolve_from_index("$ext")[0])')
+    curl -O $url
+    pip install *.whl --dry-run
+    if [ $? != 0 ]
+        then
+            exit_code=1
+            echo "Failed to install:" $ext
+        fi
+    rm *.whl
+
+done
+
+
+exit $exit_code


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Inspired by `TestExtensionsLoading`.
This test will check if extension's dependency is conflict with azure-cli. This should avoid issues like https://github.com/Azure/azure-cli/issues/24213
Currently, the extension and its dependency is installed into `~/.azure/cliextensions`. The dependency error is not shown during installation.

This test also finds four incompatible extentions: `attestation`, `cloud-service`, `functionapp`, `serial-console`. 
To pass the test, add them to `ignore_list` in the script.
