### PR TITLE
{Core} Fix the lack of arguments for extension commands

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -498,9 +498,10 @@ class MainCommandsLoader(CLICommandsLoader):
 
                 if command is None:
                     # load all arguments via reflection
+                    loader.skip_applicability = True
                     for cmd in loader.command_table.values():
                         cmd.load_arguments()  # this loads the arguments via reflection
-                    loader.skip_applicability = True
+                        loader.load_arguments(cmd.name) # this can load all the arguments for commands in extensions
                     loader.load_arguments('')  # this adds entries to the argument registries
                 else:
                     loader.command_name = command


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
While generating reference docs for Azure CLI and extensions, I found that some arguments in extension commands (especially for `azure-cli-ml`, e.g. `--path` for `az ml folder attach`) are missed from extraction. After fixing by code change in this PR, it can extract a full set of arguments.

This change aligns with [Line 38 and 46 in azhelpgen.py in azure-cli-extensions repo](https://github.com/Azure/azure-cli-extensions/blob/main/scripts/refdoc/azhelpgen/azhelpgen.py#L46):
![image](https://user-images.githubusercontent.com/34960224/200533708-35a70ed5-fd21-4171-b4a1-f2edc63474b2.png)


**Testing Guide**
<!--Example commands with explanations.-->
Calling [this function](https://github.com/Azure/azure-cli/blob/main/src/azure-cli-core/azure/cli/core/file_util.py#L49) and watch the related objects during `load_arguments`.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
