### PR TITLE
{Doc} Update Homebrew edge installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ You can download the latest builds by following the links below:
 You can easily install the latest Homebrew edge build with the following command:
 
 ```bash
-brew install $(curl -Ls -o /dev/null -w %{url_effective} https://aka.ms/InstallAzureCliHomebrewEdge)
+# You need to uninstall the stable version with `brew uninstall azure-cli` first
+curl -Ls -o azure-cli.rb https://aka.ms/InstallAzureCliHomebrewEdge
+brew install --build-from-source azure-cli.rb
 ```
 
 You can install the edge build on Ubuntu Xenial with the following command:

--- a/README.md
+++ b/README.md
@@ -162,20 +162,20 @@ You can easily install the latest Homebrew edge build with the following command
 
 ```bash
 # You need to uninstall the stable version with `brew uninstall azure-cli` first
-curl -Ls -o azure-cli.rb https://aka.ms/InstallAzureCliHomebrewEdge
+curl --location --silent --output azure-cli.rb https://aka.ms/InstallAzureCliHomebrewEdge
 brew install --build-from-source azure-cli.rb
 ```
 
 You can install the edge build on Ubuntu Xenial with the following command:
 
 ```bash
-curl -Ls -o azure-cli_xenial_all.deb https://aka.ms/InstallAzureCliXenialEdge && dpkg -i azure-cli_xenial_all.deb
+curl --location --silent --output azure-cli_xenial_all.deb https://aka.ms/InstallAzureCliXenialEdge && dpkg -i azure-cli_xenial_all.deb
 ```
 
 And install the edge build with rpm package on CentOS/RHEL/Fedora:
 
 ```bash
-rpm -ivh --nodeps $(curl -Ls -o /dev/null -w %{url_effective} https://aka.ms/InstallAzureCliRpmEdge)
+rpm -ivh --nodeps $(curl --location --silent --output /dev/null  --write-out %{url_effective} https://aka.ms/InstallAzureCliRpmEdge)
 ```
 
 Here's an example of installing edge builds with pip3 in a virtual environment. The `--upgrade-strategy=eager` option will install the edge builds of dependencies as well. 


### PR DESCRIPTION
Homebrew stops to install from url in this PR https://github.com/Homebrew/brew/pull/7660 and raises `Non-checksummed download of azure-cli formula file from an arbitrary URL is unsupported!`. 

We should download the formula and install it with ` --build-from-source`.