### PR TITLE
[Role] EXPERIMENTAL: Add config option `graph.api_version` to override default Microsoft Graph API version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_msgrpah/_graph_client.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_msgrpah/_graph_client.py
@@ -28,6 +28,10 @@ class GraphClient:
 
     def __init__(self, cli_ctx):
         self._cli_ctx = cli_ctx
+
+        # EXPERIMENTAL: Use config option graph.api_version to override default API version
+        self._api_version = cli_ctx.config.get('graph', 'api_version', fallback=GraphClient.V1_0)
+
         self._scopes = resource_to_scopes(cli_ctx.cloud.endpoints.microsoft_graph_resource_id)
 
         # https://graph.microsoft.com/ (AzureCloud)
@@ -38,7 +42,9 @@ class GraphClient:
         # https://microsoftgraph.chinacloudapi.cn
         self._endpoint = cli_ctx.cloud.endpoints.microsoft_graph_resource_id.rstrip('/')
 
-    def _send(self, method, url, param=None, body=None, api_version=V1_0):
+    def _send(self, method, url, param=None, body=None, api_version=None):
+        # Specify api_version to override the client's default
+        api_version = api_version or self._api_version
         url = f'{self._endpoint}/{api_version}{url}'
 
         if body:


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->
Workaround for 
- #23951
- #22664

Due to Microsoft Graph API limitation, service principals are not listed in the result of below commands. This limitation is conveyed in those API documents:

- `az ad group owner list`, which calls [List group owners](https://learn.microsoft.com/en-us/graph/api/group-list-owners?view=graph-rest-1.0&tabs=http) API
  > Note: Currently, service principals are not listed as group owners due to the staged rollout of service principals to the Microsoft Graph v1.0 endpoint.
- `az ad group member list`, which calls [List group members](https://learn.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http) API
  > Currently service principals are not listed as group members due to staged roll-out of service principals on Graph V1.0 endpoint.

This limitation is solved in `beta` API. However, because `az ad` is a GA command module, it should only call GA APIs internally, but not `beta` versions.

This PR adds an experimental config option `graph.api_version` to override default API version so that users can get unblocked without using the more complex `az rest` workaround.

**Testing Guide**
```
az config set graph.api_version=beta
az ad app show --id 0e040bf6-334f-4412-bcf4-1a82b0ebe11b --debug
az config unset graph.api_version
```

**Additional information**
My first thought was to add config option `graph.use_beta_api`, but we will have to add new options if other API versions are introduced, such as `v2.0` or `alpha`, so I switched to this more general option name.
