### PR TITLE
{Packaging} Not install libssl1.1 explicitly in test

### DIFF
--- a/scripts/release/debian/test_deb_in_docker.sh
+++ b/scripts/release/debian/test_deb_in_docker.sh
@@ -8,12 +8,6 @@ export USERNAME=azureuser
 apt update
 apt install -y apt-transport-https git gcc python3-dev
 
-# The distros that need libssl1.1
-case ${DISTRO} in
-    bionic|buster|focal) apt install -y libssl1.1;;
-    *)                        :;;
-esac
-
 dpkg -i /mnt/artifacts/azure-cli_$CLI_VERSION-1~${DISTRO}_all.deb
 
 time az self-test


### PR DESCRIPTION
I am not sure why `libssl1.1` is needed. But it is already installed as dependency when install `git` in previous step.
We can safely remove this step to pass the `DS440000 Generic: Do not hardcode SSL/TLS versions within an application` check.

>This package is part of the OpenSSL project's implementation of the SSL
and TLS cryptographic protocols for secure communication over the
Internet.
It provides the libssl and libcrypto shared libraries.

```
root@2f0a89968088:/# apt install git
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  ca-certificates git-man krb5-locales less libasn1-8-heimdal libbrotli1 libbsd0 libcbor0.6 libcurl3-gnutls libedit2 liberror-perl
  libexpat1 libfido2-1 libgdbm-compat4 libgdbm6 libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3 libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libldap-common libnghttp2-14 libperl5.30 libpsl5 libroken18-heimdal librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db
  libsqlite3-0 libssh-4 libssl1.1 libwind0-heimdal libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxmuu1 netbase
  openssh-client openssl patch perl perl-modules-5.30 publicsuffix xauth
Suggested packages:
  gettext-base git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn
  gdbm-l10n krb5-doc krb5-user libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal libsasl2-modules-ldap
  libsasl2-modules-otp libsasl2-modules-sql keychain libpam-ssh monkeysphere ssh-askpass ed diffutils-doc perl-doc
  libterm-readline-gnu-perl | libterm-readline-perl-perl make libb-debug-perl liblocale-codes-perl
The following NEW packages will be installed:
  ca-certificates git git-man krb5-locales less libasn1-8-heimdal libbrotli1 libbsd0 libcbor0.6 libcurl3-gnutls libedit2
  liberror-perl libexpat1 libfido2-1 libgdbm-compat4 libgdbm6 libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal
  libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3 libkeyutils1 libkrb5-26-heimdal libkrb5-3
  libkrb5support0 libldap-2.4-2 libldap-common libnghttp2-14 libperl5.30 libpsl5 libroken18-heimdal librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libsqlite3-0 libssh-4 libssl1.1 libwind0-heimdal libx11-6 libx11-data libxau6 libxcb1
  libxdmcp6 libxext6 libxmuu1 netbase openssh-client openssl patch perl perl-modules-5.30 publicsuffix xauth
0 upgraded, 56 newly installed, 0 to remove and 0 not upgraded.
Need to get 19.7 MB of archives.
```