### PR TITLE
[Packaging] Add CentOS 7 RPM Package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -633,6 +633,11 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   strategy:
     matrix:
+      Red Hat Universal Base Image 7:
+        dockerfile: ubi
+        image: registry.access.redhat.com/ubi7/ubi:7.9
+        artifact: rpm-ubi7
+        python_package: rh-python38-python
       Red Hat Universal Base Image 8:
         dockerfile: ubi
         image: registry.access.redhat.com/ubi8/ubi:8.4
@@ -679,6 +684,13 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   strategy:
     matrix:
+      Red Hat Universal Base Image 7:
+        artifact: rpm-ubi7
+        distro: el7
+        image: registry.access.redhat.com/ubi7/ubi:7.9
+        python_package: rh-python38-python
+        python_cmd: python3.8
+        pip_cmd: pip3.8
       Red Hat Universal Base Image 8:
         artifact: rpm-ubi8
         distro: el8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -656,11 +656,13 @@ jobs:
         image: fedora:35
         artifact: rpm-fedora35
         python_package: python3
+        python_cmd: python3
       Fedora36:
         dockerfile: fedora
         image: fedora:36
         artifact: rpm-fedora36
         python_package: python3
+        python_cmd: python3
   steps:
   - task: Bash@3
     displayName: 'Build Rpm Package'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -633,10 +633,10 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   strategy:
     matrix:
-      Red Hat Universal Base Image 7:
+      CentOS 7:
         dockerfile: ubi
-        image: registry.access.redhat.com/ubi7/ubi:7.9
-        artifact: rpm-ubi7
+        image: centos:7
+        artifact: rpm-centos7
         python_package: rh-python38-python
         python_cmd:  /opt/rh/rh-python38/root/usr/bin/python3.8
       Red Hat Universal Base Image 8:
@@ -689,10 +689,10 @@ jobs:
     name: ${{ variables.ubuntu_pool }}
   strategy:
     matrix:
-      Red Hat Universal Base Image 7:
-        artifact: rpm-ubi7
+      CentOS 7:
+        artifact: rpm-centos7
         distro: el7
-        image: registry.access.redhat.com/ubi7/ubi:7.9
+        image: centos:7
         python_package: rh-python38-python
         python_cmd: /opt/rh/rh-python38/root/usr/bin/python3.8
         pip_cmd: /opt/rh/rh-python38/root/usr/bin/pip3.8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -638,16 +638,19 @@ jobs:
         image: registry.access.redhat.com/ubi7/ubi:7.9
         artifact: rpm-ubi7
         python_package: rh-python38-python
+        python_cmd:  /opt/rh/rh-python38/root/usr/bin/python3.8
       Red Hat Universal Base Image 8:
         dockerfile: ubi
         image: registry.access.redhat.com/ubi8/ubi:8.4
         artifact: rpm-ubi8
         python_package: python39
+        python_cmd: python3.9
       Red Hat Universal Base Image 9:
         dockerfile: ubi
         image: registry.access.redhat.com/ubi9/ubi:9.0.0
         artifact: rpm-ubi9
         python_package: python3.9
+        python_cmd: python3.9
       Fedora35:
         dockerfile: fedora
         image: fedora:35
@@ -689,8 +692,8 @@ jobs:
         distro: el7
         image: registry.access.redhat.com/ubi7/ubi:7.9
         python_package: rh-python38-python
-        python_cmd: python3.8
-        pip_cmd: pip3.8
+        python_cmd: /opt/rh/rh-python38/root/usr/bin/python3.8
+        pip_cmd: /opt/rh/rh-python38/root/usr/bin/pip3.8
       Red Hat Universal Base Image 8:
         artifact: rpm-ubi8
         distro: el8

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -5,11 +5,6 @@
 # Turn off python byte compilation
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
-# .el7.centos -> .el7
-%if 0%{?rhel}
-  %define dist .el%{?rhel}
-%endif
-
 # The Python package name for dnf/yum/tdnf, such as python39, python3
 %define python_package %{getenv:PYTHON_PACKAGE}
 # The Python executable name, such as python3.9, python3
@@ -52,11 +47,11 @@ A great cloud needs great tools; we're excited to introduce Azure CLI,
 # Create a fully instantiated virtual environment, ready to use the CLI.
 %{python_cmd} -m venv %{buildroot}%{cli_lib_dir}
 source %{buildroot}%{cli_lib_dir}/bin/activate
-%{python_cmd} -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 source %{repo_path}/scripts/install_full.sh
 
 # cffi 1.15.0 doesn't work with RPM: https://foss.heptapod.net/pypy/cffi/-/issues/513
-%{python_cmd} -m pip install cffi==1.14.6
+python3 -m pip install cffi==1.14.6
 
 deactivate
 

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -33,6 +33,7 @@ docker build \
     --build-arg cli_version=${CLI_VERSION} \
     --build-arg image=${IMAGE} \
     --build-arg python_package=${PYTHON_PACKAGE} \
+    --build-arg python_cmd=${PYTHON_CMD} \
     -f ./scripts/release/rpm/${DOCKERFILE}.dockerfile \
     -t azure/azure-cli:${DOCKERFILE} \
     .

--- a/scripts/release/rpm/pipeline.sh
+++ b/scripts/release/rpm/pipeline.sh
@@ -12,6 +12,8 @@ set -exv
 : "${IMAGE:?IMAGE environment variable not set.}"
 # PYTHON_PACKAGE should be python package name
 : "${PYTHON_PACKAGE:?PYTHON_PACKAGE environment variable not set.}"
+# PYTHON_CMD should be python command
+: "${PYTHON_CMD:?PYTHON_CMD environment variable not set.}"
 
 CLI_VERSION=`cat src/azure-cli/azure/cli/__main__.py | grep __version__ | sed s/' '//g | sed s/'__version__='// |  sed s/\"//g`
 
@@ -21,6 +23,7 @@ docker build \
     --build-arg cli_version=${CLI_VERSION} \
     --build-arg image=${IMAGE} \
     --build-arg python_package=${PYTHON_PACKAGE} \
+    --build-arg python_cmd=${PYTHON_CMD} \
     -f ./scripts/release/rpm/${DOCKERFILE}.dockerfile \
     -t azure/azure-cli:${DOCKERFILE}-builder \
     .

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -12,7 +12,7 @@ else
 fi
 
 if [ $centos7 == true ] ; then
-    rpm install -y dnf
+    yum install -y dnf
     dnf install -y centos-release-scl
 fi
 

--- a/scripts/release/rpm/test_rpm_in_docker.sh
+++ b/scripts/release/rpm/test_rpm_in_docker.sh
@@ -5,12 +5,28 @@ set -exv
 
 export USERNAME=azureuser
 
+if [ `rpm --eval "%{dist}"` == '.el7' ] ; then
+    centos7=true
+else
+    centos7=false
+fi
+
+if [ $centos7 == true ] ; then
+    rpm install -y dnf
+    dnf install -y centos-release-scl
+fi
+
 dnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
 dnf install git gcc $PYTHON_PACKAGE-devel findutils -y
 
-ln -s -f /usr/bin/$PYTHON_CMD /usr/bin/python
-ln -s -f /usr/bin/$PIP_CMD /usr/bin/pip
+if [ $centos7 == true ] ; then
+    ln -s -f $PYTHON_CMD /usr/bin/python
+    ln -s -f $PIP_CMD /usr/bin/pip
+else
+    ln -s -f /usr/bin/$PYTHON_CMD /usr/bin/python
+    ln -s -f /usr/bin/$PIP_CMD /usr/bin/pip
+fi
 time az self-test
 time az --version
 

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -6,6 +6,7 @@ ARG image=registry.access.redhat.com/ubi8/ubi:8.4
 FROM ${image} AS build-env
 ARG cli_version=dev
 ARG python_package=python39
+ARG python_cmd=python3.9
 
 RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
@@ -20,7 +21,7 @@ COPY . .
 # RHEL 8's 'python3' is Python 3.6. RHEL 9's 'python3' is Python 3.9.
 # We have to explicitly specify 'python39' to install Python 3.9.
 RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
-    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=$python_package PYTHON_CMD=python3.9 \
+    REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=$python_package PYTHON_CMD=$python_cmd \
     rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
     cp /root/rpmbuild/RPMS/x86_64/azure-cli-${cli_version}-1.*.x86_64.rpm /azure-cli-dev.rpm
 

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -12,7 +12,7 @@ RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
 
 # dos2unix is not avaialble in ubi7
-RUN if [ "${image}" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm fi
+RUN if [ "${image}" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm ; fi
 
 WORKDIR /azure-cli
 

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -10,6 +10,9 @@ ARG python_package=python39
 RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
 
+# dos2unix is not avaialble in ubi7
+RUN if [ "${image}" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm fi
+
 WORKDIR /azure-cli
 
 COPY . .

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -7,14 +7,11 @@ FROM ${image} AS build-env
 ARG cli_version=dev
 ARG python_package=python39
 ARG python_cmd=python3.9
-# image goes out of scope, state again.
-ARG image
 
 RUN yum update -y
+ARG image
+RUN if [ "$image" == "centos:7" ]; then yum install -y centos-release-scl ; fi
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
-
-# dos2unix is not avaialble in ubi7
-RUN if [ "$image" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm ; fi
 
 WORKDIR /azure-cli
 

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -27,8 +27,8 @@ RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
 FROM ${image} AS execution-env
 
 RUN yum update -y
-RUN yum install -y python39
-
+ARG image
+RUN if [ "$image" == "centos:7" ]; then yum install -y centos-release-scl ; fi
 COPY --from=build-env /azure-cli-dev.rpm ./
-RUN rpm -i ./azure-cli-dev.rpm && \
+RUN yum install -y ./azure-cli-dev.rpm && \
     az --version

--- a/scripts/release/rpm/ubi.dockerfile
+++ b/scripts/release/rpm/ubi.dockerfile
@@ -7,12 +7,14 @@ FROM ${image} AS build-env
 ARG cli_version=dev
 ARG python_package=python39
 ARG python_cmd=python3.9
+# image goes out of scope, state again.
+ARG image
 
 RUN yum update -y
 RUN yum install -y wget rpm-build gcc libffi-devel ${python_package}-devel openssl-devel make bash diffutils patch dos2unix perl
 
 # dos2unix is not avaialble in ubi7
-RUN if [ "${image}" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm ; fi
+RUN if [ "$image" == "registry.access.redhat.com/ubi7/ubi:7.9" ]; then wget "http://mirror.centos.org/centos/7/os/x86_64/Packages/dos2unix-6.0.3-7.el7.x86_64.rpm" && rpm -i dos2unix-6.0.3-7.el7.x86_64.rpm ; fi
 
 WORKDIR /azure-cli
 


### PR DESCRIPTION
In CentOS 7, Python3.8 can be installed from [Software Collections](https://www.softwarecollections.org/en/).
`rh-python38-python` will retire in Jun 2024. (https://access.redhat.com/support/policy/updates/rhscl-rhel7)
We support this distribution again.

RHEL 7 users can install the package directly.
CentOS 7 users need to enable Software Collections with `yum install centos-release-scl` before installing CLI.