### PR TITLE
{Packaging} Update pywin32 to support Python 3.11

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -127,7 +127,7 @@ PyMySQL==1.0.2
 PyNaCl==1.5.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pywin32==302
+pywin32==305
 requests-oauthlib==1.2.0
 requests[socks]==2.26.0
 scp==0.13.2


### PR DESCRIPTION
`pywin32` is not compatible with Python3.11, update it to latest version.

Related issue: #24494