### PR TITLE
{Packaging} Update psycopg2 to support Python 3.11

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -119,7 +119,7 @@ pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2
 psutil==5.9.0
-psycopg2==2.9.3
+psycopg2==2.9.5
 pycparser==2.19
 PyGithub==1.55
 PyJWT==2.4.0


### PR DESCRIPTION
`psycopg2` provided wheel for Windows Python3.11 in 2.9.5.

Related issue: #24494