### PR TITLE
[App Service] `az webapp config snapshot restore`: Fix the AttributeError `str object has no attribute get`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2166,7 +2166,7 @@ def restore_snapshot(cmd, resource_group_name, name, time, slot=None, restore_co
         request = SnapshotRestoreRequest(overwrite=False, snapshot_time=time, recovery_source=source,
                                          recover_configuration=recover_config)
         if slot:
-            return client.web_apps.begin_restore_snapshot_slot(resource_group_name, name, request, slot)
+            return client.web_apps.begin_restore_snapshot_slot(resource_group_name, name, slot, request)
         return client.web_apps.begin_restore_snapshot(resource_group_name, name, request)
     if any([source_resource_group, source_name]):
         raise ArgumentUsageError('usage error: --source-resource-group and '
@@ -2174,7 +2174,7 @@ def restore_snapshot(cmd, resource_group_name, name, time, slot=None, restore_co
     # Overwrite app with its own snapshot
     request = SnapshotRestoreRequest(overwrite=True, snapshot_time=time, recover_configuration=recover_config)
     if slot:
-        return client.web_apps.begin_restore_snapshot_slot(resource_group_name, name, request, slot)
+        return client.web_apps.begin_restore_snapshot_slot(resource_group_name, name, slot, request)
     return client.web_apps.begin_restore_snapshot(resource_group_name, name, request)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_webapp_commands_thru_mock.py
@@ -348,7 +348,7 @@ class TestWebappMocked(unittest.TestCase):
         restore_snapshot(cmd_mock, 'rg', 'web1', '2018-12-07T02:01:31.4708832Z', restore_content_only=False)
 
         # assert
-        client.web_apps.begin_restore_snapshot_slot.assert_called_with('rg', 'web1', request, 'slot1')
+        client.web_apps.begin_restore_snapshot_slot.assert_called_with('rg', 'web1', 'slot1', request)
         client.web_apps.begin_restore_snapshot.assert_called_with('rg', 'web1', overwrite_request)
 
     @mock.patch('azure.cli.command_modules.appservice.custom._generic_site_operation', autospec=True)


### PR DESCRIPTION
**Related command**
az webapp config snapshot restore
https://learn.microsoft.com/en-us/cli/azure/webapp/config/snapshot?view=azure-cli-latest#az-webapp-config-snapshot-restore

**Description**
The restore snapshot command is failing to perform operation if the slot parameter is sent.

**Testing Guide**
Sample command : az webapp config snapshot restore --resource-group test_group --name dbapptesttt --slot build --source-resource-group test_group  --source-name dbapptesttt  --source-slot production --time 2022-11-22T09:09:08.6157038  --restore-content-only

Without this fix, the command fails with below error

_The command failed with an unexpected error. Here is the traceback:
('Unable to build a model: ("Unable to deserialize to object: type, AttributeError: \'str\' object has no attribute \'get\'", AttributeError("\'str\' object has no attribute \'get\'")), DeserializationError: ("Unable to deserialize to object: type, AttributeError: \'str\' object has no attribute \'get\'", AttributeError("\'str\' object has no attribute \'get\'"))', DeserializationError("Unable to deserialize to object: type, AttributeError: 'str' object has no attribute 'get'", AttributeError("'str' object has no attribute 'get'")))
Traceback (most recent call last):
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1436, in _deserialize
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1201, in rest_key_case_insensitive_extractor
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1230, in attribute_key_case_insensitive_extractor
AttributeError: 'str' object has no attribute 'get'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 622, in body
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1454, in _deserialize
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/exceptions.py", line 51, in raise_with_traceback
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1436, in _deserialize
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1201, in rest_key_case_insensitive_extractor
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1230, in attribute_key_case_insensitive_extractor
azure.core.exceptions.DeserializationError: ("Unable to deserialize to object: type, AttributeError: 'str' object has no attribute 'get'", AttributeError("'str' object has no attribute 'get'"))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\knack/cli.py", line 231, in invoke
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 663, in execute
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 697, in _run_job
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/__init__.py", line 333, in __call__
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 121, in handler
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/appservice/custom.py", line 2164, in restore_snapshot
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/core/tracing/decorator.py", line 73, in wrapper_use_tracer
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/web/v2022_03_01/operations/_web_apps_operations.py", line 44098, in begin_restore_snapshot_slot
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/mgmt/web/v2022_03_01/operations/_web_apps_operations.py", line 44017, in _restore_snapshot_slot_initial
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 624, in body
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/exceptions.py", line 51, in raise_with_traceback
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 622, in body
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1454, in _deserialize
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/exceptions.py", line 51, in raise_with_traceback
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1436, in _deserialize
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1201, in rest_key_case_insensitive_extractor
  File "D:\a\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\msrest/serialization.py", line 1230, in attribute_key_case_insensitive_extractor
azure.core.exceptions.SerializationError: ('Unable to build a model: ("Unable to deserialize to object: type, AttributeError: \'str\' object has no attribute \'get\'", AttributeError("\'str\' object has no attribute \'get\'")), DeserializationError: ("Unable to deserialize to object: type, AttributeError: \'str\' object has no attribute \'get\'", AttributeError("\'str\' object has no attribute \'get\'"))', DeserializationError("Unable to deserialize to object: type, AttributeError: 'str' object has no attribute 'get'", AttributeError("'str' object has no attribute 'get'")))_
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
