### PR TITLE
[Storage] New features for listing encryption scope and failover

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -159,6 +159,9 @@ examples:
   - name: List encryption scopes within storage account.
     text: |
         az storage account encryption-scope list --account-name mystorageaccount -g MyResourceGroup
+  - name: List encryption scopes starting with specific name.
+    text: |
+        az storage account encryption-scope list --account-name mystorageaccount -g myresourcegroup --filter startswith(name, value)
 """
 
 helps['storage account encryption-scope show'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_help.py
@@ -161,7 +161,7 @@ examples:
         az storage account encryption-scope list --account-name mystorageaccount -g MyResourceGroup
   - name: List encryption scopes starting with specific name.
     text: |
-        az storage account encryption-scope list --account-name mystorageaccount -g myresourcegroup --filter startswith(name, value)
+        az storage account encryption-scope list --account-name mystorageaccount -g myresourcegroup --filter 'startswith(name, value)'
 """
 
 helps['storage account encryption-scope show'] = """

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -584,7 +584,8 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
                    'all blob read/write operations using this encryption scope will fail.')
 
     with self.argument_context('storage account encryption-scope list') as c:
-        t_encryption_scope_include = self.get_models("ListEncryptionScopesInclude", resource_type=ResourceType.MGMT_STORAGE)
+        t_encryption_scope_include = self.get_models("ListEncryptionScopesInclude",
+                                                     resource_type=ResourceType.MGMT_STORAGE)
         c.argument('filter', help='When specified, only encryption scope names starting with the filter will be listed')
         c.argument('include', arg_type=get_enum_type(t_encryption_scope_include),
                    help='when specified, will list encryption scopes with the specific state')

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -305,6 +305,10 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('name', options_list=['--name', '-n'],
                    help='The name of the storage account within the specified resource group')
 
+    with self.argument_context('storage account failover') as c:
+        c.argument('failover_type', options_list=['--failover-type', '--type'], is_preview=True, default=None,
+                   help="The parameter is set to 'Planned' to indicate whether a Planned failover is requested")
+
     with self.argument_context('storage account delete') as c:
         c.argument('account_name', acct_name_type, options_list=['--name', '-n'], local_context_attribute=None)
 
@@ -578,6 +582,15 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.argument('state', arg_type=get_enum_type(t_state),
                    help='Change the state the encryption scope. When disabled, '
                    'all blob read/write operations using this encryption scope will fail.')
+
+    with self.argument_context('storage account encryption-scope list') as c:
+        t_encryption_scope_include = self.get_models("ListEncryptionScopesInclude", resource_type=ResourceType.MGMT_STORAGE)
+        c.argument('filter', help='When specified, only encryption scope names starting with the filter will be listed')
+        c.argument('include', arg_type=get_enum_type(t_encryption_scope_include),
+                   help='when specified, will list encryption scopes with the specific state')
+        c.argument('maxpagesize', type=int,
+                   help='the maximum number of encryption scopes that will be included in the list response')
+        c.argument('marker', arg_type=marker_type)
 
     with self.argument_context('storage account keys list', resource_type=ResourceType.MGMT_STORAGE) as c:
         t_expand_key_type = self.get_models('ListKeyExpand', resource_type=ResourceType.MGMT_STORAGE)

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -184,7 +184,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
 
         g.custom_command('create', 'create_encryption_scope')
         g.show_command('show', 'get')
-        g.command('list', 'list')
+        g.custom_command('list', 'list_encryption_scope')
         g.custom_command('update', 'update_encryption_scope')
 
     management_policy_sdk = CliCommandType(

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -881,7 +881,7 @@ def update_encryption_scope(cmd, client, resource_group_name, account_name, encr
 
 
 def list_encryption_scope(client, resource_group_name, account_name,
-                          maxpagesize=None, marker=None, filter=None, include=None):
+                          maxpagesize=None, marker=None, filter=None, include=None):  # pylint: redefined-builtin
     generator = client.list(resource_group_name, account_name, maxpagesize=maxpagesize, filter=filter, include=include)
     pages = generator.by_page(continuation_token=marker)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -880,6 +880,19 @@ def update_encryption_scope(cmd, client, resource_group_name, account_name, encr
                         encryption_scope_name=encryption_scope_name, encryption_scope=encryption_scope)
 
 
+def list_encryption_scope(client, resource_group_name, account_name,
+                          maxpagesize=None, marker=None, filter=None, include=None):
+    generator = client.list(resource_group_name, account_name, maxpagesize=maxpagesize, filter=filter, include=include)
+    pages = generator.by_page(continuation_token=marker)
+
+    result = list(next(pages))
+    if pages.continuation_token:
+        next_marker = {"nextMarker": pages.continuation_token}
+        result.append(next_marker)
+
+    return result
+
+
 # pylint: disable=no-member
 def create_or_policy(cmd, client, account_name, resource_group_name=None, properties=None, source_account=None,
                      destination_account=None, policy_id="default", rule_id=None, source_container=None,

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -881,7 +881,7 @@ def update_encryption_scope(cmd, client, resource_group_name, account_name, encr
 
 
 def list_encryption_scope(client, resource_group_name, account_name,
-                          maxpagesize=None, marker=None, filter=None, include=None):  # pylint: redefined-builtin
+                          maxpagesize=None, marker=None, filter=None, include=None):  # pylint: disable=redefined-builtin
     generator = client.list(resource_group_name, account_name, maxpagesize=maxpagesize, filter=filter, include=include)
     pages = generator.by_page(continuation_token=marker)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_account_encryption_scope_list.yaml
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/recordings/test_storage_account_encryption_scope_list.yaml
@@ -1,0 +1,431 @@
+interactions:
+- request:
+    body: '{"properties": {"source": "Microsoft.Storage", "requireInfrastructureEncryption":
+      true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '88'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -i --account-name -g -n
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/myencryption?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/myencryption","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"myencryption","properties":{"source":"Microsoft.Storage","keyVaultProperties":{},"creationTime":"2022-11-23T09:22:57.2606182Z","lastModifiedTime":"2022-11-23T09:22:57.2606182Z","state":"Enabled","requireInfrastructureEncryption":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '503'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:22:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"source": "Microsoft.Storage", "requireInfrastructureEncryption":
+      true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '88'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -i --account-name -g -n
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption1?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption1","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption1","properties":{"source":"Microsoft.Storage","keyVaultProperties":{},"creationTime":"2022-11-23T09:22:58.6657768Z","lastModifiedTime":"2022-11-23T09:22:58.6657768Z","state":"Enabled","requireInfrastructureEncryption":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '509'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:22:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"source": "Microsoft.Storage", "requireInfrastructureEncryption":
+      true}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '88'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -i --account-name -g -n
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","keyVaultProperties":{},"creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:00.1438917Z","state":"Enabled","requireInfrastructureEncryption":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '509'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:22:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"state": "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope update
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --account-name -g -n --state
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:01.7659204Z","state":"Disabled","requireInfrastructureEncryption":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '486'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1198'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/myencryption","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"myencryption","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:22:57.2606182Z","lastModifiedTime":"2022-11-23T09:22:57.2606182Z","state":"Enabled","requireInfrastructureEncryption":true}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption1","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption1","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:22:58.6657768Z","lastModifiedTime":"2022-11-23T09:22:58.6657768Z","state":"Enabled","requireInfrastructureEncryption":true}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:01.7659204Z","state":"Disabled","requireInfrastructureEncryption":true}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1464'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g --include
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01&$include=Disabled
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:01.7659204Z","state":"Disabled","requireInfrastructureEncryption":true}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '498'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g --filter
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01&$filter=startswith%28name%2C%20test%29
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption1","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption1","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:22:58.6657768Z","lastModifiedTime":"2022-11-23T09:22:58.6657768Z","state":"Enabled","requireInfrastructureEncryption":true}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:01.7659204Z","state":"Disabled","requireInfrastructureEncryption":true}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '984'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g --maxpagesize
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01&$maxpagesize=2
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/myencryption","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"myencryption","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:22:57.2606182Z","lastModifiedTime":"2022-11-23T09:22:57.2606182Z","state":"Enabled","requireInfrastructureEncryption":true}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption1","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption1","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:22:58.6657768Z","lastModifiedTime":"2022-11-23T09:22:58.6657768Z","state":"Enabled","requireInfrastructureEncryption":true}}],"nextLink":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01&$maxpagesize=2&$skipToken=testencryption2"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1262'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - storage account encryption-scope list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g --maxpagesize --marker
+      User-Agent:
+      - AZURECLI/2.42.0 azsdk-python-azure-mgmt-storage/21.0.0 Python/3.7.9 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes?api-version=2022-09-01&$maxpagesize=2&$skipToken=testencryption2
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_storage_encryption000001/providers/Microsoft.Storage/storageAccounts/encryption000002/encryptionScopes/testencryption2","type":"Microsoft.Storage/storageAccounts/encryptionScopes","name":"testencryption2","properties":{"source":"Microsoft.Storage","creationTime":"2022-11-23T09:23:00.1438917Z","lastModifiedTime":"2022-11-23T09:23:01.7659204Z","state":"Disabled","requireInfrastructureEncryption":true}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '498'
+      content-type:
+      - application/json
+      date:
+      - Wed, 23 Nov 2022 09:23:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_account_scenarios.py
@@ -2230,7 +2230,7 @@ class StorageAccountSkuScenarioTest(ScenarioTest):
 
 
 class StorageAccountFailoverScenarioTest(ScenarioTest):
-    @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2019-04-01')
+    @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2022-09-01')
     @ResourceGroupPreparer(name_prefix='clistorage', location='westus2')
     def test_storage_account_failover(self, resource_group):
         self.kwargs = {
@@ -2254,7 +2254,7 @@ class StorageAccountFailoverScenarioTest(ScenarioTest):
         ])
 
         time.sleep(900)
-        self.cmd('storage account failover -n {sa} -g {rg} --no-wait -y')
+        self.cmd('storage account failover -n {sa} -g {rg} --failover-type Planned --no-wait -y')
 
         self.cmd('storage account show -n {sa} -g {rg} --expand geoReplicationStats', checks=[
             self.check('name', '{sa}'),

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_encryption_scope_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_encryption_scope_scenarios.py
@@ -133,6 +133,42 @@ class StorageAccountEncryptionTests(StorageScenarioMixin, ScenarioTest):
         self.cmd('storage blob upload -c {} -n {} -f "{}" --encryption-scope {} --connection-string "{}"'.format(
             self.kwargs['con'], blob2, file, self.kwargs['encryption'], result['connectionString']))
 
+    @AllowLargeResponse()
+    @api_version_constraint(ResourceType.MGMT_STORAGE, min_api='2022-09-01')
+    @ResourceGroupPreparer(name_prefix='cli_test_storage_encryption')
+    @StorageAccountPreparer(name_prefix='encryption', kind="StorageV2")
+    def test_storage_account_encryption_scope_list(self, resource_group, storage_account):
+        # Prepare 3 encryption scopes: myencryption, testencryption1, testencryption2
+        self.cmd("storage account encryption-scope create -i --account-name {sa} -g {rg} -n myencryption")
+        self.cmd("storage account encryption-scope create -i --account-name {sa} -g {rg} -n testencryption1")
+        self.cmd("storage account encryption-scope create -i --account-name {sa} -g {rg} -n testencryption2")
+
+        # Disable encryption scope testencryption2
+        self.cmd("storage account encryption-scope update --account-name {sa} -g {rg} -n testencryption2 --state Disabled")
+
+        # List all encryption scopes
+        self.cmd("storage account encryption-scope list --account-name {sa} -g {rg}", checks=[
+            JMESPathCheck("length(@)", 3)
+        ])
+
+        # List disabled encryption scopes
+        self.cmd("storage account encryption-scope list --account-name {sa} -g {rg} --include Disabled", checks=[
+            JMESPathCheck("length(@)", 1)
+        ])
+
+        # List encryption scopes with filter
+        self.cmd("storage account encryption-scope list --account-name {sa} -g {rg} --filter 'startswith(name, test)'",
+                 checks=[JMESPathCheck("length(@)", 2)])
+
+        # List encryption scopes with maxpagesize
+        encryption_scopes = self.cmd("storage account encryption-scope list --account-name {sa} -g {rg} --maxpagesize 2").get_output_in_json()
+        self.assertEqual(len(encryption_scopes), 3)
+        self.assertIn('nextMarker', encryption_scopes[2])
+
+        self.kwargs['marker'] = encryption_scopes[2]["nextMarker"]
+        self.cmd("storage account encryption-scope list --account-name {sa} -g {rg} --maxpagesize 2 --marker {marker}",
+                 checks=[JMESPathCheck("length(@)", 1)])
+
     @ResourceGroupPreparer(name_prefix='cli_test_adls_encryption')
     @StorageAccountPreparer(name_prefix='encryption', kind="StorageV2", hns=True)
     def test_storage_adls_gen2_encryption_scope(self, resource_group, storage_account_info):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account encryption-scope list`
`az storage account failover`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
New features for API version 2022-09-01
- Support listing encryption scopes with specific filter/state/pagesize
- Support failover type


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] `az storage account encryption-scope list`: Add `--filter`, `--include`, `--maxpagesize` to support advanced list
[Storage] `az storage account failover`: Add `--failover-type` to support planned failover

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
