### PR TITLE
[Role] `az ad sp create-for-rbac`: Drop no-op argument `--skip-assignment`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -177,8 +177,6 @@ def load_arguments(self, _):
                         "/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM")
         c.argument('role', completer=get_role_definition_name_completion_list,
                    help='Role of the service principal.')
-        c.argument('skip_assignment', arg_type=get_three_state_flag(),
-                   deprecate_info=c.deprecate(target='--skip-assignment', hide=True), help='No-op.')
         c.argument('show_auth_for_sdk', options_list='--sdk-auth', deprecate_info=c.deprecate(target='--sdk-auth'),
                    help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
 

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1148,9 +1148,9 @@ def list_service_principal_owners(client, identifier):
 
 # pylint: disable=inconsistent-return-statements
 def create_service_principal_for_rbac(
-        # pylint:disable=too-many-statements,too-many-locals, too-many-branches, unused-argument
+        # pylint:disable=too-many-statements,too-many-locals, too-many-branches
         cmd, display_name=None, years=None, create_cert=False, cert=None, scopes=None, role=None,
-        show_auth_for_sdk=None, skip_assignment=False, keyvault=None):
+        show_auth_for_sdk=None, keyvault=None):
     import time
 
     if role and not scopes or not role and scopes:


### PR DESCRIPTION
**Related command**
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->
`az ad sp create-for-rbac` stopped creating role assignment for newly created service principal without `--role` (#19805) and `--scopes` (#21323).

It has been nearly one year since `--skip-assignment` was made a no-op argument (#19805). We should remove it to keep the command clean.
