### PR TITLE
{App Service} `az webapp config container show`: Fix accidental side-effect plus make sure this function handles both types of input data, lists and dict

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1619,10 +1619,13 @@ def _filter_for_container_settings(cmd, resource_group_name, name, settings,
 
 # TODO: remove this when #3660(service tracking issue) is resolved
 def _mask_creds_related_appsettings(settings):
-    for x in [x1 for x1 in settings if x1 in APPSETTINGS_TO_MASK]:
-        settings[x] = None
-    return settings
+    if isinstance(settings, list):
+        return [
+            {**x, **{'value': None if x['name'] in APPSETTINGS_TO_MASK else x['value']}}
+            for x in settings
+        ]
 
+    return {k: None if k in APPSETTINGS_TO_MASK else v for k, v in settings.items()}
 
 def add_hostname(cmd, resource_group_name, webapp_name, hostname, slot=None):
     from azure.mgmt.web.models import HostNameBinding

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1627,6 +1627,7 @@ def _mask_creds_related_appsettings(settings):
 
     return {k: None if k in APPSETTINGS_TO_MASK else v for k, v in settings.items()}
 
+
 def add_hostname(cmd, resource_group_name, webapp_name, hostname, slot=None):
     from azure.mgmt.web.models import HostNameBinding
     client = web_client_factory(cmd.cli_ctx)


### PR DESCRIPTION
The current implementation only supports dicts while its unit test explicitely passes a list of dicts as one of 6 cases. So it's actually broken in this regard.

**Related command**
N/A

**Description**<!--Mandatory-->
I've accidentally noticed a side-effect in the function `_mask_creds_related_appsettings()` - it's modifying the dictionary it's iterating over, so when it's returning a new dict, in fact the input dict is also being modified, which may lead to some failures later. While fixing it, I also noticed that it's supposed to work with both list or dicts and dicts, while not actually doing it.

In fact, this could be a bug, that this function should have only been used for one type of data, and it just accidentally does not break on lists while doing nothing basically, so difficult to spot the problem.

**Testing Guide**
```shell
# this is the command that I originally used
$ az webapp config container show

$ azdev test LinuxWebappScenarioTest --pytest-args "-n0 -s"
```

**History Notes**
N/A

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
