### PR TITLE
{Misc.} Fix #24749: Remove outdated argument from dev documentation

### DIFF
--- a/doc/authoring_command_modules/README.md
+++ b/doc/authoring_command_modules/README.md
@@ -160,7 +160,7 @@ Style Checks
 ------------
 
 ```
-azdev style --module <module> [--pylint] [--pep8]
+azdev style <module> [--pylint] [--pep8]
 ```
 
 Submitting Pull Requests


### PR DESCRIPTION
closed https://github.com/Azure/azure-cli/issues/24749

**Related command**
Developer Documentation

**Description**<!--Mandatory-->
Removal of outdated argument from developer documentation.

**Testing Guide**
none

**History Notes**

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
