### PR TITLE
[Service Connector] `az webapp/spring/containerapp connection create mysql`: Deprecate mysql single server connection command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/commands.py
@@ -48,12 +48,20 @@ def load_command_table(self, _):
             for target in supported_target_resources:
                 with self.command_group('{} connection create'.format(source.value),
                                         connection_type, client_factory=cf_linker) as ig:
-                    ig.custom_command(target.value, 'connection_create',
-                                      supports_no_wait=True, transform=transform_linker_properties)
+                    if target == RESOURCE.Mysql:
+                        ig.custom_command(target.value, 'connection_create', deprecate_info=self.deprecate(hide=False),
+                                          supports_no_wait=True, transform=transform_linker_properties)
+                    else:
+                        ig.custom_command(target.value, 'connection_create',
+                                          supports_no_wait=True, transform=transform_linker_properties)
                 with self.command_group('{} connection update'.format(source.value),
                                         connection_type, client_factory=cf_linker) as ig:
-                    ig.custom_command(target.value, 'connection_update',
-                                      supports_no_wait=True, transform=transform_linker_properties)
+                    if target == RESOURCE.Mysql:
+                        ig.custom_command(target.value, 'connection_update', deprecate_info=self.deprecate(hide=False),
+                                          supports_no_wait=True, transform=transform_linker_properties)
+                    else:
+                        ig.custom_command(target.value, 'connection_update',
+                                          supports_no_wait=True, transform=transform_linker_properties)
 
             # special target resource, independent implementation
             target = RESOURCE.ConfluentKafka


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
- `az webapp connection create mysql`
- `az spring connection create mysql`
- `az containerapp connection create mysql`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Deprecate the above commands as Mysql Single Server is on the retirement path. https://learn.microsoft.com/en-us/azure/mysql/single-server/single-server-overview

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
