### PR TITLE
{CI} Increase TestDebPackages job timeout to 120 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ variables:
 
 jobs:
 - job: CheckPullRequest
+  timeoutInMinutes: 120
   displayName: "Check the Format of Pull Request Title and Content"
   condition: and(succeeded(), in(variables['System.PullRequest.TargetBranch'], 'dev', 'release'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ variables:
 
 jobs:
 - job: CheckPullRequest
-  timeoutInMinutes: 120
   displayName: "Check the Format of Pull Request Title and Content"
   condition: and(succeeded(), in(variables['System.PullRequest.TargetBranch'], 'dev', 'release'))
 
@@ -808,6 +807,7 @@ jobs:
       ArtifactName: $(deb_system)-$(distro)
 
 - job: TestDebPackages
+  timeoutInMinutes: 120
   displayName: Test Deb Packages
   dependsOn:
   - BuildDebPackages


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Some jobs reached the default timeout 60min and failed. Increase default timeout to 120 minutes.
```
The job running on agent pool-ubuntu-2004 20 ran longer than the maximum time of 60 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134 
```

Ref: [Set timeout in Azure Pipeline](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#timeouts)
