### PR TITLE
{Packaging} Use openssl 1.1 in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ LABEL maintainer="Microsoft" \
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl perl git zip \
- && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev linux-headers \
+RUN apk add --no-cache bash openssh ca-certificates jq curl openssl1.1-compat perl git zip \
+ && apk add --no-cache --virtual .build-deps gcc make openssl1.1-compat-dev libffi-dev musl-dev linux-headers \
  && apk add --no-cache libintl icu-libs libc6-compat \
  && apk add --no-cache bash-completion \
  && update-ca-certificates


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
[Apline 3.17](https://alpinelinux.org/posts/Alpine-3.17.0-released.html) use openssl3 as default openssl.
Current cryptography or pyOpenSSL is not compatible and fails when run `az self-test`
```
ERROR: Error relocating /usr/local/lib/python3.10/site-packages/cryptography/hazmat/bindings/_openssl.abi3.so: FIPS_mode_set: symbol not found
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
    raise ex
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/command_modules/profile/custom.py", line 188, in check_cli
    raise ex
  File "/usr/local/lib/python3.10/site-packages/azure/cli/command_modules/profile/custom.py", line 183, in check_cli
    create_invoker_and_load_cmds_and_args(cmd.cli_ctx)
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/file_util.py", line 74, in create_invoker_and_load_cmds_and_args
    invoker.commands_loader.load_arguments()
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/__init__.py", line 502, in load_arguments
    cmd.load_arguments()  # this loads the arguments via reflection
  File "/usr/local/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 318, in load_arguments
    super(AzCliCommand, self).load_arguments()
  File "/usr/local/lib/python3.10/site-packages/knack/commands.py", line 104, in load_arguments

```

Use 1.1 explicitly.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
