### PR TITLE
{Packaging} Bump knack to 0.10.1 to support `bytearray` serialization

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -49,7 +49,7 @@ DEPENDENCIES = [
     'cryptography',
     'humanfriendly~=10.0',
     'jmespath',
-    'knack~=0.10.0',
+    'knack~=0.10.1',
     'msal-extensions~=1.0.0',
     'msal[broker]==1.20.0',
     'msrestazure~=0.6.4',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -106,7 +106,7 @@ javaproperties==0.5.1
 Jinja2==3.0.3
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.10.0
+knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal[broker]==1.20.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -107,7 +107,7 @@ javaproperties==0.5.1
 Jinja2==3.0.3
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.10.0
+knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal[broker]==1.20.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -106,7 +106,7 @@ javaproperties==0.5.1
 Jinja2==3.0.3
 jmespath==0.9.5
 jsondiff==2.0.0
-knack==0.10.0
+knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
 msal[broker]==1.20.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
Adopt https://github.com/microsoft/knack/pull/268 to provide a temporary workaround for https://github.com/Azure/azure-cli/pull/24763. This unblocks containerservice (AKS) extension's serialization of [ManagedClusterSecurityProfileCustomCATrustCertificates](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/containerservice/resource-manager/Microsoft.ContainerService/preview/2022-09-02-preview/managedClusters.json#L6605) object.
