### PR TITLE
[Packaging] Fix #24788: Add `-I` in entrypoint on MacOS

### DIFF
--- a/scripts/release/homebrew/docker/formula_template.txt
+++ b/scripts/release/homebrew/docker/formula_template.txt
@@ -47,7 +47,7 @@ class AzureCli < Formula
 
     (bin/"az").write <<~EOS
       #!/usr/bin/env bash
-      AZ_INSTALLER=HOMEBREW #{libexec}/bin/python -m azure.cli \"$@\"
+      AZ_INSTALLER=HOMEBREW #{libexec}/bin/python -Im azure.cli \"$@\"
     EOS
 
     bash_completion.install "az.completion" => "az"


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #24788.

`az` start with `python -m` and [`-m`](https://docs.python.org/3.11/using/cmdline.html#cmdoption-m) adds the current directory to the start of `sys.path`.

In #24788, if the working dir has a `brotli` folder, `urllib3` will import it and lead to error.
https://github.com/urllib3/urllib3/blob/0612a53f48f72ab6e9ef58ccf1d6a25b847152fc/src/urllib3/response.py#L17-L23

To remove current dir from path, `-I` is needed.
> [-I](https://docs.python.org/3.11/using/cmdline.html#cmdoption-I) option can be used to run the script in isolated mode where [sys.path](https://docs.python.org/3.11/library/sys.html#sys.path) contains neither the current directory nor the user’s site-packages directory. All PYTHON* environment variables are ignored, too.     ----[Python doc](https://docs.python.org/3.11/using/cmdline.html)


`-I` has already been added in entrypoint on Linux and Windows, this PR adds it on MacOS.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
