### PR TITLE
[ServiceBus] Fix #24741: Remove invalid arguments for entity update commands

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -170,11 +170,10 @@ def cli_sbqueue_create(cmd, client, resource_group_name, namespace_name, queue_n
         parameters=queue_params)
 
 
-def cli_sbqueue_update(instance, lock_duration=None,
-                       max_size_in_megabytes=None, requires_duplicate_detection=None, requires_session=None,
+def cli_sbqueue_update(instance, lock_duration=None, max_size_in_megabytes=None,
                        default_message_time_to_live=None, dead_lettering_on_message_expiration=None,
                        duplicate_detection_history_time_window=None, max_delivery_count=None, status=None,
-                       auto_delete_on_idle=None, enable_partitioning=None, enable_express=None,
+                       auto_delete_on_idle=None, enable_express=None,
                        forward_to=None, forward_dead_lettered_messages_to=None, enable_batched_operations=None,
                        max_message_size_in_kilobytes=None):
 
@@ -188,12 +187,6 @@ def cli_sbqueue_update(instance, lock_duration=None,
 
     if max_size_in_megabytes:
         instance.max_size_in_megabytes = max_size_in_megabytes
-
-    if requires_duplicate_detection is not None:
-        instance.requires_duplicate_detection = requires_duplicate_detection
-
-    if requires_session is not None:
-        instance.requires_session = requires_session
 
     if default_message_time_to_live:
         instance.default_message_time_to_live = return_valid_duration(default_message_time_to_live, instance.default_message_time_to_live)
@@ -218,9 +211,6 @@ def cli_sbqueue_update(instance, lock_duration=None,
         instance.auto_delete_on_idle = return_valid_duration(auto_delete_on_idle, instance.auto_delete_on_idle)
     elif instance.auto_delete_on_idle > timedelta(days=DURATION_LIMIT):
         instance.auto_delete_on_idle = None
-
-    if enable_partitioning is not None:
-        instance.enable_partitioning = enable_partitioning
 
     if enable_express is not None:
         instance.enable_express = enable_express
@@ -301,10 +291,9 @@ def cli_sbtopic_create(cmd, client, resource_group_name, namespace_name, topic_n
 
 
 def cli_sbtopic_update(instance, default_message_time_to_live=None,
-                       max_size_in_megabytes=None, requires_duplicate_detection=None,
-                       duplicate_detection_history_time_window=None,
+                       max_size_in_megabytes=None, duplicate_detection_history_time_window=None,
                        enable_batched_operations=None, status=None, support_ordering=None, auto_delete_on_idle=None,
-                       enable_partitioning=None, enable_express=None, max_message_size_in_kilobytes=None):
+                       enable_express=None, max_message_size_in_kilobytes=None):
 
     from datetime import timedelta
     from azure.cli.command_modules.servicebus.constants import DURATION_LIMIT
@@ -316,9 +305,6 @@ def cli_sbtopic_update(instance, default_message_time_to_live=None,
 
     if max_size_in_megabytes:
         instance.max_size_in_megabytes = max_size_in_megabytes
-
-    if requires_duplicate_detection is not None:
-        instance.requires_duplicate_detection = requires_duplicate_detection
 
     if duplicate_detection_history_time_window:
         instance.duplicate_detection_history_time_window = return_valid_duration(duplicate_detection_history_time_window, instance.duplicate_detection_history_time_window)
@@ -338,9 +324,6 @@ def cli_sbtopic_update(instance, default_message_time_to_live=None,
         instance.auto_delete_on_idle = return_valid_duration(auto_delete_on_idle, instance.auto_delete_on_idle)
     elif instance.auto_delete_on_idle > timedelta(days=DURATION_LIMIT):
         instance.auto_delete_on_idle = None
-
-    if enable_partitioning is not None:
-        instance.enable_partitioning = enable_partitioning
 
     if enable_express is not None:
         instance.enable_express = enable_express
@@ -419,8 +402,7 @@ def cli_sbsubscription_create(cmd, client, resource_group_name, namespace_name, 
         parameters=subscription_params)
 
 
-def cli_sbsubscription_update(instance, lock_duration=None,
-                              requires_session=None, default_message_time_to_live=None,
+def cli_sbsubscription_update(instance, lock_duration=None, default_message_time_to_live=None,
                               dead_lettering_on_message_expiration=None,
                               max_delivery_count=None, status=None, enable_batched_operations=None,
                               auto_delete_on_idle=None, forward_to=None, forward_dead_lettered_messages_to=None, dead_lettering_on_filter_evaluation_exceptions=None):
@@ -432,9 +414,6 @@ def cli_sbsubscription_update(instance, lock_duration=None,
         instance.lock_duration = return_valid_duration(lock_duration, instance.lock_duration)
     elif instance.lock_duration > timedelta(days=DURATION_LIMIT):
         instance.lock_duration = None
-
-    if requires_session is not None:
-        instance.requires_session = requires_session
 
     if default_message_time_to_live:
         instance.default_message_time_to_live = return_valid_duration(default_message_time_to_live, instance.default_message_time_to_live)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```sh
az servicebus queue update --resource-group {} --namespace-name {} --name {} --enable-partitioning --enable-duplicate-detection --enable-session
az servicebus topic update --resource-group {} --namespace-name {} --name {} --enable-partitioning --enable-duplicate-detection
az servicebus topic subscription update --resource-group {} --namespace-name {} --name {} --enable-session
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The following properties of an entity cannot be updated post creation but the update the commands for entities have these arguments, which are invalid and fail as such

- Partitioning (Queues & Topics)
- Duplicate Detection (Queues & Topics)
- Sessions (Queues & Subscriptions)

This PR removes the arguments for the update commands.

resolves #24741

**Testing Guide**
<!--Example commands with explanations.-->

```sh
az servicebus queue update --resource-group {} --namespace-name {} --name {} --enable-partitioning --enable-duplicate-detection --enable-session
az servicebus topic update --resource-group {} --namespace-name {} --name {} --enable-partitioning --enable-duplicate-detection
az servicebus topic subscription update --resource-group {} --namespace-name {} --name {} --enable-session
```

The above commands currently fail with a 400 Bad Request, which is expected due to the invalid arguments that can't be updated post entity creation. With this PR, they should be removed from the documentation, command help, and error as invalid arguments directly.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ServiceBus] `az servicebus queue update`: Remove invalid arguments for queue update command
[ServiceBus] `az servicebus topic update`: Remove invalid arguments for topic update command
[ServiceBus] `az servicebus topic subscription update`: Remove invalid arguments for subscription update command

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
