### PR TITLE
{Style} Use light theme by default on MacOS

### DIFF
--- a/src/azure-cli-core/azure/cli/core/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/__init__.py
@@ -171,11 +171,21 @@ class AzCli(CLI):
     def _configure_style(self):
         from azure.cli.core.util import in_cloud_console
         from azure.cli.core.style import format_styled_text, get_theme_dict, Style
+        import platform
 
-        # Configure Style
+        # Most terminals, like those on Windows, Ubuntu use dark background
+        default_theme = 'dark'
+
+        if in_cloud_console():
+            # Cloud Shell has its own RGB-defined theme
+            default_theme = 'cloud-shell'
+        elif platform.system() == 'Darwin':
+            # MacOS's terminal by default has white background
+            # https://github.com/Azure/azure-cli/issues/18298#issuecomment-1263529261
+            default_theme = 'light'
+
         if self.enable_color:
-            theme = self.config.get('core', 'theme',
-                                    fallback="cloud-shell" if in_cloud_console() else "dark")
+            theme = self.config.get('core', 'theme', fallback=default_theme)
 
             theme_dict = get_theme_dict(theme)
 


### PR DESCRIPTION
## Issue

We specify the color for warnings as [ANSI color](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) **Bright Yellow** without any specification of the actual RGB value:

https://github.com/Azure/azure-cli/blob/8d8d71707d6c60083d008062667cab18d0adaa25/src/azure-cli-core/azure/cli/core/style.py#L73

According to https://github.com/Azure/azure-cli/issues/18298#issuecomment-1263529261, MacOS's terminal by default uses white background and **Bright Yellow** is not readable on that white background.

Something like:

![image](https://user-images.githubusercontent.com/6078508/120118834-4bc28e80-c19d-11eb-9738-f6084b01a644.png)

Personally, I think it should the terminal's theme's responsibility to make all ANSI colors readable on its background.

## Change

Since MacOS's terminal by default uses white background, we by default uses `light` theme which uses (dark) **Yellow** for warnings:

https://github.com/Azure/azure-cli/blob/8d8d71707d6c60083d008062667cab18d0adaa25/src/azure-cli-core/azure/cli/core/style.py#L85

## Cons

However, a disadvantage is that if the user manually chooses a dark background, or use an IDE like PyCharm with dark theme. There may be other readability issues if we default to `light` theme, such as blue, magenta. 

As there isn't a way to detect the background color, there is no optimal solution. Users still need to run `az config set core.theme=light/dark` to select the color theme or totally disable color with `az config set core.no_color=true`.
