### PR TITLE
{Packaging} Hotfix: Install OpenSSL 3.0 in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,11 @@ LABEL maintainer="Microsoft" \
 # pip wheel - required for CLI packaging
 # jmespath-terminal - we include jpterm as a useful tool
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl1.1-compat perl git zip \
+
+# We don't use openssl (3.0) for now. We only install it so that users can use it.
+# Once cryptography is bumped to the latest version, openssl1.1-compat should be removed and openssl1.1-compat-dev
+# should be replaced by openssl-dev.
+RUN apk add --no-cache bash openssh ca-certificates jq curl openssl openssl1.1-compat perl git zip \
  && apk add --no-cache --virtual .build-deps gcc make openssl1.1-compat-dev libffi-dev musl-dev linux-headers \
  && apk add --no-cache libintl icu-libs libc6-compat \
  && apk add --no-cache bash-completion \


### PR DESCRIPTION
**Description**<!--Mandatory-->

An out-of-courtesy fix for https://github.com/Azure/azure-cli/issues/24836

`openssl` command was replaced by `openssl1.1` in the docker image by https://github.com/Azure/azure-cli/pull/24768.

Some users using Azure CLI docker image directly rely on `openssl` command without explicitly specifying `openssl` dependency. This is not a good practice as a dependency(Azure CLI)'s dependency (`openssl`) is an internal implementation, so the user shouldn't assume the dependency's dependency is always available. 

Even though we don't guarantee the availability of tools or packages in the docker image, we add `openssl` out of courtesy, so that those users can be unblocked quickly without changing their code.

**Additional information**

This hotfix will only be rolled out to the docker image. We won't bump version or forward `main` branch because

- this is not a change on Azure CLI
- this will make `az upgrade` on all platforms think there is an available update
