### PR TITLE
[Postgres Flexible Server] Update Postgres Flexible server help text - replace single quote with double quote

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -115,13 +115,13 @@ examples:
 
       # add testIdentity as an access policy with key permissions 'Wrap Key', 'Unwrap Key', 'Get' and 'List' inside testVault
 
-      az keyvault set-policy -g testGroup -n testVault --object-id '<principalID of testIdentity>' --key-permissions wrapKey unwrapKey get list
+      az keyvault set-policy -g testGroup -n testVault --object-id "<principalID of testIdentity>" --key-permissions wrapKey unwrapKey get list
 
 
       # create flexible server with data encryption enabled
 
       az postgres flexible-server create -g testGroup -n testServer --location testLocation \\
-        --key '<key identifier of testKey>' --identity testIdentity
+        --key "<key identifier of testKey>" --identity testIdentity
 """
 
 helps['postgres flexible-server show'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -157,7 +157,7 @@ examples:
   - name: Change key/identity for data encryption. Data encryption cannot be enabled post server creation, this will only update the key/identity.
     text: >
       az postgres flexible-server update --resource-group testGroup --name testserver \\
-        --key '<key identifier of newKey>' --identity newIdentity
+        --key "<key identifier of newKey>" --identity newIdentity
 """
 
 helps['postgres flexible-server restore'] = """


### PR DESCRIPTION
**Related command**
az postgres flexible-server create --help

**Description**<!--Mandatory-->
Replace the single quote with double quote in the --help text for postgres flexible server
when running the command with single quote the command will fail and having single quate in the --help text is confusing for the cli consumer.

**Testing Guide**
az postgres flexible-server create --help

