### PR TITLE
{RDBMS} Improve help docs for MySQL and PostgreSQL flexible server CMK

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_mysql.py
@@ -98,77 +98,89 @@ examples:
     text: >
       # create keyvault
 
-      az keyvault create -g testGroup -n testVault --location testLocation --enable-purge-protection true
+      az keyvault create -g testGroup -n testVault --location testLocation \\
+        --enable-purge-protection true
 
 
-      # create key in keyvault
+      # create key in keyvault and save its key identifier
 
-      az keyvault key create --name testKey -p software --vault-name testVault
+      keyIdentifier=$(az keyvault key create --name testKey -p software \\
+        --vault-name testVault --query key.kid -o tsv)
 
 
-      # create identity
+      # create identity and save its principalId
 
-      az identity create -g testGroup --name testIdentity --location testLocation
+      identityPrincipalId=$(az identity create -g testGroup --name testIdentity \\
+        --location testLocation --query principalId -o tsv)
 
 
       # add testIdentity as an access policy with key permissions 'Wrap Key', 'Unwrap Key', 'Get' and 'List' inside testVault
 
-      az keyvault set-policy -g testGroup -n testVault --object-id '<principalID of testIdentity>' --key-permissions wrapKey unwrapKey get list
+      az keyvault set-policy -g testGroup -n testVault --object-id $identityPrincipalId \\
+        --key-permissions wrapKey unwrapKey get list
 
 
       # create flexible server with data encryption enabled
 
       az mysql flexible-server create -g testGroup -n testServer --location testLocation \\
-        --key '<key identifier of testKey>' --identity testIdentity
+        --key $keyIdentifier --identity testIdentity
   - name: >
       Create a MySQL flexible server with geo redundant backup and data encryption.
     text: >
       # create keyvault
 
-      az keyvault create -g testGroup -n testVault --location testLocation --enable-purge-protection true
+      az keyvault create -g testGroup -n testVault --location testLocation \\
+        --enable-purge-protection true
 
 
-      # create key in keyvault
+      # create key in keyvault and save its key identifier
 
-      az keyvault key create --name testKey -p software --vault-name testVault
+      keyIdentifier=$(az keyvault key create --name testKey -p software \\
+        --vault-name testVault --query key.kid -o tsv)
 
 
-      # create identity
+      # create identity and save its principalId
 
-      az identity create -g testGroup --name testIdentity --location testLocation
+      identityPrincipalId=$(az identity create -g testGroup --name testIdentity \\
+        --location testLocation --query principalId -o tsv)
 
 
       # add testIdentity as an access policy with key permissions 'Wrap Key', 'Unwrap Key', 'Get' and 'List' inside testVault
 
-      az keyvault set-policy -g testGroup -n testVault --object-id '<principalID of testIdentity>' --key-permissions wrapKey unwrapKey get list
+      az keyvault set-policy -g testGroup -n testVault --object-id $identityPrincipalId \\
+        --key-permissions wrapKey unwrapKey get list
 
 
       # create backup keyvault
 
-      az keyvault create -g testGroup -n testBackupVault --location testBackupLocation --enable-purge-protection true
+      az keyvault create -g testGroup -n testBackupVault --location testBackupLocation \\
+        --enable-purge-protection true
 
 
-      # create backup key in backup keyvault
+      # create backup key in backup keyvault and save its key identifier
 
-      az keyvault key create --name testBackupKey -p software --vault-name testBackupVault
+      backupKeyIdentifier=$(az keyvault key create --name testBackupKey -p software \\
+        --vault-name testBackupVault --query key.kid -o tsv)
 
 
-      # create backup identity
+      # create backup identity and save its principalId
 
-      az identity create -g testGroup --name testBackupIdentity --location testBackupLocation
+      backupIdentityPrincipalId=$(az identity create -g testGroup --name testBackupIdentity \\
+        --location testBackupLocation --query principalId -o tsv)
 
 
       # add testBackupIdentity as an access policy with key permissions 'Wrap Key', 'Unwrap Key', 'Get' and 'List' inside testBackupVault
 
-      az keyvault set-policy -g testGroup -n testBackupVault --object-id '<principalID of testBackupIdentity>' --key-permissions wrapKey unwrapKey get list
+      az keyvault set-policy -g testGroup -n testBackupVault \\
+        --object-id $backupIdentityPrincipalId --key-permissions wrapKey unwrapKey get list
 
 
       # create flexible server with geo redundant backup and data encryption enabled
 
       az mysql flexible-server create -g testGroup -n testServer --location testLocation \\
         --geo-redundant-backup Enabled \\
-        --key '<key identifier of testKey>' --identity testIdentity \\
-        --backup-key '<key identifier of testBackupKey>' --backup-identity testBackupIdentity
+        --key $keyIdentifier --identity testIdentity \\
+        --backup-key $backupKeyIdentifier --backup-identity testBackupIdentity
 """
 
 helps['mysql flexible-server show'] = """
@@ -203,15 +215,36 @@ examples:
     crafted: true
   - name: Set or change key and identity for data encryption.
     text: >
+      # get key identifier of the existing key
+
+      newKeyIdentifier=$(az keyvault key show --vault-name testVault --name testKey \\
+        --query key.kid -o tsv)
+
+
+      # update server with new key/identity
+
       az mysql flexible-server update --resource-group testGroup --name testserver \\
-        --key '<key identifier of newKey>' --identity newIdentity
+        --key $newKeyIdentifier --identity newIdentity
   - name: Set or change key, identity, backup key and backup identity for data encryption with geo redundant backup.
     text: >
+      # get key identifier of the existing key and backup key
+
+      newKeyIdentifier=$(az keyvault key show --vault-name testVault --name testKey \\
+        --query key.kid -o tsv)
+
+      newBackupKeyIdentifier=$(az keyvault key show --vault-name testBackupVault \\
+        --name testBackupKey --query key.kid -o tsv)
+
+
+      # update server with new key/identity and backup key/identity
+
       az mysql flexible-server update --resource-group testGroup --name testserver \\
-        --key '<key identifier of newKey>' --identity newIdentity \\
-        --backup-key '<key identifier of newBackupKey>' --backup-identity newBackupIdentity
+        --key $newKeyIdentifier --identity newIdentity \\
+        --backup-key $newBackupKeyIdentifier --backup-identity newBackupIdentity
   - name: Disable data encryption for flexible server.
-    text: az mysql flexible-server update --resource-group testGroup --name testserver --disable-data-encryption
+    text: >
+      az mysql flexible-server update --resource-group testGroup --name testserver \\
+        --disable-data-encryption
 """
 
 helps['mysql flexible-server delete'] = """


### PR DESCRIPTION
**Related command**
`az mysql/postgres flexible-server create/update`

**Description**<!--Mandatory-->
For CMK related commands for MySQL and PostgreSQL flexible server, we add explicitly in the instructions how to get the necessary key identifiers and principalId's for user managed identities.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
