### PR TITLE
[ARM] Fix #24810: Support ARM64 architecture for Bicep installation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -105,7 +105,7 @@ def load_arguments(self, _):
     bicep_stdout_type = CLIArgumentType(options_list=['--stdout'], action='store_true', help="When set, prints all output to stdout instead of corresponding files.")
     bicep_target_platform_type = CLIArgumentType(options_list=['--target-platform', '-t'],
                                                  arg_type=get_enum_type(
-                                                     ["win-x64", "linux-musl-x64", "linux-x64", "osx-x64"]),
+                                                     ["win-x64", "linux-musl-x64", "linux-x64", "osx-x64", "linux-arm64", "osx-arm64"]),
                                                  help="The platform the Bicep CLI will be running on. Set this to skip automatic platform detection if it does not work properly.")
 
     _PROVIDER_HELP_TEXT = 'the resource namespace, aka \'provider\''


### PR DESCRIPTION
Fix to support ARM64 arch for Bicep installation

 fixes Azure/azure-cli#24810 

On OSX ARM64 architecture VMs the Bicep install fails because the `bicep_target_platform_type` enum currently has only x64 arch. So this ends up installing x64 version. It eventually fails with the below error:

```
$ az bicep install --target-platform osx-arm64
az bicep install: 'osx-arm64' is not a valid value for '--target-platform'. Allowed values: win-x64, linux-musl-x64, linux-x64, osx-x64.
```

```
> az bicep version
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

Here is the download URL for the ARM64:
https://github.com/Azure/bicep/releases/latest/download/bicep-linux-arm64
https://github.com/Azure/bicep/releases/download/v0.13.1/bicep-osx-arm64


**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
