### PR TITLE
{Packaging} Handle `cm2` in Mariner 2.0 RPM name

### DIFF
--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -10,13 +10,12 @@ WORKDIR /azure-cli
 
 COPY . .
 
-# Mariner only has 'python3' package. It has no version-specific packages, like 'python39'.
-# - On Mariner 1.0, 'python3' is Python 3.7
-# - On Mariner 2.0, 'python3' is Python 3.9
+# Mariner 2.0 only has 'python3' package, which is currently (2022-12-09) Python 3.9.
+# It has no version-specific packages like 'python39'.
 RUN dos2unix ./scripts/release/rpm/azure-cli.spec && \
     REPO_PATH=$(pwd) CLI_VERSION=$cli_version PYTHON_PACKAGE=python3 PYTHON_CMD=python3 \
     rpmbuild -v -bb --clean scripts/release/rpm/azure-cli.spec && \
-    cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.x86_64.rpm /azure-cli-dev.rpm
+    cp /usr/src/mariner/RPMS/x86_64/azure-cli-${cli_version}-1.cm2.x86_64.rpm /azure-cli-dev.rpm
 
 FROM ${image} AS execution-env
 


### PR DESCRIPTION
**Description**<!--Mandatory-->

CI job **Build Rpm Package Mariner 2.0** fails:

https://dev.azure.com/azclitools/public/_build/results?buildId=20025&view=logs&j=05d32766-0180-56c9-d65b-603741da4b97&t=199e5dcb-1f4f-59eb-61f9-d8fc896d9ae2

```
Wrote: /usr/src/mariner/RPMS/x86_64/azure-cli-2.43.0-1.cm2.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.UNvYKb
+ umask 022
+ cd /usr/src/mariner/BUILD
+ /bin/rm -rf /usr/src/mariner/BUILDROOT/azure-cli-2.43.0-1.cm2.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
Executing(rmbuild): /bin/sh -e /var/tmp/rpm-tmp.ShFyrU
+ umask 022
+ cd /usr/src/mariner/BUILD
+ RPM_EC=0
++ jobs -p
+ exit 0
cp: cannot stat '/usr/src/mariner/RPMS/x86_64/azure-cli-2.43.0-1.x86_64.rpm': No such file or directory
```

Previously the package name looks like `azure-cli-2.43.0-1.x86_64.rpm`, but it now became `azure-cli-2.43.0-1.cm2.x86_64.rpm` - `cm2` is added to the name (https://github.com/microsoft/CBL-Mariner/pull/3958), just like `el8`.

Other packages in https://packages.microsoft.com/cbl-mariner/2.0/prod/Microsoft/x86_64/ even have other inconsistent names  such as `aspnetcore-runtime-6.0.7-cm.2-x64.rpm`. While I will contact Mariner 2.0 team internally for this change, let's first fix the CI pipeline.

**Additional information**

Our other RPM packages:

- for RHEL 8: `azure-cli-2.43.0-1.el8.x86_64.rpm` (https://packages.microsoft.com/rhel/8/prod/)
- for RHEL 9: `azure-cli-2.43.0-1.el9.x86_64.rpm` (https://packages.microsoft.com/rhel/9.0/prod/)