### PR TITLE
[App Service] Fix #24858: Support for new isolated v2 (I4v2, I5v2, I6v2) SKUs

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -86,7 +86,7 @@ def get_sku_tier(name):  # pylint: disable=too-many-return-statements
         return 'ElasticPremium'
     if name in ['I1', 'I2', 'I3']:
         return 'Isolated'
-    if name in ['I1V2', 'I2V2', 'I3V2']:
+    if name in ['I1V2', 'I2V2', 'I3V2', 'I4V2', 'I5V2', 'I6V2']:
         return 'IsolatedV2'
     if name in ['WS1', 'WS2', 'WS3']:
         return 'WorkflowStandard'


### PR DESCRIPTION
PR to add the Support for New Isolated v2 (I4v2, I5v2, I6v2) skus

 fixes Azure/azure-cli#24858 Support for New Isolated v2 (I4v2, I5v2, I6v2) skus

The below docs talks about the new isolated plan skus:

https://learn.microsoft.com/en-us/cli/azure/appservice?view=azure-cli-latest#az-appservice-list-locations

However, running the command with those skus fails:

>az appservice list-locations --sku I5v2

```
ERROR: az_command_data_logger: az appservice list-locations: 'I5V2' is not a valid value for '--sku'. Allowed values: F1, FREE, D1, SHARED, B1, B2, B3, S1, S2, S3, P1V2, P2V2, P3V2, P1V3, P2V3, P3V3, I1, I2, I3, I1v2, I2v2, I3v2, WS1, WS2, WS3.
```

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
