### PR TITLE
[App Service] `az appservice ase upgrade/send-test-notification`: Add new commands for ASE to support ASE upgrade and sending test notifications

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2296,7 +2296,7 @@ helps['appservice ase create-inbound-services'] = """
 
 helps['appservice ase upgrade'] = """
     type: command
-    short-summary: Upgrade app service environment.
+    short-summary: Upgrade app service environment v3.
     examples:
     - name: Upgrade app service environment v3.
       text: |
@@ -2305,9 +2305,9 @@ helps['appservice ase upgrade'] = """
 
 helps['appservice ase send-test-notification'] = """
     type: command
-    short-summary: Send test notifications.
+    short-summary: Send a test upgrade notification in app service environment v3.
     examples:
-    - name: Send test notification about upgrade - app service environment v3.
+    - name: Send a test upgrade notification in app service environment v3.
       text: |
           az appservice ase send-test-notification -n MyAseV3Name -g MyResourceGroup
 """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2294,6 +2294,17 @@ helps['appservice ase create-inbound-services'] = """
             --vnet-name MyASEVirtualNetwork --subnet MyAseSubnet
 """
 
+helps['appservice ase upgrade'] = """
+    type: command
+    short-summary: Upgrade app service environment.
+    examples:
+    - name: Upgrade app service environment v3.
+      text: |
+          az appservice ase upgrade -n MyAseV3Name -g MyResourceGroup
+    - name: Send test notification about upgrade - app service environment v3.
+      text: |
+          az appservice ase upgrade -n MyAseV3Name -g MyResourceGroup --test-notification
+"""
 
 helps['appservice ase update'] = """
     type: command

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2301,9 +2301,15 @@ helps['appservice ase upgrade'] = """
     - name: Upgrade app service environment v3.
       text: |
           az appservice ase upgrade -n MyAseV3Name -g MyResourceGroup
+"""
+
+helps['appservice ase upgrade-test-notification'] = """
+    type: command
+    short-summary: Send test notifications.
+    examples:
     - name: Send test notification about upgrade - app service environment v3.
       text: |
-          az appservice ase upgrade -n MyAseV3Name -g MyResourceGroup --test-notification
+          az appservice ase upgrade-test-notification -n MyAseV3Name -g MyResourceGroup
 """
 
 helps['appservice ase update'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2303,13 +2303,13 @@ helps['appservice ase upgrade'] = """
           az appservice ase upgrade -n MyAseV3Name -g MyResourceGroup
 """
 
-helps['appservice ase upgrade-test-notification'] = """
+helps['appservice ase send-test-notification'] = """
     type: command
     short-summary: Send test notifications.
     examples:
     - name: Send test notification about upgrade - app service environment v3.
       text: |
-          az appservice ase upgrade-test-notification -n MyAseV3Name -g MyResourceGroup
+          az appservice ase send-test-notification -n MyAseV3Name -g MyResourceGroup
 """
 
 helps['appservice ase update'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -983,6 +983,9 @@ def load_arguments(self, _):
                    help='Configure App Service Environment as Zone Redundant. Applies to ASEv3 only.')
     with self.argument_context('appservice ase delete') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
+    with self.argument_context('appservice ase upgrade') as c:
+        c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
+        c.argument('test_notification', options_list=['--test-notification', '-t'], help='(ASEv3 only) Send test notifications')
     with self.argument_context('appservice ase update') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment',
                    local_context_attribute=LocalContextAttribute(name='ase_name', actions=[LocalContextAction.GET]))

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -985,7 +985,7 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
     with self.argument_context('appservice ase upgrade') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
-    with self.argument_context('appservice ase upgrade-test-notification') as c:
+    with self.argument_context('appservice ase send-test-notification') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
     with self.argument_context('appservice ase update') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment',

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -985,7 +985,8 @@ def load_arguments(self, _):
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
     with self.argument_context('appservice ase upgrade') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
-        c.argument('test_notification', options_list=['--test-notification', '-t'], help='(ASEv3 only) Send test notifications')
+    with self.argument_context('appservice ase upgrade-test-notification') as c:
+        c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment')
     with self.argument_context('appservice ase update') as c:
         c.argument('name', options_list=['--name', '-n'], help='Name of the app service environment',
                    local_context_attribute=LocalContextAttribute(name='ase_name', actions=[LocalContextAction.GET]))

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -125,24 +125,39 @@ def update_appserviceenvironment(cmd, name, resource_group_name=None, front_end_
     logger.warning('No updates were applied. The version of ASE may not be applicable to this update.')
 
 
-def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, test_notification=False, no_wait=False):
+def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, no_wait=False):
     ase_client = _get_ase_client_factory(cmd.cli_ctx)
     if resource_group_name is None:
         resource_group_name = _get_resource_group_name_from_ase(ase_client, name)
     ase_def = ase_client.get(resource_group_name, name)
     if ase_def.kind.lower() == 'asev3':
         if ase_def.upgrade_preference == "Manual":
-            if test_notification:
+            if ase_def.upgrade_availability == "Ready":
+               return sdk_no_wait(no_wait, ase_client.begin_upgrade, resource_group_name=resource_group_name, name=name)
+            else:
+                raise ValidationError('An upgrade is not available for your ASEv3.')
+        else:
+            raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
+https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information')
+    else:
+        raise ValidationError('No upgrade were applied. This version of ASE not support upgrade.')
+
+
+def upgrade_test_notification_appserviceenvironment(cmd, name, resource_group_name=None):
+    ase_client = _get_ase_client_factory(cmd.cli_ctx)
+    if resource_group_name is None:
+        resource_group_name = _get_resource_group_name_from_ase(ase_client, name)
+    ase_def = ase_client.get(resource_group_name, name)
+    if ase_def.kind.lower() == 'asev3':
+        if ase_def.upgrade_preference == "Manual":
                 ase_client.test_upgrade_available_notification(resource_group_name=resource_group_name,
                                                                name=name)
                 return logger.info('The test notification has been sent')
-            if ase_def.upgrade_availability == "Ready":
-                ase_client.begin_upgrade(resource_group_name=resource_group_name, name=name, no_wait=no_wait)
         else:
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
-                https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference')
+https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information')
     else:
-        logger.warning('No upgrade were applied. This version of ASE not support upgrade.')
+        raise ValidationError('The test notification has not been sent. This version of ASE does not support test notification.')
 
 
 def list_appserviceenvironment_addresses(cmd, name, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -143,7 +143,7 @@ https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-prefere
         raise ValidationError('No upgrade were applied. This version of ASE not support upgrade.')
 
 
-def upgrade_test_notification_appserviceenvironment(cmd, name, resource_group_name=None):
+def send_test_notification_appserviceenvironment(cmd, name, resource_group_name=None):
     ase_client = _get_ase_client_factory(cmd.cli_ctx)
     if resource_group_name is None:
         resource_group_name = _get_resource_group_name_from_ase(ase_client, name)

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -142,7 +142,7 @@ def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, test_noti
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
                 https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference')
     else:
-        logger.warning('No updates were applied. The version of ASE may not be applicable to this update.')
+        logger.warning('No upgrade were applied. This version of ASE not support upgrade.')
 
 
 def list_appserviceenvironment_addresses(cmd, name, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -133,7 +133,8 @@ def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, no_wait=F
     if ase_def.kind.lower() == 'asev3':
         if ase_def.upgrade_preference == "Manual":
             if ase_def.upgrade_availability == "Ready":
-               return sdk_no_wait(no_wait, ase_client.begin_upgrade, resource_group_name=resource_group_name, name=name)
+                sdk_no_wait(no_wait, ase_client.begin_upgrade,
+                            resource_group_name=resource_group_name, name=name)
             else:
                 raise ValidationError('An upgrade is not available for your ASEv3.')
         else:
@@ -150,14 +151,15 @@ def send_test_notification_appserviceenvironment(cmd, name, resource_group_name=
     ase_def = ase_client.get(resource_group_name, name)
     if ase_def.kind.lower() == 'asev3':
         if ase_def.upgrade_preference == "Manual":
-                ase_client.test_upgrade_available_notification(resource_group_name=resource_group_name,
-                                                               name=name)
-                return logger.info('The test notification has been sent.')
+            ase_client.test_upgrade_available_notification(resource_group_name=resource_group_name,
+                                                           name=name)
+            logger.info('The test notification has been sent.')
         else:
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
 https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information.')
     else:
-        raise ValidationError('The test notification has not been sent. This version of ASE does not support test notification.')
+        raise ValidationError('The test notification has not been sent. \
+This version of ASE does not support test notification.')
 
 
 def list_appserviceenvironment_addresses(cmd, name, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -138,7 +138,7 @@ def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, no_wait=F
                 raise ValidationError('An upgrade is not available for your ASEv3.')
         else:
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
-https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information')
+https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information.')
     else:
         raise ValidationError('No upgrade were applied. This version of ASE not support upgrade.')
 
@@ -152,10 +152,10 @@ def send_test_notification_appserviceenvironment(cmd, name, resource_group_name=
         if ase_def.upgrade_preference == "Manual":
                 ase_client.test_upgrade_available_notification(resource_group_name=resource_group_name,
                                                                name=name)
-                return logger.info('The test notification has been sent')
+                return logger.info('The test notification has been sent.')
         else:
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
-https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information')
+https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information.')
     else:
         raise ValidationError('The test notification has not been sent. This version of ASE does not support test notification.')
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -141,7 +141,7 @@ def upgrade_appserviceenvironment(cmd, name, resource_group_name=None, no_wait=F
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
 https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information.')
     else:
-        raise ValidationError('No upgrade were applied. This version of ASE not support upgrade.')
+        raise ValidationError('No upgrade has been applied. This version of ASE not support upgrade.')
 
 
 def send_test_notification_appserviceenvironment(cmd, name, resource_group_name=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/appservice_environment.py
@@ -153,12 +153,12 @@ def send_test_notification_appserviceenvironment(cmd, name, resource_group_name=
         if ase_def.upgrade_preference == "Manual":
             ase_client.test_upgrade_available_notification(resource_group_name=resource_group_name,
                                                            name=name)
-            logger.info('The test notification has been sent.')
+            logger.info('The test notification is being processed.')
         else:
             raise ValidationError('Upgrade preference in ASEv3 must be set to manual, please check \
 https://learn.microsoft.com/azure/app-service/environment/how-to-upgrade-preference for more information.')
     else:
-        raise ValidationError('The test notification has not been sent. \
+        raise ValidationError('The test notification has not been processed. \
 This version of ASE does not support test notification.')
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -439,7 +439,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_appserviceenvironment', supports_no_wait=True, confirmation=True)
         g.custom_command('create-inbound-services', 'create_ase_inbound_services', is_preview=True)
         g.custom_command('upgrade', 'upgrade_appserviceenvironment', supports_no_wait=True, confirmation=True, is_preview=True)
-        g.custom_command('upgrade-test-notification', 'upgrade_test_notification_appserviceenvironment', is_preview=True)
+        g.custom_command('send-test-notification', 'send_test_notification_appserviceenvironment', is_preview=True)
 
     with self.command_group('appservice domain', custom_command_type=appservice_domains, is_preview=True) as g:
         g.custom_command('create', 'create_domain')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -438,6 +438,7 @@ def load_command_table(self, _):
         g.custom_command('update', 'update_appserviceenvironment', supports_no_wait=True)
         g.custom_command('delete', 'delete_appserviceenvironment', supports_no_wait=True, confirmation=True)
         g.custom_command('create-inbound-services', 'create_ase_inbound_services', is_preview=True)
+        g.custom_command('upgrade', 'upgrade_appserviceenvironment', supports_no_wait=True, confirmation=True, is_preview=True)
 
     with self.command_group('appservice domain', custom_command_type=appservice_domains, is_preview=True) as g:
         g.custom_command('create', 'create_domain')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -439,6 +439,7 @@ def load_command_table(self, _):
         g.custom_command('delete', 'delete_appserviceenvironment', supports_no_wait=True, confirmation=True)
         g.custom_command('create-inbound-services', 'create_ase_inbound_services', is_preview=True)
         g.custom_command('upgrade', 'upgrade_appserviceenvironment', supports_no_wait=True, confirmation=True, is_preview=True)
+        g.custom_command('upgrade-test-notification', 'upgrade_test_notification_appserviceenvironment', is_preview=True)
 
     with self.command_group('appservice domain', custom_command_type=appservice_domains, is_preview=True) as g:
         g.custom_command('create', 'create_domain')

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -22,7 +22,8 @@ from azure.cli.command_modules.appservice.appservice_environment import (show_ap
                                                                          create_appserviceenvironment_arm,
                                                                          update_appserviceenvironment,
                                                                          upgrade_appserviceenvironment,
-                                                                         delete_appserviceenvironment)
+                                                                         delete_appserviceenvironment,
+                                                                         upgrade_test_notification_appserviceenvironment)
 
 
 class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
@@ -299,10 +300,63 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         ase_client.get.return_value = host_env
         ase_client.list.return_value = [host_env]
 
-        upgrade_appserviceenvironment(self.mock_cmd, ase_name, test_notification=False, no_wait=False)
+        upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
 
-        # Assert create_or_update is called with correct properties
-        ase_client.begin_upgrade(resource_group_name=rg_name, name=ase_name)
+        # Assert upgrade is called with correct properties
+        ase_client.begin_upgrade.assert_called_once_with(resource_group_name=rg_name, name=ase_name, no_wait=False)
+
+#remove
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
+    def test_app_service_environment_upgrade(self, ase_client_factory_mock, resource_group_mock):
+        ase_name = 'mock_ase_name'
+        rg_name = 'mock_rg_name'
+
+        ase_client = mock.MagicMock()
+        ase_client_factory_mock.return_value = ase_client
+
+        resource_group_mock.return_value = rg_name
+
+        host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
+        host_env.name = ase_name
+        host_env.kind = 'ASEv2'
+        ase_client.get.return_value = host_env
+        ase_client.list.return_value = [host_env]
+
+        upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
+
+        # Assert upgrade is called with correct properties
+        #assert_host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
+        #ase_name = 'mock_ase_name'
+        #assert_host_env.name = ase_name
+        #assert_host_env.kind = 'ASEv2'
+        #result = upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
+        #self.assertIn('No upgrade were applied. This version of ASE not support upgrade.' in result)
+#remove
+
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
+    def test_app_service_environment_upgrade_test_notification_appserviceenvironment_asev3(self, ase_client_factory_mock, resource_group_mock):
+        ase_name = 'mock_ase_name'
+        rg_name = 'mock_rg_name'
+
+        ase_client = mock.MagicMock()
+        ase_client_factory_mock.return_value = ase_client
+
+        resource_group_mock.return_value = rg_name
+
+        host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
+        host_env.name = ase_name
+        host_env.kind = 'ASEv3'
+        host_env.upgrade_availability = 'Ready'
+        host_env.upgrade_preference ='Manual'
+        ase_client.get.return_value = host_env
+        ase_client.list.return_value = [host_env]
+
+        upgrade_test_notification_appserviceenvironment(self.mock_cmd, ase_name)
+
+        # Assert upgrade-test-notification is called with correct properties
+        ase_client.test_upgrade_available_notification.assert_called_once_with(resource_group_name=rg_name, name=ase_name)
 
 
 if __name__ == '__main__':

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -280,6 +280,8 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         self.assertEqual(call_args[0][0], rg_name)
         self.assertEqual(call_args[0][1], deployment_name)
 
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
     def test_app_service_environment_upgrade_asev3(self, ase_client_factory_mock, resource_group_mock):
         ase_name = 'mock_ase_name'
         rg_name = 'mock_rg_name'
@@ -292,9 +294,10 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
         host_env.name = ase_name
         host_env.kind = 'ASEv3'
+        host_env.upgrade_availability = 'Ready'
+        host_env.upgrade_preference ='Manual'
         ase_client.get.return_value = host_env
         ase_client.list.return_value = [host_env]
-        ase_client.upgrade_availability = 'Ready'
 
         upgrade_appserviceenvironment(self.mock_cmd, ase_name, test_notification=False, no_wait=False)
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -283,7 +283,7 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
-    def test_app_service_environment_upgrade_asev3(self, ase_client_factory_mock, resource_group_mock):
+    def test_app_service_environment_send_test_notification(self, ase_client_factory_mock, resource_group_mock):
         ase_name = 'mock_ase_name'
         rg_name = 'mock_rg_name'
 
@@ -294,16 +294,13 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
 
         host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
         host_env.name = ase_name
-        host_env.kind = 'ASEv3'
-        host_env.upgrade_availability = 'Ready'
-        host_env.upgrade_preference ='Manual'
+        host_env.kind = 'ASEv2'
         ase_client.get.return_value = host_env
         ase_client.list.return_value = [host_env]
 
-        upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
-
-        # Assert upgrade is called with correct properties
-        ase_client.begin_upgrade.assert_called_once_with(resource_group_name=rg_name, name=ase_name, no_wait=False)
+        # Assert that ValidationError raised when ASEv2
+        with self.assertRaises(ValidationError):
+            send_test_notification_appserviceenvironment(self.mock_cmd, ase_name)
 
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
@@ -329,7 +326,12 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         # Assert upgrade is called with correct properties
         ase_client.test_upgrade_available_notification.assert_called_once_with(resource_group_name=rg_name, name=ase_name)
 
-#remove
+        host_env.upgrade_availability = None
+
+        # Assert that ValidationError raised when upgrade_availability None
+        with self.assertRaises(ValidationError):
+            upgrade_appserviceenvironment(self.mock_cmd, ase_name)
+
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
     def test_app_service_environment_upgrade(self, ase_client_factory_mock, resource_group_mock):
@@ -347,20 +349,13 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         ase_client.get.return_value = host_env
         ase_client.list.return_value = [host_env]
 
-        upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
-
-        # Assert upgrade is called with correct properties
-        #assert_host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
-        #ase_name = 'mock_ase_name'
-        #assert_host_env.name = ase_name
-        #assert_host_env.kind = 'ASEv2'
-        #result = upgrade_appserviceenvironment(self.mock_cmd, ase_name, no_wait=False)
-        #self.assertIn('No upgrade were applied. This version of ASE not support upgrade.' in result)
-#remove
+        # Assert that ValidationError raised when ASEv2
+        with self.assertRaises(ValidationError):
+            upgrade_appserviceenvironment(self.mock_cmd, ase_name)
 
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
-    def test_app_service_environment_upgrade_test_notification_appserviceenvironment_asev3(self, ase_client_factory_mock, resource_group_mock):
+    def test_app_service_environment_upgrade_asev3(self, ase_client_factory_mock, resource_group_mock):
         ase_name = 'mock_ase_name'
         rg_name = 'mock_rg_name'
 
@@ -377,11 +372,16 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
         ase_client.get.return_value = host_env
         ase_client.list.return_value = [host_env]
 
-        upgrade_test_notification_appserviceenvironment(self.mock_cmd, ase_name)
+        upgrade_appserviceenvironment(self.mock_cmd, ase_name)
 
-        # Assert upgrade-test-notification is called with correct properties
-        ase_client.test_upgrade_available_notification.assert_called_once_with(resource_group_name=rg_name, name=ase_name)
+        # Assert upgrade is called with correct properties
+        ase_client.begin_upgrade.assert_called_once_with(resource_group_name=rg_name, name=ase_name)
 
+        host_env.upgrade_availability = None
+
+        # Assert that ValidationError raised when upgrade_availability None
+        with self.assertRaises(ValidationError):
+            upgrade_appserviceenvironment(self.mock_cmd, ase_name)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_app_service_environment_commands_thru_mock.py
@@ -23,7 +23,7 @@ from azure.cli.command_modules.appservice.appservice_environment import (show_ap
                                                                          update_appserviceenvironment,
                                                                          upgrade_appserviceenvironment,
                                                                          delete_appserviceenvironment,
-                                                                         upgrade_test_notification_appserviceenvironment)
+                                                                         send_test_notification_appserviceenvironment)
 
 
 class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
@@ -304,6 +304,30 @@ class AppServiceEnvironmentScenarioMockTest(unittest.TestCase):
 
         # Assert upgrade is called with correct properties
         ase_client.begin_upgrade.assert_called_once_with(resource_group_name=rg_name, name=ase_name, no_wait=False)
+
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)
+    @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_ase_client_factory', autospec=True)
+    def test_app_service_environment_send_test_notification_asev3(self, ase_client_factory_mock, resource_group_mock):
+        ase_name = 'mock_ase_name'
+        rg_name = 'mock_rg_name'
+
+        ase_client = mock.MagicMock()
+        ase_client_factory_mock.return_value = ase_client
+
+        resource_group_mock.return_value = rg_name
+
+        host_env = HostingEnvironmentProfile(id='/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/mock_rg_name/Microsoft.Web/hostingEnvironments/mock_ase_name')
+        host_env.name = ase_name
+        host_env.kind = 'ASEv3'
+        host_env.upgrade_availability = 'Ready'
+        host_env.upgrade_preference ='Manual'
+        ase_client.get.return_value = host_env
+        ase_client.list.return_value = [host_env]
+
+        send_test_notification_appserviceenvironment(self.mock_cmd, ase_name)
+
+        # Assert upgrade is called with correct properties
+        ase_client.test_upgrade_available_notification.assert_called_once_with(resource_group_name=rg_name, name=ase_name)
 
 #remove
     @mock.patch('azure.cli.command_modules.appservice.appservice_environment._get_location_from_resource_group', autospec=True)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az appservice ase upgrade

az appservice ase send-test-notification


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

New commands for ASE to support ASE upgrades and sending test notifications

More information about ase upgrade - https://learn.microsoft.com/en-us/azure/app-service/environment/how-to-upgrade-preference?pivots=experience-azcli#manual-upgrade-preference

More information about sending test notifications -  https://learn.microsoft.com/en-us/azure/app-service/environment/how-to-upgrade-preference?pivots=experience-azcli#send-test-notifications

**Testing Guide**
<!--Example commands with explanations.-->

This command will start upgrade process
az appservice ase upgrade -n ase-name -g resource-group-name

This command will send test notification 
az appservice ase send-test-notification -n ase-name -g resource-group-name

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
