### PR TITLE
[App Service] Fix #23488: `az appservice plan create`: Fix zone redundant ASP creation fails for ASEv3

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -87,10 +87,10 @@ def validate_ase_create(cmd, namespace):
 
 
 def _validate_asp_sku(sku, app_service_environment, zone_redundant):
-    if zone_redundant and get_sku_tier(sku.upper()) not in ['PREMIUMV2', 'PREMIUMV3']:
+    if zone_redundant and get_sku_tier(sku).upper() not in ['PREMIUMV2', 'PREMIUMV3', 'ISOLATEDV2']:
         raise ValidationError("Zone redundancy cannot be enabled for sku {}".format(sku))
     # Isolated SKU is supported only for ASE
-    if sku.upper() in ['I1', 'I2', 'I3', 'I1V2', 'I2V2', 'I3V2']:
+    if sku.upper() in ['I1', 'I2', 'I3', 'I1V2', 'I2V2', 'I3V2', 'I4V2', 'I5V2', 'I6V2']:
         if not app_service_environment:
             raise ValidationError("The pricing tier 'Isolated' is not allowed for this app service plan. "
                                   "Use this link to learn more: "


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

az appservice plan create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Close: #23488 #24112

Zone redundant ASP plan creation on an ASE currently does not work on the CLI. It fails with error "Zone redundancy cannot be enabled for I1V2 SKU". This PR adds the ISOLATEDV2 tier to the validation step.

**Testing Guide**
<!--Example commands with explanations.-->

az appservice plan create -g resource-group-name -n plan-name --location westeurope --sku I1V2  --is-linux --app-service-environment asev3-name --zone-redundant

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
