### PR TITLE
{Core} Print traceback for all subclasses of `AzCLIError`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -62,6 +62,11 @@ class AzCLIError(CLIError):
     def print_error(self):
         from azure.cli.core.azlogging import CommandLoggerContext
         from azure.cli.core.style import print_styled_text
+
+        # Print the traceback and exception message to debug log
+        import traceback
+        logger.debug(traceback.format_exc())
+
         with CommandLoggerContext(logger):
             # print error message
             logger.error(self.error_msg)

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -63,11 +63,6 @@ def handle_exception(ex):  # pylint: disable=too-many-locals, too-many-statement
     from requests.exceptions import SSLError, HTTPError
     from azure.cli.core import azclierror
     from msal_extensions.persistence import PersistenceError
-    import traceback
-
-    logger.debug("azure.cli.core.util.handle_exception is called with an exception:")
-    # Print the traceback and exception message
-    logger.debug(traceback.format_exc())
 
     error_msg = getattr(ex, 'message', str(ex))
     exit_code = 1


### PR DESCRIPTION
## Change

This PR unifies the traceback printing logic into `azure.cli.core.azclierror.AzCLIError.print_error` so that traceback will be printed to debug log for all all subclasses of `AzCLIError`, including `azure.cli.core.azclierror.ResourceNotFoundError` and `azure.cli.core.azclierror.ValidationError`.

This greatly simplifies the troubleshooting for validation failures, such as https://github.com/Azure/azure-cli/issues/24896, as now the debug log reveals which validator fails.

## Context

Even though we already print traceback in `azure.cli.core.util.handle_exception`:

https://github.com/Azure/azure-cli/blob/325dfa64d8b77bfddb3b087162ad98acee5037ab/src/azure-cli-core/azure/cli/core/util.py#L68-L70

`ResourceNotFoundError` and `ValidationError` are not handled here, so no traceback is printed.

Instead, `ResourceNotFoundError` is initiated and printed by `azure.cli.core.commands.arm.show_exception_handler`:

https://github.com/Azure/azure-cli/blob/ce3a1f1ddea0b59f0a5803bb427c55862ccae72b/src/azure-cli-core/azure/cli/core/commands/arm.py#L419-L429

When a command fails with `ResourceNotFoundError`, the debug log doesn't reveal the traceback:

```
> az group show -n notexist --debug

cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/notexist?api-version=2021-04-01'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
...
cli.azure.cli.core.sdk.policies: Response status: 404
...
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"error":{"code":"ResourceGroupNotFound","message":"Resource group 'notexist' could not be found."}}
cli.azure.cli.core.azclierror: (ResourceGroupNotFound) Resource group 'notexist' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'notexist' could not be found.
```

`ValidationError` is initiated and printed by `azure.cli.core.parser.AzCliCommandParser.validation_error`:

https://github.com/Azure/azure-cli/blob/37053a386dfcce2f78277e1667fc84b80b6b5feb/src/azure-cli-core/azure/cli/core/parser.py#L146-L150

When a command fails with `ValidationError`, the debug log doesn't reveal the traceback:

```
> az vm create --resource-group testrg --name crosstenantvm --image "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/visualstudiorg/providers/Microsoft.Compute/galleries/visualstudiogallery/images/testwindowsdef/versions/1.0.0" --admin-username testuser --location westus --debug

cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/visualstudiorg/providers/Microsoft.Compute/galleries/visualstudiogallery/images/testwindowsdef?api-version=2021-10-01'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
c...
cli.azure.cli.core.sdk.policies: Response status: 404
...
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"error":{"code":"ResourceGroupNotFound","message":"Resource group 'visualstudiorg' could not be found."}}
cli.azure.cli.core.azclierror: (ResourceGroupNotFound) Resource group 'visualstudiorg' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'visualstudiorg' could not be found.
```

In this example, the `--image` is not an existing resource ID. Judging by the debug log, there is no way to know which validator fails.

## Testing Guide

After the change, traceback is shown for `ResourceNotFoundError`:

```
> az group show -n notexist --debug

cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourcegroups/notexist?api-version=2021-04-01'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
...
cli.azure.cli.core.sdk.policies: Response status: 404
...
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"error":{"code":"ResourceGroupNotFound","message":"Resource group 'notexist' could not be found."}}
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\command_operation.py", line 361, in handler
    return op(**command_args)
  File "D:\cli\py310\lib\site-packages\azure\core\tracing\decorator.py", line 73, in wrapper_use_tracer
    return func(*args, **kwargs)
  File "D:\cli\py310\lib\site-packages\azure\mgmt\resource\resources\v2021_04_01\operations\_operations.py", line 9980, in get
    map_error(status_code=response.status_code, response=response, error_map=error_map)
  File "D:\cli\py310\lib\site-packages\azure\core\exceptions.py", line 107, in map_error
    raise error
azure.core.exceptions.ResourceNotFoundError: (ResourceGroupNotFound) Resource group 'notexist' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'notexist' could not be found.

cli.azure.cli.core.azclierror: (ResourceGroupNotFound) Resource group 'notexist' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'notexist' could not be found.
```

Traceback is shown for `ValidationError`:

```
> az vm create --resource-group testrg --name crosstenantvm --image "/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/visualstudiorg/providers/Microsoft.Compute/galleries/visualstudiogallery/images/testwindowsdef/versions/1.0.0" --admin-username testuser --location westus --debug

cli.azure.cli.core.sdk.policies: Request URL: 'https://management.azure.com/subscriptions/1c638cf4-608f-4ee6-b680-c329e824c3a8/resourceGroups/visualstudiorg/providers/Microsoft.Compute/galleries/visualstudiogallery/images/testwindowsdef?api-version=2021-10-01'
cli.azure.cli.core.sdk.policies: Request method: 'GET'
...
cli.azure.cli.core.sdk.policies: Response status: 404
...
cli.azure.cli.core.sdk.policies: Response content:
cli.azure.cli.core.sdk.policies: {"error":{"code":"ResourceGroupNotFound","message":"Resource group 'visualstudiorg' could not be found."}}
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "D:\cli\py310\lib\site-packages\knack\invocation.py", line 111, in _validation
    self._validate_cmd_level(parsed_ns, cmd_validator)
  File "d:\cli\azure-cli\src\azure-cli-core\azure\cli\core\commands\__init__.py", line 849, in _validate_cmd_level
    cmd_validator(**self._build_kwargs(cmd_validator, ns))
  File "d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\vm\_validators.py", line 1457, in process_vm_create_namespace
    _validate_vm_create_storage_profile(cmd, namespace)
  File "d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\vm\_validators.py", line 504, in _validate_vm_create_storage_profile
    image_info = compute_client.gallery_images.get(resource_group_name=res['resource_group'],
  File "D:\cli\py310\lib\site-packages\azure\core\tracing\decorator.py", line 73, in wrapper_use_tracer
    return func(*args, **kwargs)
  File "D:\cli\py310\lib\site-packages\azure\mgmt\compute\v2021_10_01\operations\_gallery_images_operations.py", line 754, in get
    map_error(status_code=response.status_code, response=response, error_map=error_map)
  File "D:\cli\py310\lib\site-packages\azure\core\exceptions.py", line 107, in map_error
    raise error
azure.core.exceptions.ResourceNotFoundError: (ResourceGroupNotFound) Resource group 'visualstudiorg' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'visualstudiorg' could not be found.

cli.azure.cli.core.azclierror: (ResourceGroupNotFound) Resource group 'visualstudiorg' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'visualstudiorg' could not be found.
```

The debug log clearly shows `File "d:\cli\azure-cli\src\azure-cli\azure\cli\command_modules\vm\_validators.py", line 504, in _validate_vm_create_storage_profile` is where the error occurs.

