### PR TITLE
{Role} `az role assignment create`: Refine help message for `--name`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -301,7 +301,6 @@ def load_arguments(self, _):
         c.argument('resource_group_name', options_list=['--resource-group', '-g'], help='use it only if the role or assignment was added at the level of a resource group')
 
     with self.argument_context('role assignment') as c:
-        c.argument('role_assignment_name', options_list=['--name', '-n'])
         c.argument('role', help='role name or id', completer=get_role_definition_name_completion_list)
         c.argument('show_all', options_list=['--all'], action='store_true', help='show all assignments under the current subscription')
         c.argument('include_inherited', action='store_true', help='include assignments applied on parent scopes')
@@ -317,7 +316,7 @@ def load_arguments(self, _):
         c.argument('condition', is_preview=True, min_api='2020-04-01-preview', help='Condition under which the user can be granted permission.')
         c.argument('condition_version', is_preview=True, min_api='2020-04-01-preview', help='Version of the condition syntax. If --condition is specified without --condition-version, default to 2.0.')
         c.argument('assignment_name', name_arg_type,
-                   help='Name of the role assignment. If omitted, a new GUID is generetd.')
+                   help='A GUID for the role assignment. It must be unique and different for each role assignment. If omitted, a new GUID is generetd.')
 
     time_help = ('The {} of the query in the format of %Y-%m-%dT%H:%M:%SZ, e.g. 2000-12-31T12:59:59Z. Defaults to {}')
     with self.argument_context('role assignment list-changelogs') as c:


### PR DESCRIPTION
**Related command**
`az role assignment create`

**Description**<!--Mandatory-->
https://github.com/Azure/azure-cli/pull/24324 introduced `--name` for `az role assignment create` but is unclear about its type. This may lead to incorrect usages (https://github.com/Azure/azure-cli/issues/24919), as user can use invalid role assignment name, resulting in malformed URL and causing confusing service error (https://github.com/Azure/azure-cli/issues/7441).

**Additional information**
That help message originally was

```
The name of the role assignment to create. It can be any valid GUID.
```

https://github.com/Azure/azure-rest-api-specs/pull/16639 updated it for `2020-04-01-preview` API to

https://github.com/Azure/azure-rest-api-specs/blob/cf848c9f570c1157bbad81e214f5bb2993e578bb/specification/authorization/resource-manager/Microsoft.Authorization/preview/2020-04-01-preview/authorization-RoleAssignmentsCalls.json#L242

```
          {
            "name": "roleAssignmentName",
            "in": "path",
            "required": true,
            "type": "string",
            "description": "A GUID for the role assignment to create. The name must be unique and different for each role assignment."
          },
```

However, that change was reverted in `2022-04-01` API:

https://github.com/Azure/azure-rest-api-specs/blob/020f48c422ec455cdee9f6516f2d0172d13e77a3/specification/authorization/resource-manager/Microsoft.Authorization/stable/2022-04-01/authorization-RoleAssignmentsCalls.json#L693

```
    "RoleAssignmentNameParameter": {
      "name": "roleAssignmentName",
      "in": "path",
      "required": true,
      "type": "string",
      "description": "The name of the role assignment. It can be any valid GUID.",
      "x-ms-skip-url-encoding": true,
      "x-ms-parameter-location": "method"
    },
```

I am not sure why. `It can be any valid GUID.` is certainly not accurate. No matter how swagger describes it, at least we make it accurate.

