### PR TITLE
[Service Connector] `az containerapp connection create`: Ignore `--vault-id` for container app as not supported

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/serviceconnector/_params.py
@@ -130,7 +130,11 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
             context.ignore('new_addon')
 
     def add_secret_store_argument(context):
-        context.argument('key_vault_id', options_list=['--vault-id'], help='The id of key vault to store secret value')
+        if source == RESOURCE.ContainerApp:
+            context.ignore('key_vault_id')
+        else:
+            context.argument('key_vault_id', options_list=['--vault-id'],
+                             help='The id of key vault to store secret value')
 
     def add_vnet_block(context, target):
         if target not in TARGET_SUPPORT_SERVICE_ENDPOINT:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

* `az containerapp connection create`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Ignore parameter `--vault-id` in `az containerapp connection create` as not supported.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Service Connector] BREAKING CHANGE: `az containerapp connection create`: Parameter `--vault-id` would be ignored

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
