### PR TITLE
[DMS] `az dms project task create`: Update DMS MySQL API to support new migration types

### DIFF
--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -478,6 +478,7 @@
     <Compile Include="azure-cli\azure\cli\command_modules\dls\__init__.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\commands.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\custom.py" />
+    <Content Include="azure-cli\azure\cli\command_modules\dms\scenario_inputs.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\latest\test_service_scenarios.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\latest\__init__.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\__init__.py" />

--- a/azure-cli2017.pyproj
+++ b/azure-cli2017.pyproj
@@ -479,6 +479,7 @@
     <Compile Include="azure-cli\azure\cli\command_modules\dms\commands.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\custom.py" />
     <Content Include="azure-cli\azure\cli\command_modules\dms\scenario_inputs.py" />
+    <Compile Include="azure-cli\azure\cli\command_modules\dms\validators.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\latest\test_service_scenarios.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\latest\__init__.py" />
     <Compile Include="azure-cli\azure\cli\command_modules\dms\tests\__init__.py" />

--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -267,12 +267,12 @@ parameters:
                         ..n
                     }
                     // the below items are only necessary for selective schema migration
-                    // optional, migrates schema for the following tables            
+                    // optional, migrates schema for the following tables
                     'tables_to_migrate_schema': {
                         "sourceSchema1.table2": "targetSchema1.table2",
                         "sourceSchema1.table3": "targetSchema1.table3"
                     },
-                    // optional, migrates the enumerated views            
+                    // optional, migrates the enumerated views
                     'selected_views': [
                         'sourceSchema1.view1'
                     ],
@@ -284,7 +284,7 @@ parameters:
                     'selected_routines': [
                         'sourceSchema1.build_report'
                     ],
-                    // optional, migrates the enumerated events            
+                    // optional, migrates the enumerated events
                     'selected_events': [
                         'sourceSchema1.nightly_maintenance'
                     ]
@@ -317,7 +317,7 @@ parameters:
                 "ThrottleQueryTableDataRangeTaskAtBatchCount": 36,
                 // Optional setting that configures the delay between updates of result objects in Azure Table Storage.
                 "DelayProgressUpdatesInStorageInterval": "00:00:30",
-                },
+            },
             // Optional setting to set the source server read only.
             "make_source_server_read_only": "true|false",
             // Optional setting to enable consistent backup. True by default for the sync migration, and false otherwise.
@@ -334,6 +334,11 @@ parameters:
             "migrate_all_tables_schema": "true|false",
             // Optional. If true, all users/grants will be migrated.
             "migrate_user_system_tables": "true|false",
+            // Binlog position to start the migration from. Only applicable for the ReplicateChanges migration.
+            "binLogInfo": {
+                "filename": "binlog.0004523",
+                "position": 283287
+            }
         }
 
   - name: --source-connection-json

--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -294,8 +294,22 @@ parameters:
                 // Optional setting that configures the delay between updates of result objects in Azure Table Storage.
                 "DelayProgressUpdatesInStorageInterval": "00:00:30",
                 },
-            // [Optional]
-            "make_source_server_read_only": "true|false"
+            // Optional setting to set the source server read only.
+            "make_source_server_read_only": "true|false",
+            // Optional setting to enable consistent backup. True by default for the sync migration, and false otherwise.
+            "enable_consistent_backup": "true|false",
+            // Optional. If true, all view definitions will be migrated in the selected databases.
+            "migrate_all_views": "true|false",
+            // Optional. If true, all trigger definitions will be migrated in the selected databases.
+            "migrate_all_triggers": "true|false",
+            // Optional. If true, all event definitions will be migrated in the selected databases.
+            "migrate_all_events": "true|false",
+            // Optional. If true, all stored proc definitions will be migrated in the selected databases.
+            "migrate_all_routines": "true|false",
+            // Optional. If true, all table's schemas will be migrated.
+            "migrate_all_tables_schema": "true|false",
+            // Optional. If true, all users/grants will be migrated.
+            "migrate_user_system_tables": "true|false",
         }
 
   - name: --source-connection-json

--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -260,10 +260,34 @@ parameters:
                   "target_database_name": "targetSchema1",
                   // Table mapping from source to target schemas [Optional]
                   // Don't add it if all tables of this database needs to be migrated
-                  "table_map": {"sourceSchema1.table1": "targetSchema1.table1",
-                                "sourceSchema1.table2": "targetSchema1.table2",
-                                "sourceSchema1.table3": "targetSchema1.table3",
-                                ..n}
+                  "table_map": {
+                        "sourceSchema1.table1": "targetSchema1.table1",
+                        "sourceSchema1.table2": "targetSchema1.table2",
+                        "sourceSchema1.table3": "targetSchema1.table3",
+                        ..n
+                    }
+                    // the below items are only necessary for selective schema migration
+                    // optional, migrates schema for the following tables            
+                    'tables_to_migrate_schema': {
+                        "sourceSchema1.table2": "targetSchema1.table2",
+                        "sourceSchema1.table3": "targetSchema1.table3"
+                    },
+                    // optional, migrates the enumerated views            
+                    'selected_views': [
+                        'sourceSchema1.view1'
+                    ],
+                    // optional, migrates the enumerated triggers
+                    'selected_triggers': [
+                        'sourceSchema1.on_table1_updated'
+                    ],
+                    // optional, migrates the enumerated routines
+                    'selected_routines': [
+                        'sourceSchema1.build_report'
+                    ],
+                    // optional, migrates the enumerated events            
+                    'selected_events': [
+                        'sourceSchema1.nightly_maintenance'
+                    ]
                 },
                 ...n
             ],

--- a/src/azure-cli/azure/cli/command_modules/dms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/custom.py
@@ -280,10 +280,12 @@ def core_handles_scenario(
         target_platform,
         task_type=""):
     # Add scenarios here after migrating them to the core from the extension.
-    CoreScenarioTypes = [ScenarioType.sql_sqldb_offline,
-                         ScenarioType.postgres_azurepostgres_online,
-                         ScenarioType.mysql_azuremysql_offline]
-    return get_scenario_type(source_platform, target_platform, task_type) in CoreScenarioTypes
+    core_scenario_types = [ScenarioType.sql_sqldb_offline,
+                           ScenarioType.postgres_azurepostgres_online,
+                           ScenarioType.mysql_azuremysql_offline,
+                           ScenarioType.mysql_azuremysql_online,
+                           ScenarioType.mysql_azuremysql_cdc]
+    return get_scenario_type(source_platform, target_platform, task_type) in core_scenario_types
 
 
 def transform_json_inputs(
@@ -454,9 +456,6 @@ def get_migrate_mysql_to_azuredbformysql_cdc_task_properties(**kwargs):
 
 
 def get_scenario_type(source_platform, target_platform, task_type=""):
-    print("v**********************************************v")
-    print(task_type, source_platform, target_platform)
-
     if source_platform == "sql" and target_platform == "sqldb":
         scenario_type = ScenarioType.sql_sqldb_offline if not task_type or "offline" in task_type else \
             ScenarioType.unknown
@@ -472,8 +471,6 @@ def get_scenario_type(source_platform, target_platform, task_type=""):
     else:
         scenario_type = ScenarioType.unknown
 
-    print(scenario_type)
-    print("^**********************************************^")
     return scenario_type
 
 

--- a/src/azure-cli/azure/cli/command_modules/dms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/custom.py
@@ -315,8 +315,9 @@ def get_file_or_parse_json(value, value_type):
     # Test if provided value is a valid json
     try:
         json_parse = shell_safe_json_parse(value)
-    except:
-        raise CLIError("The supplied input for '" + value_type + "' is not a valid file path or a valid json object.")
+    except Exception as e:
+        raise CLIError("The supplied input for '{type}' is not a valid file path or a valid json object. {ex}'"
+                       .format(type=value_type, ex=e))
     else:
         return json_parse
 

--- a/src/azure-cli/azure/cli/command_modules/dms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/custom.py
@@ -21,14 +21,16 @@ from azure.mgmt.datamigration.models import (DataMigrationService,
                                              Project,
                                              ProjectTask,
                                              ServiceSku,
-                                             SqlConnectionInfo)
+                                             SqlConnectionInfo, MigrateMySqlAzureDbForMySqlSyncTaskProperties)
 
 from azure.cli.core.azclierror import RequiredArgumentMissingError
 from azure.cli.core.util import sdk_no_wait, get_file_json, shell_safe_json_parse
 from azure.cli.command_modules.dms._client_factory import dms_cf_projects
 from azure.cli.command_modules.dms.scenario_inputs import (get_migrate_sql_to_sqldb_offline_input,
                                                            get_migrate_postgresql_to_azuredbforpostgresql_sync_input,
-                                                           get_migrate_mysql_to_azuredbformysql_offline_input)
+                                                           get_migrate_mysql_to_azuredbformysql_offline_input,
+                                                           get_migrate_mysql_to_azuredbformysql_sync_input,
+                                                           get_migrate_mysql_to_azuredbformysql_cdc_input)
 
 
 # region Service
@@ -384,6 +386,12 @@ def get_task_migration_properties(
     elif st == ScenarioType.mysql_azuremysql_offline:
         TaskProperties = MigrateMySqlAzureDbForMySqlOfflineTaskProperties
         GetInput = get_migrate_mysql_to_azuredbformysql_offline_input
+    elif st == ScenarioType.mysql_azuremysql_online:
+        TaskProperties = MigrateMySqlAzureDbForMySqlSyncTaskProperties
+        GetInput = get_migrate_mysql_to_azuredbformysql_sync_input
+    elif st == ScenarioType.mysql_azuremysql_cdc:
+        TaskProperties = get_migrate_mysql_to_azuredbformysql_cdc_task_properties
+        GetInput = get_migrate_mysql_to_azuredbformysql_cdc_input
     elif st == ScenarioType.postgres_azurepostgres_online:
         TaskProperties = MigratePostgreSqlAzureDbForPostgreSqlSyncTaskProperties
         GetInput = get_migrate_postgresql_to_azuredbforpostgresql_sync_input
@@ -420,7 +428,10 @@ def get_task_properties(scenario_type,
             enable_schema_validation,
             enable_data_integrity_validation,
             enable_query_analysis_validation)
-    elif scenario_type == ScenarioType.mysql_azuremysql_offline:
+    elif scenario_type in {
+            ScenarioType.mysql_azuremysql_offline,
+            ScenarioType.mysql_azuremysql_online,
+            ScenarioType.mysql_azuremysql_cdc}:
         task_input = input_func(
             options_json,
             source_connection_info,
@@ -436,12 +447,21 @@ def get_task_properties(scenario_type,
     return task_properties_type(**task_properties_params)
 
 
+def get_migrate_mysql_to_azuredbformysql_cdc_task_properties(**kwargs):
+    result = MigrateMySqlAzureDbForMySqlOfflineTaskProperties(**kwargs)
+    result.task_type = "Migrate.MySql.AzureDbForMySql.ReplicateChanges"
+    return result
+
+
 def get_scenario_type(source_platform, target_platform, task_type=""):
     if source_platform == "sql" and target_platform == "sqldb":
         scenario_type = ScenarioType.sql_sqldb_offline if not task_type or "offline" in task_type else \
             ScenarioType.unknown
     elif source_platform == "mysql" and target_platform == "azuredbformysql":
-        scenario_type = ScenarioType.mysql_azuremysql_offline if not task_type or "offline" in task_type else \
+        scenario_type = \
+            ScenarioType.mysql_azuremysql_offline if not task_type or "offline" in task_type else \
+            ScenarioType.mysql_azuremysql_online if "online" in task_type else \
+            ScenarioType.mysql_azuremysql_cdc if "replicate" in task_type else \
             ScenarioType.unknown
     elif source_platform == "postgresql" and target_platform == "azuredbforpostgresql":
         scenario_type = ScenarioType.postgres_azurepostgres_online if not task_type or "online" in task_type else \
@@ -456,11 +476,13 @@ class ScenarioType(Enum):
     unknown = 0
     # SQL to SQLDB
     sql_sqldb_offline = 1
-    # MySQL to Azure for MySQL
+    # MySQL to Azure for MySQL Online
     mysql_azuremysql_online = 21
-    # PostgresSQL to Azure for PostgreSQL
-    postgres_azurepostgres_online = 31
     # MySQL to Azure for MySQL Offline
     mysql_azuremysql_offline = 22
+    # MySQL to Azure for MySQL Replicate Changes
+    mysql_azuremysql_cdc = 23
+    # PostgresSQL to Azure for PostgreSQL
+    postgres_azurepostgres_online = 31
 
 # endregion

--- a/src/azure-cli/azure/cli/command_modules/dms/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/custom.py
@@ -454,6 +454,9 @@ def get_migrate_mysql_to_azuredbformysql_cdc_task_properties(**kwargs):
 
 
 def get_scenario_type(source_platform, target_platform, task_type=""):
+    print("v**********************************************v")
+    print(task_type, source_platform, target_platform)
+
     if source_platform == "sql" and target_platform == "sqldb":
         scenario_type = ScenarioType.sql_sqldb_offline if not task_type or "offline" in task_type else \
             ScenarioType.unknown
@@ -469,6 +472,8 @@ def get_scenario_type(source_platform, target_platform, task_type=""):
     else:
         scenario_type = ScenarioType.unknown
 
+    print(scenario_type)
+    print("^**********************************************^")
     return scenario_type
 
 

--- a/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
@@ -10,7 +10,9 @@ from azure.mgmt.datamigration.models import (MigrateSqlServerSqlDbTaskInput,
                                              MigratePostgreSqlAzureDbForPostgreSqlSyncDatabaseInput,
                                              MigratePostgreSqlAzureDbForPostgreSqlSyncDatabaseTableInput,
                                              MigrateMySqlAzureDbForMySqlOfflineTaskInput,
-                                             MigrateMySqlAzureDbForMySqlOfflineDatabaseInput)
+                                             MigrateMySqlAzureDbForMySqlOfflineDatabaseInput,
+                                             MigrateMySqlAzureDbForMySqlSyncDatabaseInput,
+                                             MigrateMySqlAzureDbForMySqlSyncTaskInput)
 
 from azure.cli.core.azclierror import ValidationError
 
@@ -63,9 +65,49 @@ def get_migrate_postgresql_to_azuredbforpostgresql_sync_input(database_options_j
                                                               selected_databases=database_options)
 
 
+def get_migrate_mysql_to_azuredbformysql_sync_input(database_options_json,
+                                                    source_connection_info,
+                                                    target_connection_info):
+    return get_migrate_mysql_to_azuredbformysql_input(database_options_json,
+                                                      source_connection_info,
+                                                      target_connection_info,
+                                                      has_schema_migration_options=True,
+                                                      has_consistent_snapshot_options=True,
+                                                      requires_consistent_snapshot=True,
+                                                      has_binlog_position=False)
+
+
 def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
                                                        source_connection_info,
                                                        target_connection_info):
+    return get_migrate_mysql_to_azuredbformysql_input(database_options_json,
+                                                      source_connection_info,
+                                                      target_connection_info,
+                                                      has_schema_migration_options=True,
+                                                      has_consistent_snapshot_options=True,
+                                                      requires_consistent_snapshot=False,
+                                                      has_binlog_position=False)
+
+
+def get_migrate_mysql_to_azuredbformysql_cdc_input(database_options_json,
+                                                   source_connection_info,
+                                                   target_connection_info):
+    return get_migrate_mysql_to_azuredbformysql_input(database_options_json,
+                                                      source_connection_info,
+                                                      target_connection_info,
+                                                      has_schema_migration_options=False,
+                                                      has_consistent_snapshot_options=False,
+                                                      requires_consistent_snapshot=False,
+                                                      has_binlog_position=True)
+
+
+def get_migrate_mysql_to_azuredbformysql_input(database_options_json,
+                                               source_connection_info,
+                                               target_connection_info,
+                                               has_schema_migration_options: bool,
+                                               has_consistent_snapshot_options: bool,
+                                               requires_consistent_snapshot: bool,
+                                               has_binlog_position: bool):
     database_options = []
     migration_level_settings = {}
     make_source_server_read_only = False
@@ -76,7 +118,8 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
         raise ValidationError('Format of the database option file is wrong')
 
     if 'selected_databases' not in database_options_json:
-        raise ValidationError('Database option file should contain atleast one selected database for migration')
+        raise ValidationError('Database option file should contain at least one selected database for migration')
+
     selected_databases = database_options_json.get('selected_databases')
 
     for database in selected_databases:
@@ -88,46 +131,54 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
             raise ValidationError('Selected database should have a target_database_name')
         if 'table_map' in database and (not isinstance(database.get('table_map'), dict) or
                                         len(database.get('table_map')) == 0):
-            raise ValidationError('Table map should be dictionary and non empty, to select all tables remove table_map')
-        database_options.append(
-            MigrateMySqlAzureDbForMySqlOfflineDatabaseInput(
-                name=database.get('name', None),
-                target_database_name=database.get('target_database_name', None),
-                table_map=database.get('table_map', None)))
+            raise ValidationError('table_map should be dictionary and non empty, to select all tables remove table_map')
 
-    if 'migration_level_settings' in database_options_json and \
-            (not isinstance(database_options_json, dict) or len(
-                database_options_json.get('migration_level_settings')) == 0):
-        raise ValidationError('migration_level_settings have wrong format or is empty')
+        db_input = MigrateMySqlAzureDbForMySqlOfflineDatabaseInput(
+            name=database.get('name', None),
+            target_database_name=database.get('target_database_name', None),
+            table_map=database.get('table_map', None))
 
-    if isinstance(database_options_json, dict):
-        if 'migration_level_settings' in database_options_json:
-            migration_level_settings = database_options_json.get('migration_level_settings')
+        if has_schema_migration_options:
+            tables_to_migrate_schema = database.get("tablesToMigrateSchema", {})
+            if not isinstance(tables_to_migrate_schema, dict):
+                raise ValidationError('tables_to_migrate_schema should be a dictionary')
+            db_input.additional_properties = {"tablesToMigrateSchema": tables_to_migrate_schema}
+            db_input.enable_additional_properties_sending()
 
+        database_options.append(db_input)
+
+    if 'migration_level_settings' in database_options_json:
+        migration_level_settings = database_options_json.get('migration_level_settings')
+        if not isinstance(migration_level_settings, dict):
+            raise ValidationError('migration_level_settings should be a dictionary')
+
+    if requires_consistent_snapshot:
+        migration_level_settings['enableConsistentBackup'] = 'true'
+    elif has_consistent_snapshot_options:
         if 'make_source_server_read_only' in database_options_json:
             make_source_server_read_only = database_options_json.get('make_source_server_read_only')
-
         if 'enable_consistent_backup' in database_options_json:
-            enable_consistent_backup = database_options_json.get('enable_consistent_backup')
-            migration_level_settings['enableConsistentBackup'] = enable_consistent_backup
+            migration_level_settings['enableConsistentBackup'] = database_options_json.get('enable_consistent_backup')
 
+    if has_schema_migration_options:
         if 'migrate_all_views' in database_options_json:
             additional_properties['migrateAllViews'] = database_options_json.get('migrate_all_views')
-
         if 'migrate_all_triggers' in database_options_json:
             additional_properties['migrateAllTriggers'] = database_options_json.get('migrate_all_triggers')
-
         if 'migrate_all_events' in database_options_json:
             additional_properties['migrateAllEvents'] = database_options_json.get('migrate_all_events')
-
         if 'migrate_all_routines' in database_options_json:
             additional_properties['migrateAllRoutines'] = database_options_json.get('migrate_all_routines')
-
         if 'migrate_all_tables_schema' in database_options_json:
             additional_properties['migrateAllTablesSchema'] = database_options_json.get('migrate_all_tables_schema')
-
         if 'migrate_user_system_tables' in database_options_json:
             additional_properties['migrateUserSystemTables'] = database_options_json.get('migrate_user_system_tables')
+
+    if has_binlog_position:
+        binlog_info = additional_properties.get('binlog_info', {})
+        if not isinstance(binlog_info, dict) or len(binlog_info) == 0:
+            raise ValidationError("binlog_info should be a non-empty dictionary")
+        additional_properties['binLogInfo'] = binlog_info
 
     task_input = MigrateMySqlAzureDbForMySqlOfflineTaskInput(source_connection_info=source_connection_info,
                                                              target_connection_info=target_connection_info,
@@ -135,8 +186,15 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
                                                              optional_agent_settings=migration_level_settings,
                                                              make_source_server_read_only=make_source_server_read_only)
 
-    if additional_properties:
+    if len(additional_properties) > 0:
         task_input.additional_properties = additional_properties
         task_input.enable_additional_properties_sending()
 
     return task_input
+
+
+def validate_keys_and_values_match(table_map: dict):
+    renamed_tables = {s: t for s, t in table_map.items() if s != t}
+    if len(renamed_tables) > 0:
+        raise ValidationError(
+            "All source and target table names should match. The following mismatches were found: " + str(renamed_tables))

--- a/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
@@ -69,6 +69,7 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
     database_options = []
     migration_level_settings = {}
     make_source_server_read_only = False
+    additional_properties = {}
     selected_databases = []
 
     if not isinstance(database_options_json, dict):
@@ -98,13 +99,44 @@ def get_migrate_mysql_to_azuredbformysql_offline_input(database_options_json,
             (not isinstance(database_options_json, dict) or len(
                 database_options_json.get('migration_level_settings')) == 0):
         raise ValidationError('migration_level_settings have wrong format or is empty')
-    if 'migration_level_settings' in database_options_json and isinstance(database_options_json, dict):
-        migration_level_settings = database_options_json.get('migration_level_settings', None)
-    if 'make_source_server_read_only' in database_options_json and isinstance(database_options_json, dict):
-        make_source_server_read_only = database_options_json.get('make_source_server_read_only', None)
 
-    return MigrateMySqlAzureDbForMySqlOfflineTaskInput(source_connection_info=source_connection_info,
-                                                       target_connection_info=target_connection_info,
-                                                       selected_databases=database_options,
-                                                       optional_agent_settings=migration_level_settings,
-                                                       make_source_server_read_only=make_source_server_read_only)
+    if isinstance(database_options_json, dict):
+        if 'migration_level_settings' in database_options_json:
+            migration_level_settings = database_options_json.get('migration_level_settings')
+
+        if 'make_source_server_read_only' in database_options_json:
+            make_source_server_read_only = database_options_json.get('make_source_server_read_only')
+
+        if 'enable_consistent_backup' in database_options_json:
+            enable_consistent_backup = database_options_json.get('enable_consistent_backup')
+            migration_level_settings['enableConsistentBackup'] = enable_consistent_backup
+
+        if 'migrate_all_views' in database_options_json:
+            additional_properties['migrateAllViews'] = database_options_json.get('migrate_all_views')
+
+        if 'migrate_all_triggers' in database_options_json:
+            additional_properties['migrateAllTriggers'] = database_options_json.get('migrate_all_triggers')
+
+        if 'migrate_all_events' in database_options_json:
+            additional_properties['migrateAllEvents'] = database_options_json.get('migrate_all_events')
+
+        if 'migrate_all_routines' in database_options_json:
+            additional_properties['migrateAllRoutines'] = database_options_json.get('migrate_all_routines')
+
+        if 'migrate_all_tables_schema' in database_options_json:
+            additional_properties['migrateAllTablesSchema'] = database_options_json.get('migrate_all_tables_schema')
+
+        if 'migrate_user_system_tables' in database_options_json:
+            additional_properties['migrateUserSystemTables'] = database_options_json.get('migrate_user_system_tables')
+
+    task_input = MigrateMySqlAzureDbForMySqlOfflineTaskInput(source_connection_info=source_connection_info,
+                                                             target_connection_info=target_connection_info,
+                                                             selected_databases=database_options,
+                                                             optional_agent_settings=migration_level_settings,
+                                                             make_source_server_read_only=make_source_server_read_only)
+
+    if additional_properties:
+        task_input.additional_properties = additional_properties
+        task_input.enable_additional_properties_sending()
+
+    return task_input

--- a/src/azure-cli/azure/cli/command_modules/dms/tests/latest/recordings/test_task_commands.yaml
+++ b/src/azure-cli/azure/cli/command_modules/dms/tests/latest/recordings/test_task_commands.yaml
@@ -2300,4 +2300,204 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+        - application/json
+      Accept-Encoding:
+        - gzip, deflate
+      CommandName:
+        - dms project task create
+      Connection:
+        - keep-alive
+      ParameterSetName:
+        - --task-type --database-options-json -n --project-name -g --service-name --source-connection-json
+          --target-connection-json
+      User-Agent:
+        - AZURECLI/2.28.1 azsdk-python-mgmt-datamigration/10.0.0 Python/3.6.8 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009?api-version=2021-06-30
+  response:
+    body:
+      string: '{"properties":{"sourcePlatform":"MySQL","targetPlatform":"AzureDbForMySQL","creationTime":"2021-10-08T04:34:22.040907+00:00","provisioningState":"Succeeded"},"etag":"UpeqLgXa9JO28X3wJZhW5a1qNczWzhpA0g2JHKkwn3Y=","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009","location":"centralus","name":"projectmysql000009","type":"Microsoft.DataMigration/services/projects"}'
+    headers:
+      cache-control:
+        - no-cache
+      content-length:
+        - '555'
+      content-type:
+        - application/json; charset=utf-8
+      date:
+        - Fri, 08 Oct 2021 04:34:31 GMT
+      etag:
+        - '"UpeqLgXa9JO28X3wJZhW5a1qNczWzhpA0g2JHKkwn3Y="'
+      expires:
+        - '-1'
+      pragma:
+        - no-cache
+      server:
+        - Microsoft-IIS/10.0
+      strict-transport-security:
+        - max-age=31536000; includeSubDomains
+      transfer-encoding:
+        - chunked
+      vary:
+        - Accept-Encoding
+      x-content-type-options:
+        - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"taskType": "Migrate.MySql.AzureDbForMySql.Sync"}}'
+    headers:
+      Accept:
+        - application/json
+      Accept-Encoding:
+        - gzip, deflate
+      CommandName:
+        - dms project task create
+      Connection:
+        - keep-alive
+      Content-Length:
+        - '733'
+      Content-Type:
+        - application/json
+      ParameterSetName:
+        - --task-type --database-options-json -n --project-name -g --service-name --source-connection-json
+          --target-connection-json
+      User-Agent:
+        - AZURECLI/2.28.1 azsdk-python-mgmt-datamigration/10.0.0 Python/3.6.8 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009/tasks/taskmysql2000011?api-version=2021-06-30
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009/tasks/taskmysql2000011","name":"taskmysql2000011","type":"Microsoft.DataMigration/services/projects/tasks"}'
+    headers:
+      cache-control:
+        - no-cache
+      content-length:
+        - '1669'
+      content-type:
+        - application/json; charset=utf-8
+      date:
+        - Fri, 08 Oct 2021 04:34:32 GMT
+      etag:
+        - '"T7O9baOu2VWNXBCvAZK1Zl+bxAAqTCSMT5Tyi0vPJdA="'
+      expires:
+        - '-1'
+      pragma:
+        - no-cache
+      server:
+        - Microsoft-IIS/10.0
+      strict-transport-security:
+        - max-age=31536000; includeSubDomains
+      x-content-type-options:
+        - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+        - '1199'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+        - application/json
+      Accept-Encoding:
+        - gzip, deflate
+      CommandName:
+        - dms project task create
+      Connection:
+        - keep-alive
+      ParameterSetName:
+        - --task-type --database-options-json -n --project-name -g --service-name --source-connection-json
+          --target-connection-json
+      User-Agent:
+        - AZURECLI/2.28.1 azsdk-python-mgmt-datamigration/10.0.0 Python/3.6.8 (Windows-10-10.0.19041-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009?api-version=2021-06-30
+  response:
+    body:
+      string: '{"properties":{"sourcePlatform":"MySQL","targetPlatform":"AzureDbForMySQL","creationTime":"2021-10-08T04:34:22.040907+00:00","provisioningState":"Succeeded"},"etag":"UpeqLgXa9JO28X3wJZhW5a1qNczWzhpA0g2JHKkwn3Y=","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009","location":"centralus","name":"projectmysql000009","type":"Microsoft.DataMigration/services/projects"}'
+    headers:
+      cache-control:
+        - no-cache
+      content-length:
+        - '555'
+      content-type:
+        - application/json; charset=utf-8
+      date:
+        - Fri, 08 Oct 2021 04:34:31 GMT
+      etag:
+        - '"UpeqLgXa9JO28X3wJZhW5a1qNczWzhpA0g2JHKkwn3Y="'
+      expires:
+        - '-1'
+      pragma:
+        - no-cache
+      server:
+        - Microsoft-IIS/10.0
+      strict-transport-security:
+        - max-age=31536000; includeSubDomains
+      transfer-encoding:
+        - chunked
+      vary:
+        - Accept-Encoding
+      x-content-type-options:
+        - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"taskType": "Migrate.MySql.AzureDbForMySql.ReplicateChanges"}}'
+    headers:
+      Accept:
+        - application/json
+      Accept-Encoding:
+        - gzip, deflate
+      CommandName:
+        - dms project task create
+      Connection:
+        - keep-alive
+      Content-Length:
+        - '733'
+      Content-Type:
+        - application/json
+      ParameterSetName:
+        - --task-type --database-options-json -n --project-name -g --service-name --source-connection-json
+          --target-connection-json
+      User-Agent:
+        - AZURECLI/2.28.1 azsdk-python-mgmt-datamigration/10.0.0 Python/3.6.8 (Windows-10-10.0.19041-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009/tasks/taskmysql3000012?api-version=2021-06-30
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dms_cli_test000001/providers/Microsoft.DataMigration/services/dmsclitest000003/projects/projectmysql000009/tasks/taskmysql2000011","name":"taskmysql3000012","type":"Microsoft.DataMigration/services/projects/tasks"}'
+    headers:
+      cache-control:
+        - no-cache
+      content-length:
+        - '1669'
+      content-type:
+        - application/json; charset=utf-8
+      date:
+        - Fri, 08 Oct 2021 04:34:32 GMT
+      etag:
+        - '"T7O9baOu2VWNXBCvAZK1Zl+bxAAqTCSMT5Tyi0vPJdA="'
+      expires:
+        - '-1'
+      pragma:
+        - no-cache
+      server:
+        - Microsoft-IIS/10.0
+      strict-transport-security:
+        - max-age=31536000; includeSubDomains
+      x-content-type-options:
+        - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+        - '1199'
+    status:
+      code: 201
+      message: Created
 version: 1

--- a/src/azure-cli/azure/cli/command_modules/dms/tests/latest/test_service_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/tests/latest/test_service_scenarios.py
@@ -3,10 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-
-import json
-import unittest
-
 from azure.cli.testsdk import ScenarioTest, ResourceGroupPreparer, VirtualNetworkPreparer, JMESPathCheck, JMESPathCheckGreaterThan
 
 
@@ -179,6 +175,7 @@ class DmsServiceTests(ScenarioTest):
         project_name = self.create_random_name('project', 15)
         task_name1 = self.create_random_name('task1', 15)
         task_name2 = self.create_random_name('task2', 15)
+
         database_options1 = "[ { 'name': 'SourceDatabase1', 'target_database_name': 'TargetDatabase1', 'make_source_db_read_only': False, 'table_map': { 'dbo.TestTableSource1': 'dbo.TestTableTarget1', 'dbo.TestTableSource2': 'dbo.TestTableTarget2' } } ]"
         database_options2 = "[ { 'name': 'SourceDatabase2', 'target_database_name': 'TargetDatabase2', 'make_source_db_read_only': False, 'table_map': { 'dbo.TestTableSource1': 'dbo.TestTableTarget1', 'dbo.TestTableSource2': 'dbo.TestTableTarget2' } } ]"
         source_connection_info = "{ 'userName': 'testuser', 'password': 'testpassword', 'dataSource': 'notarealsourceserver', 'authentication': 'SqlAuthentication', 'encryptConnection': True, 'trustServerCertificate': True }"
@@ -200,16 +197,17 @@ class DmsServiceTests(ScenarioTest):
         project_name_mysql = self.create_random_name('projectmysql', 20)
         task_name_mysql1 = self.create_random_name('taskmysql', 20)
         task_name_mysql2 = self.create_random_name('taskmysql2', 20)
+        task_name_mysql3 = self.create_random_name('taskmysql3', 20)
+
         source_connection_info_mysql = "{ 'userName': 'testuser', 'password': 'testpassword', 'serverName': 'notarealsourceserver', 'databaseName': 'notarealdatabasename', 'encryptConnection': False }"
         target_connection_info_mysql = "{ 'userName': 'testuser', 'password': 'testpassword', 'serverName': 'notarealtargetserver', 'databaseName': 'notarealdatabasename'}"
         database_options_mysql = "{'make_source_server_read_only': 'true', 'selected_databases':[ { 'name': 'SourceDatabase1', 'target_database_name': 'TargetDatabase1', 'table_map': { 'sourceSchema.tableName': 'targetSchema.tableName'} } ], 'migration_level_settings': { 'DesiredRangesCount': '4', 'QueryTableDataRangeTaskCount':'8'}}"
 
         database_options_mysql_complete = """{
-            'selectedDatabases': [{
-                    'id': '',
+            'selected_databases': [{
                     'name': 'employees',
-                    'targetDatabaseName': 'employees',
-                    'tableMap': {
+                    'target_database_name': 'employees',
+                    'table_map': {
                         '`employees`.address': '`employees`.address',
                         '`employees`.datetype': '`employees`.datetype',
                         '`employees`.departments': '`employees`.departments',
@@ -219,46 +217,45 @@ class DmsServiceTests(ScenarioTest):
                         '`employees`.salaries': '`employees`.salaries',
                         '`employees`.titles': '`employees`.titles'
                     },
-                    'tablesToMigrateSchema': {
+                    'tables_to_migrate_schema': {
                         '`employees`.address': '`employees`.address',
-                        '`employees`.departments': '`employees`.departments',
+                        '`employees`.departments': '`employees`.departments'
                     },
-                    'selectedViews': {
+                    'selected_views': [
                         'employees.contractors'
-                    }
-                    'selectedTriggers': {
+                    ],
+                    'selected_triggers': [
                         'employees.on_salaries_update'
-                    }
-                    'selectedRoutines': {
+                    ],
+                    'selected_routines': [
                         'employees.hire',
                         'employees.transfer',
                         'employees.fire',
-                    }
-                    'selectedEvents': {
+                    ],
+                    'selected_events': [
                         'employees.nightly_maintenance',
-                    }
+                    ]
                 }
             ],
-            'startedOn': '2022-10-29T04:16:14.161Z',
-            'sourceServerResourceId': '',
-            'targetServerResourceId': '/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/mytest/providers/Microsoft.DBforMySQL/flexibleServers/myserver',
-            'makeSourceServerReadOnly': false,
-            'migrateAllViews': false,
-            'migrateAllTriggers': false,
-            'migrateAllEvents': false,
-            'migrateAllRoutines': false,
-            'migrateUserSystemTables': false,
-            'optionalAgentSettings': {
-                'enableConsistentBackup': true
+            'source_server_resource_id': '',
+            'target_server_resource_id': '/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/mytest/providers/Microsoft.DBforMySQL/flexibleServers/myserver',
+            'make_sourceserver_read_only': 'false',
+            'migrate_all_views': 'false',
+            'migrate_all_triggers': 'false',
+            'migrate_all_events': 'false',
+            'migrate_all_routines': 'false',
+            'migrate_user_system_tables': 'false',
+            'migration_level_settings': {
+                'enableConsistentBackup': 'true'
             }
         }"""
 
         database_options_mysql_replicate_changes = """{
-            'selectedDatabases': [{
+            'selected_databases': [{
                     'id': '',
                     'name': 'employees',
-                    'targetDatabaseName': 'employees',
-                    'tableMap': {
+                    'target_database_name': 'employees',
+                    'table_map': {
                         '`employees`.address': '`employees`.address',
                         '`employees`.datetype': '`employees`.datetype',
                         '`employees`.departments': '`employees`.departments',
@@ -270,10 +267,9 @@ class DmsServiceTests(ScenarioTest):
                     }
                 }
             ],
-            'startedOn': '2022-10-29T04:16:14.161Z',
-            'sourceServerResourceId': '',
-            'targetServerResourceId': '/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/mytest/providers/Microsoft.DBforMySQL/flexibleServers/myserver',
-            'binLogInfo': {
+            'source_server_resource_id': '',
+            'target_server_resource_id': '/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/mytest/providers/Microsoft.DBforMySQL/flexibleServers/myserver',
+            'binlog_info': {
                 'filename': 'binlog.000127',
                 'position': 5485347
             }
@@ -302,6 +298,7 @@ class DmsServiceTests(ScenarioTest):
             'pnamemysql': project_name_mysql,
             'tnamemysql1': task_name_mysql1,
             'tnamemysql2': task_name_mysql2,
+            'tnamemysql3': task_name_mysql3,
             'dboptionsmysql': database_options_mysql,
             'dboptionsmysql2': database_options_mysql_complete,
             'dboptionsmysql3': database_options_mysql_replicate_changes,
@@ -359,6 +356,11 @@ class DmsServiceTests(ScenarioTest):
                                              'notarealtargetserver'),
                                JMESPathCheck('properties.input.targetConnectionInfo.encryptConnection', True),
                                JMESPathCheck('properties.taskType', 'Migrate.MySql.AzureDbForMySql')]
+        # it does not really make sense to check all response attributes here as done above because the response
+        # is hardcoded at the test_task_commands.yaml file, and it is not generated by any service
+        create_checks_mysql2 = [JMESPathCheck('name', task_name_mysql2)]
+        create_checks_mysql3 = [JMESPathCheck('name', task_name_mysql3)]
+
         cancel_checks_mysql = [JMESPathCheck('name', task_name_mysql1),
                                JMESPathPatternCheck('properties.state', 'Cancel(?:ed|ing)')]
 
@@ -382,12 +384,12 @@ class DmsServiceTests(ScenarioTest):
         self.cmd('az dms project task show -g {rg} --service-name {sname} --project-name {pnamepg} -n {tnamepg}', checks=create_checks_pg)
         self.cmd('az dms project task cancel -g {rg} --service-name {sname} --project-name {pnamepg} -n {tnamepg}', checks=cancel_checks_pg)
 
-        # MySQL Tests
         self.cmd('az dms project task create --task-type OfflineMigration --database-options-json "{dboptionsmysql}" -n {tnamemysql1} --project-name {pnamemysql} -g {rg} --service-name {sname} --source-connection-json "{sconnmysql}" --target-connection-json "{tconnmysql}"', checks=create_checks_mysql)
         self.cmd('az dms project task show -g {rg} --service-name {sname} --project-name {pnamemysql} -n {tnamemysql1}', checks=create_checks_mysql)
         self.cmd('az dms project task cancel -g {rg} --service-name {sname} --project-name {pnamemysql} -n {tnamemysql1}', checks=cancel_checks_mysql)
 
-        # self.cmd('az dms project task create --task-type OfflineMigration --database-options-json "{dboptionsmysql2}" -n {tnamemysql2} --project-name {pnamemysql} -g {rg} --service-name {sname} --source-connection-json "{sconnmysql}" --target-connection-json "{tconnmysql}"')
+        self.cmd('az dms project task create --task-type OnlineMigration --database-options-json "{dboptionsmysql2}" -n {tnamemysql2} --project-name {pnamemysql} -g {rg} --service-name {sname} --source-connection-json "{sconnmysql}" --target-connection-json "{tconnmysql}"', checks=create_checks_mysql2)
+        self.cmd('az dms project task create --task-type ReplicateChanges --database-options-json "{dboptionsmysql3}" -n {tnamemysql3} --project-name {pnamemysql} -g {rg} --service-name {sname} --source-connection-json "{sconnmysql}" --target-connection-json "{tconnmysql}"', checks=create_checks_mysql3)
 
         # Clean up service for live runs
         self.cmd('az dms delete -g {rg} -n {sname} --delete-running-tasks true -y')

--- a/src/azure-cli/azure/cli/command_modules/dms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/validators.py
@@ -1,0 +1,19 @@
+﻿from azure.cli.core.azclierror import ValidationError
+
+
+def validate_keys_and_values_match(table_map: dict):
+    renamed_tables = {s: t for s, t in table_map.items() if s != t}
+    if len(renamed_tables) > 0:
+        raise ValidationError(
+            "All source and target table names should match. The following mismatches were found: %s"
+            % str(renamed_tables))
+
+
+def throw_if_not_dictionary(obj, property_name):
+    if not isinstance(obj, dict):
+        raise ValidationError("'%s' should be a dictionary" % property_name)
+
+
+def throw_if_not_list(obj, property_name):
+    if not isinstance(obj, list):
+        raise ValidationError("'%s' should be a list" % property_name)

--- a/src/azure-cli/azure/cli/command_modules/dms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/validators.py
@@ -1,4 +1,10 @@
-﻿from azure.cli.core.azclierror import ValidationError
+﻿# coding=utf-8
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+from azure.cli.core.azclierror import ValidationError
 
 
 def validate_keys_and_values_match(table_map: dict):


### PR DESCRIPTION
**Related command**
az dms project task create

**Description**<!--Mandatory-->
Adding ability to launch Online and ReplicateChanges migrations for MySQL which are currently in preview

**Testing Guide**
az dms project task create -g {resource group} --service-name {service name} --project-name {project name} --source-connection-json {Path Source connection json file} --target-connection-json {Path Target connection json file} --database-options-json {Path to Database options json file} -n {Task name}

**History Notes**
[dms] `az dms project task create`: Update DMS MySQL API to support new migration types

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
