### PR TITLE
{Packaging} Bump PyWin32 to 305

### DIFF
--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -127,7 +127,7 @@ PyMySQL==1.0.2
 PyNaCl==1.5.0
 pyOpenSSL==19.0.0
 python-dateutil==2.8.0
-pywin32==302
+pywin32==305
 requests-oauthlib==1.2.0
 requests[socks]==2.26.0
 scp==0.13.2


### PR DESCRIPTION
## Change

Bump PyWin32 (to >= 303) so that Azure CLI no longer loads `pywintypes310.dll` or `pythoncom310.dll` from the current working directory (CWD), but always from `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\pywin32_system32\`.

## Context

### `LoadLibrary` and `LoadLibraryEx` Win32 API

According to https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-desktop-applications, even if `SafeDllSearchMode` is enabled and it places the user's current directory later in the search order, the current directory is still searched by [`LoadLibrary`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw) and [`LoadLibraryEx`](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw). `LoadLibraryEx` supports additional flags such as `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` and `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`. When these flags are specified, directories in the standard search path are not searched, so the current directory is no longer searched.

### Python 3.8's DLL loading mechanism change

https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-python-api

> DLL dependencies for extension modules and DLLs loaded with ctypes on Windows are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file, and directories added with add_dll_directory() are searched for load-time dependencies. Specifically, PATH and the current working directory are no longer used, and modifications to these will no longer have any effect on normal DLL resolution. If your application relies on these mechanisms, you should check for add_dll_directory() and if it exists, use it to add your DLLs directory while loading your library. Note that Windows 7 users will need to ensure that Windows Update KB2533623 has been installed (this is also verified by the installer). (Contributed by Steve Dower in bpo-36085.)

bpo-36085 is migrated to https://github.com/python/cpython/issues/80266.

In summary, when loading DLLs:

- in Python 3.7, `LoadLibraryExW` is called with `LOAD_WITH_ALTERED_SEARCH_PATH`.
- in Python 3.8, `LoadLibraryExW` is called with `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` and `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR`, more securely (https://github.com/python/cpython/pull/12302)

### PyWin32's DLL loading mechanism change

Since version 303, PyWin32's `_win32sysloader` switched from calling `LoadLibrary` to `LoadLibraryEx` with the same `LoadLibraryEx` flags as Python itself https://github.com/mhammond/pywin32/pull/1794.

Therefore, PyWin32's change causes **the current directory no longer to be searched**, but its change log doesn't mention this:

https://github.com/mhammond/pywin32/blob/d73b0200eba81fa551b90d15cf5da097f4197f8f/CHANGES.txt#L92-L93

> Tweaks to how DLLs are loaded and our installation found, which should improve virtualenv support and version mismatch issues (#1787, #1794)


## Testing guide

The test can be done with system Python, without Azure CLI's embedded Python.

With PyWin32 302, DLL can be loaded from the current directory:

```
> cd D:\temp
> pip install pywin32==302
> mv $env:LOCALAPPDATA\Programs\Python\Python310\Lib\site-packages\pywin32_system32\pythoncom310.dll D:\temp
> python -c "import win32com"
```

With PyWin32 305, DLL cannot be loaded from the current directory and results in an `ImportError`:

```
> cd D:\temp
> pip install pywin32==305
> mv $env:LOCALAPPDATA\Programs\Python\Python310\Lib\site-packages\pywin32_system32\pythoncom310.dll D:\temp
> python -c "import win32com"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\jiasli\AppData\Local\Programs\Python\Python310\lib\site-packages\win32com\__init__.py", line 6, in <module>
    import pythoncom
  File "C:\Users\jiasli\AppData\Local\Programs\Python\Python310\lib\site-packages\pythoncom.py", line 4, in <module>
    pywintypes.__import_pywin32_system_module__("pythoncom", globals())
  File "C:\Users\jiasli\AppData\Local\Programs\Python\Python310\lib\site-packages\win32\lib\pywintypes.py", line 105, in __import_pywin32_system_module__
    raise ImportError("No system module '%s' (%s)" % (modname, filename))
ImportError: No system module 'pythoncom' (pythoncom310.dll)
```
