### PR TITLE
[AKS] `az aks install-cli`: Automatically add the installation directories to system path on windows

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1474,13 +1474,14 @@ def append_install_dir_to_windows_user_path(install_dir, binary_name):
     user_path = ""
     try:
         user_path = get_windows_user_path()
+    # pylint: disable=broad-except
     except Exception as e:
-        logger.debug("failed to get user path, error: {}".format(e))
+        logger.debug("failed to get user path, error: %s", e)
         log_windows_post_installation_manual_steps_warning(install_dir, binary_name)
         # unable to get user path, skip appending user path
         return
     if install_dir in user_path:
-        logger.debug("installation directory '{}' already exists in user path".format(install_dir))
+        logger.debug("installation directory '%s' already exists in user path", install_dir)
         return
     # keep user path style (with or without semicolon at the end)
     flag = user_path.endswith(";")
@@ -1488,8 +1489,9 @@ def append_install_dir_to_windows_user_path(install_dir, binary_name):
     try:
         subprocess.run(setxexp, shell=True, check=True, capture_output=True)
         log_windows_successful_installation_warning(install_dir)
+    # pylint: disable=broad-except
     except Exception as e:
-        logger.debug("failed to set user path, error: {}".format(e))
+        logger.debug("failed to set user path, error: %s", e)
         log_windows_post_installation_manual_steps_warning(install_dir, binary_name)
 
 
@@ -1507,12 +1509,12 @@ def check_windows_install_dir(install_dir):
 
 def log_windows_successful_installation_warning(install_dir):
     logger.warning(
-        'The installation directory "{}" has been successfully appended to the user path, '
+        'The installation directory "%s" has been successfully appended to the user path, '
         "the configuration will only take effect in the new command sessions. "
-        "Please re-open the command window.".format(install_dir)
+        "Please re-open the command window.", install_dir
     )
 
-
+# pylint: disable=logging-format-interpolation
 def log_windows_post_installation_manual_steps_warning(install_dir, binary_name):
     logger.warning(
         'Please add "{0}" to your search PATH so the `{1}` can be found. 2 options: \n'

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1484,7 +1484,7 @@ def append_install_dir_to_windows_user_path(install_dir, binary_name):
         return
     # keep user path style (with or without semicolon at the end)
     flag = user_path.endswith(";")
-    setxexp = ["setx", "path", "\"{}{}{}{}\"".format(user_path, "" if flag else ";", install_dir, ";" if flag else "")]
+    setxexp = ["setx", "path", "{}{}{}{}".format(user_path, "" if flag else ";", install_dir, ";" if flag else "")]
     try:
         subprocess.run(setxexp, shell=True, check=True, capture_output=True)
         log_windows_successful_installation_warning(install_dir)

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1514,6 +1514,7 @@ def log_windows_successful_installation_warning(install_dir):
         "Please re-open the command window.", install_dir
     )
 
+
 # pylint: disable=logging-format-interpolation
 def log_windows_post_installation_manual_steps_warning(install_dir, binary_name):
     logger.warning(

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1453,7 +1453,7 @@ def get_arch_for_cli_binary():
 # get the user path environment variable
 def get_windows_user_path():
     reg_query_exp = "reg query HKCU\\Environment /v path"
-    reg_regex_exp = "REG\w+"
+    reg_regex_exp = r"REG\w+"
     try:
         reg_result = subprocess.run(reg_query_exp.split(" "), shell=True, check=True, capture_output=True, text=True)
     except Exception as e:
@@ -1474,7 +1474,7 @@ def append_install_dir_to_windows_user_path(install_dir, binary_name):
     user_path = ""
     try:
         user_path = get_windows_user_path()
-    except Exception as e :
+    except Exception as e:
         logger.debug("failed to get user path, error: {}".format(e))
         log_windows_post_installation_manual_steps_warning(install_dir, binary_name)
         # unable to get user path, skip appending user path
@@ -1512,6 +1512,7 @@ def log_windows_successful_installation_warning(install_dir):
         "Please re-open the command window.".format(install_dir)
     )
 
+
 def log_windows_post_installation_manual_steps_warning(install_dir, binary_name):
     logger.warning(
         'Please add "{0}" to your search PATH so the `{1}` can be found. 2 options: \n'
@@ -1521,6 +1522,7 @@ def log_windows_post_installation_manual_steps_warning(install_dir, binary_name)
         '"Control Panel->System->Advanced->Environment Variables", and re-open the command window. '
         "You only need to do it once".format(install_dir, binary_name)
     )
+
 
 # install kubectl
 def k8s_install_kubectl(cmd, client_version='latest', install_location=None, source_url=None, arch=None):

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1465,7 +1465,7 @@ def get_windows_user_path():
     if not identifier:
         raise CLIInternalError("failed to parse reg query result")
     start_idx = raw_user_path.find(identifier)
-    user_path = raw_user_path[start_idx+len(identifier):].strip()
+    user_path = raw_user_path[start_idx+len(identifier) :].strip()
     return user_path
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1465,7 +1465,7 @@ def get_windows_user_path():
     if not identifier:
         raise CLIInternalError("failed to parse reg query result")
     start_idx = raw_user_path.find(identifier)
-    user_path = raw_user_path[start_idx+len(identifier) :].strip()
+    user_path = raw_user_path[start_idx + len(identifier):].strip()
     return user_path
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks install-cli`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Automatically add the installation directories of the binaries downloaded through the `az aks install-cli` command to the search path (user environment variable `PATH`) on the windows platform.

- In this example, the latest versions of kubectl and kubelogin are downloaded to the corresponding default paths, and these paths are automatically added to the _user_ environment variable `PATH`, so that users can directly use these tools in a new command line session.
  - The installation directories are appended to the user environment variable, avoiding the need for administrator privileges to write system environment variables.
  - Although the variable `PATH` is updated in append mode, there is still a certain risk that `PATH` will be truncated if it exceeds the length limit.
  - The implementation is by querying the registry key `HKCU\Environment`, parsing the result and setting the new value through `setx` in the default shell `cmd`. If any error occurs in this process, it should not have any side effects, and will fall back to prompting the user to manually configure the search path (like it used to be).
  - This change has no effect on the linux platform.
  <img width="1112" alt="image" src="https://user-images.githubusercontent.com/81607949/209662180-ad3d546a-caf5-4487-b894-7565acc1ed00.png">
  <img width="501" alt="image" src="https://user-images.githubusercontent.com/81607949/209663029-6ad11e81-eb67-4214-9d2d-4344fe5dfe5b.png">



**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
