### PR TITLE
{CosmosDB} Normalize location in the restorable database API response

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -1773,12 +1773,14 @@ def cli_cosmosdb_restore(cmd,
     # Validate if source account is empty only for live account restores. For deleted account restores the api will not work
     if not is_source_restorable_account_deleted:
         restorable_resources = None
+        arm_location_normalized = target_restorable_account.location.lower().replace(" ", "")
+
         if target_restorable_account.api_type.lower() == "sql":
             try:
                 from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_sql_resources
                 restorable_sql_resources_client = cf_restorable_sql_resources(cmd.cli_ctx, [])
                 restorable_resources = restorable_sql_resources_client.list(
-                    target_restorable_account.location,
+                    arm_location_normalized,
                     target_restorable_account.name,
                     location,
                     restore_timestamp_datetime_utc)
@@ -1789,7 +1791,7 @@ def cli_cosmosdb_restore(cmd,
                 from azure.cli.command_modules.cosmosdb._client_factory import cf_restorable_mongodb_resources
                 restorable_mongodb_resources_client = cf_restorable_mongodb_resources(cmd.cli_ctx, [])
                 restorable_resources = restorable_mongodb_resources_client.list(
-                    target_restorable_account.location,
+                    arm_location_normalized,
                     target_restorable_account.name,
                     location,
                     restore_timestamp_datetime_utc)

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_deleted_account_restore.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_deleted_account_restore.yaml
@@ -13,13 +13,12 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_deleted_account_restore000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001","name":"cli_test_cosmosdb_deleted_account_restore000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-09-19T03:31:53Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001","name":"cli_test_cosmosdb_deleted_account_restore000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T01:45:15Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -28,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 03:31:54 GMT
+      - Wed, 28 Dec 2022 01:45:20 GMT
       expires:
       - '-1'
       pragma:
@@ -46,7 +45,8 @@ interactions:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
       "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default",
-      "backupPolicy": {"type": "Continuous"}}}'
+      "backupPolicy": {"type": "Continuous", "continuousModeProperties": {"tier":
+      "Continuous30Days"}}}}'
     headers:
       Accept:
       - application/json
@@ -57,37 +57,36 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '284'
+      - '342'
       Content-Type:
       - application/json
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T03:31:58.8440517Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"04379736-7bb7-49ea-aca7-dadd462cde88","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:45:25.6249607Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T03:31:58.8440517Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T03:31:58.8440517Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:31:58.8440517Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:31:58.8440517Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2116'
+      - '2258'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:32:01 GMT
+      - Wed, 28 Dec 2022 01:45:28 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
       pragma:
       - no-cache
       server:
@@ -121,10 +120,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -136,7 +134,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:32:31 GMT
+      - Wed, 28 Dec 2022 01:45:58 GMT
       pragma:
       - no-cache
       server:
@@ -168,10 +166,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -183,7 +180,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:33:01 GMT
+      - Wed, 28 Dec 2022 01:46:28 GMT
       pragma:
       - no-cache
       server:
@@ -215,10 +212,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -230,7 +226,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:33:31 GMT
+      - Wed, 28 Dec 2022 01:46:58 GMT
       pragma:
       - no-cache
       server:
@@ -262,10 +258,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -277,7 +272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:34:01 GMT
+      - Wed, 28 Dec 2022 01:47:29 GMT
       pragma:
       - no-cache
       server:
@@ -309,57 +304,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 19 Sep 2022 03:34:31 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.14.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -g --backup-policy-type --locations
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ccd38fb3-6ecb-483b-8081-6fb79cd14b9b?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -371,7 +318,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:01 GMT
+      - Wed, 28 Dec 2022 01:47:59 GMT
       pragma:
       - no-cache
       server:
@@ -403,27 +350,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T03:34:00.8550803Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"04379736-7bb7-49ea-aca7-dadd462cde88","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2415'
+      - '2557'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:01 GMT
+      - Wed, 28 Dec 2022 01:47:59 GMT
       pragma:
       - no-cache
       server:
@@ -455,27 +401,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T03:34:00.8550803Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"04379736-7bb7-49ea-aca7-dadd462cde88","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2415'
+      - '2557'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:01 GMT
+      - Wed, 28 Dec 2022 01:47:59 GMT
       pragma:
       - no-cache
       server:
@@ -507,27 +452,26 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T03:34:00.8550803Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"04379736-7bb7-49ea-aca7-dadd462cde88","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:34:00.8550803Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2415'
+      - '2557'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:02 GMT
+      - Wed, 28 Dec 2022 01:47:59 GMT
       pragma:
       - no-cache
       server:
@@ -559,23 +503,22 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z"}]}}'
+      string: '{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","oldestRestorableTime":"2022-12-28T01:47:22Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '565'
+      - '611'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:02 GMT
+      - Wed, 28 Dec 2022 01:48:00 GMT
       pragma:
       - no-cache
       server:
@@ -611,8 +554,7 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
@@ -620,7 +562,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/8f704530-3e22-4eb0-bea3-9534879b855f?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -628,9 +570,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:03 GMT
+      - Wed, 28 Dec 2022 01:48:01 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/8f704530-3e22-4eb0-bea3-9534879b855f?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -642,7 +584,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -660,10 +602,9 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/8f704530-3e22-4eb0-bea3-9534879b855f?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -675,7 +616,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:33 GMT
+      - Wed, 28 Dec 2022 01:48:32 GMT
       pragma:
       - no-cache
       server:
@@ -707,13 +648,12 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"GAV-AA==","_self":"dbs/GAV-AA==/","_etag":"\"00009300-0000-0700-0000-6327e36c0000\"","_colls":"colls/","_users":"users/","_ts":1663558508}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"4xUfAA==","_self":"dbs/4xUfAA==/","_etag":"\"0000a600-0000-0700-0000-63aba0570000\"","_colls":"colls/","_users":"users/","_ts":1672192087}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -722,7 +662,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:33 GMT
+      - Wed, 28 Dec 2022 01:48:32 GMT
       pragma:
       - no-cache
       server:
@@ -761,8 +701,7 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
@@ -770,7 +709,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b9adf3f7-3222-49e4-84e2-ec0ded1e80a3?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -778,9 +717,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:35:34 GMT
+      - Wed, 28 Dec 2022 01:48:34 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/b9adf3f7-3222-49e4-84e2-ec0ded1e80a3?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -792,7 +731,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -810,10 +749,9 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/b9adf3f7-3222-49e4-84e2-ec0ded1e80a3?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -825,7 +763,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:36:04 GMT
+      - Wed, 28 Dec 2022 01:49:04 GMT
       pragma:
       - no-cache
       server:
@@ -857,13 +795,12 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"GAV-AKNbUBg=","_ts":1663558539,"_self":"dbs/GAV-AA==/colls/GAV-AKNbUBg=/","_etag":"\"00009700-0000-0700-0000-6327e38b0000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"4xUfAMlJtew=","_ts":1672192119,"_self":"dbs/4xUfAA==/colls/4xUfAMlJtew=/","_etag":"\"0000a900-0000-0700-0000-63aba0770000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -872,7 +809,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:36:04 GMT
+      - Wed, 28 Dec 2022 01:49:05 GMT
       pragma:
       - no-cache
       server:
@@ -906,8 +843,7 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
@@ -915,7 +851,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -923,9 +859,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:41:06 GMT
+      - Wed, 28 Dec 2022 01:54:06 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -955,10 +891,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -970,7 +905,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:41:36 GMT
+      - Wed, 28 Dec 2022 01:54:37 GMT
       pragma:
       - no-cache
       server:
@@ -1002,10 +937,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1017,7 +951,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:42:06 GMT
+      - Wed, 28 Dec 2022 01:55:07 GMT
       pragma:
       - no-cache
       server:
@@ -1049,10 +983,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1064,7 +997,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:42:36 GMT
+      - Wed, 28 Dec 2022 01:55:37 GMT
       pragma:
       - no-cache
       server:
@@ -1096,10 +1029,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1111,7 +1043,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:43:06 GMT
+      - Wed, 28 Dec 2022 01:56:07 GMT
       pragma:
       - no-cache
       server:
@@ -1143,10 +1075,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1158,7 +1089,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:43:37 GMT
+      - Wed, 28 Dec 2022 01:56:37 GMT
       pragma:
       - no-cache
       server:
@@ -1190,10 +1121,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1205,7 +1135,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:44:07 GMT
+      - Wed, 28 Dec 2022 01:57:07 GMT
       pragma:
       - no-cache
       server:
@@ -1237,10 +1167,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1252,7 +1181,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:44:37 GMT
+      - Wed, 28 Dec 2022 01:57:37 GMT
       pragma:
       - no-cache
       server:
@@ -1284,10 +1213,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1299,7 +1227,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:45:06 GMT
+      - Wed, 28 Dec 2022 01:58:07 GMT
       pragma:
       - no-cache
       server:
@@ -1331,10 +1259,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1346,7 +1273,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:45:37 GMT
+      - Wed, 28 Dec 2022 01:58:37 GMT
       pragma:
       - no-cache
       server:
@@ -1378,10 +1305,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1393,7 +1319,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:46:07 GMT
+      - Wed, 28 Dec 2022 01:59:08 GMT
       pragma:
       - no-cache
       server:
@@ -1425,10 +1351,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1440,7 +1365,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:46:37 GMT
+      - Wed, 28 Dec 2022 01:59:38 GMT
       pragma:
       - no-cache
       server:
@@ -1472,10 +1397,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1487,7 +1411,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:47:07 GMT
+      - Wed, 28 Dec 2022 02:00:07 GMT
       pragma:
       - no-cache
       server:
@@ -1519,10 +1443,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1534,7 +1457,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:47:37 GMT
+      - Wed, 28 Dec 2022 02:00:37 GMT
       pragma:
       - no-cache
       server:
@@ -1566,10 +1489,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1581,7 +1503,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:48:07 GMT
+      - Wed, 28 Dec 2022 02:01:08 GMT
       pragma:
       - no-cache
       server:
@@ -1613,10 +1535,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1628,7 +1549,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:48:37 GMT
+      - Wed, 28 Dec 2022 02:01:38 GMT
       pragma:
       - no-cache
       server:
@@ -1660,10 +1581,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1675,7 +1595,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:49:08 GMT
+      - Wed, 28 Dec 2022 02:02:08 GMT
       pragma:
       - no-cache
       server:
@@ -1707,10 +1627,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1722,7 +1641,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:49:38 GMT
+      - Wed, 28 Dec 2022 02:02:38 GMT
       pragma:
       - no-cache
       server:
@@ -1754,10 +1673,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1769,7 +1687,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:50:08 GMT
+      - Wed, 28 Dec 2022 02:03:08 GMT
       pragma:
       - no-cache
       server:
@@ -1801,10 +1719,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1816,7 +1733,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:50:38 GMT
+      - Wed, 28 Dec 2022 02:03:38 GMT
       pragma:
       - no-cache
       server:
@@ -1848,10 +1765,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1863,7 +1779,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:51:08 GMT
+      - Wed, 28 Dec 2022 02:04:09 GMT
       pragma:
       - no-cache
       server:
@@ -1895,10 +1811,9 @@ interactions:
       ParameterSetName:
       - -n -g --yes
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5519dae9-ba21-4b45-9f20-4134ab9292fc?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1910,7 +1825,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:51:38 GMT
+      - Wed, 28 Dec 2022 02:04:39 GMT
       pragma:
       - no-cache
       server:
@@ -1942,104 +1857,268 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"value":[{"name":"d6e5008d-fdcb-4927-98ee-3c2753c89ee7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6e5008d-fdcb-4927-98ee-3c2753c89ee7","properties":{"accountName":"clilc67z5wdqqx2","apiType":"Sql","creationTime":"2022-08-25T06:08:26Z","deletionTime":"2022-08-25T06:15:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"37af2dc0-2aa6-46d3-8e41-cfed196796f9","creationTime":"2022-08-25T06:08:27Z","deletionTime":"2022-08-25T06:15:27Z"}]}},{"name":"90bd51e7-1fe7-4315-87f6-c2407cc951b0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90bd51e7-1fe7-4315-87f6-c2407cc951b0","properties":{"accountName":"cliw23t2chyagy6","apiType":"Sql","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d7cf6cbf-d6a1-4888-a620-41a07f491415","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z"}]}},{"name":"6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","properties":{"accountName":"cli7bonjdjz73wj","apiType":"MongoDB","creationTime":"2022-08-25T06:41:30Z","deletionTime":"2022-08-25T06:47:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"08709870-877a-42ea-a849-210c0fda4ee1","creationTime":"2022-08-25T06:41:31Z","deletionTime":"2022-08-25T06:47:32Z"}]}},{"name":"deff6534-a2b9-404d-b4ba-2e5e22b32bfb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/deff6534-a2b9-404d-b4ba-2e5e22b32bfb","properties":{"accountName":"cliuis4anv3ycph","apiType":"MongoDB","creationTime":"2022-08-25T07:18:31Z","deletionTime":"2022-08-25T07:26:15Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"dafa935e-6ee4-4d4a-bc1d-c8e609d42a60","creationTime":"2022-08-25T07:18:32Z","deletionTime":"2022-08-25T07:26:15Z"}]}},{"name":"d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","properties":{"accountName":"cliz5zwclforhva","apiType":"Sql","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5982b098-fba7-49cc-9996-ad4ccb1b3d33","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z"}]}},{"name":"0ccdf2af-7bda-4f61-b6df-d734c6773db6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0ccdf2af-7bda-4f61-b6df-d734c6773db6","properties":{"accountName":"cli7c6gulakolbu","apiType":"Sql","creationTime":"2022-08-25T07:35:24Z","deletionTime":"2022-08-25T07:57:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"794c2fc6-6ac1-41ba-990f-bd2c07eb7b9f","creationTime":"2022-08-25T07:35:25Z","deletionTime":"2022-08-25T07:57:18Z"}]}},{"name":"00df9a41-faa9-41a7-b061-6e3e3c923456","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/00df9a41-faa9-41a7-b061-6e3e3c923456","properties":{"accountName":"clib7httb4gycob","apiType":"Sql","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b56217c5-6fa0-4c6d-9809-80899be99f51","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","properties":{"accountName":"cliddcu3cjrh6we","apiType":"Sql","creationTime":"2022-08-25T07:57:57Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"938063bf-8716-409c-894f-60bb99781705","creationTime":"2022-08-25T07:57:58Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"68ac0330-103f-43ea-a1de-37c94072a36e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68ac0330-103f-43ea-a1de-37c94072a36e","properties":{"accountName":"clik7kgspjf6bgm","apiType":"Sql","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ff7a4f80-356f-4371-b143-ee999b63eb80","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z"}]}},{"name":"7bb0479d-7652-434b-af5b-675da5d24d9d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7bb0479d-7652-434b-af5b-675da5d24d9d","properties":{"accountName":"cligi5y5fvohgv453w5z25icozd6527bpu5ecv4k","apiType":"Sql","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bcac751b-de78-4668-9ef3-adca14decc29","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z"}]}},{"name":"212beaac-388e-4ff4-981e-f9aef3516b64","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/212beaac-388e-4ff4-981e-f9aef3516b64","properties":{"accountName":"cliren6oja2hpwe","apiType":"Sql","creationTime":"2022-08-25T17:36:41Z","deletionTime":"2022-08-25T17:43:38Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cec6d4eb-e6cc-4e65-bb67-26fde7eabc6e","creationTime":"2022-08-25T17:36:42Z","deletionTime":"2022-08-25T17:43:38Z"}]}},{"name":"045f21c9-c8cc-4ee5-ae4c-c95a481280ce","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045f21c9-c8cc-4ee5-ae4c-c95a481280ce","properties":{"accountName":"cli642xlhclhjvr","apiType":"MongoDB","creationTime":"2022-08-25T17:48:15Z","deletionTime":"2022-08-25T17:54:51Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4da784b9-9142-4cd4-a3d4-7b3b941cef0b","creationTime":"2022-08-25T17:48:16Z","deletionTime":"2022-08-25T17:54:51Z"}]}},{"name":"fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","properties":{"accountName":"cli2hngjqysuyrk","apiType":"MongoDB","creationTime":"2022-08-25T17:50:19Z","deletionTime":"2022-08-25T17:55:12Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a756769-7f16-4210-9a86-1b6a51f4ecdf","creationTime":"2022-08-25T17:50:20Z","deletionTime":"2022-08-25T17:55:12Z"}]}},{"name":"6972bff7-7971-4723-ae56-5802b096e6e3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6972bff7-7971-4723-ae56-5802b096e6e3","properties":{"accountName":"clif3lyrerpi54g","apiType":"Sql","creationTime":"2022-08-25T18:01:13Z","deletionTime":"2022-08-25T18:04:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"726278c9-7c2c-4391-bce6-e3387dff8435","creationTime":"2022-08-25T18:01:14Z","deletionTime":"2022-08-25T18:04:46Z"}]}},{"name":"3c46a652-c177-4916-9731-50bffdba55ae","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3c46a652-c177-4916-9731-50bffdba55ae","properties":{"accountName":"clitkbja6qgwko3","apiType":"Sql","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"42ae6741-aa76-4b7e-a5fa-feea888179e3","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z"}]}},{"name":"3e04e5e9-6a8f-4a78-86e6-18dc643980fd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3e04e5e9-6a8f-4a78-86e6-18dc643980fd","properties":{"accountName":"clirbh766tdrcuo","apiType":"Sql","creationTime":"2022-08-25T17:51:16Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"472275c5-7d72-489b-8069-0a041e696841","creationTime":"2022-08-25T17:51:17Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"1a2988f6-5f19-452e-a6e1-30b3716c3eff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a2988f6-5f19-452e-a6e1-30b3716c3eff","properties":{"accountName":"cliprc22bdv72rz","apiType":"Sql","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab980699-c97f-48a7-ab13-a4c750ad4665","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"b2093d64-9617-4f32-9d61-e905534e21da","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2093d64-9617-4f32-9d61-e905534e21da","properties":{"accountName":"clipyaf3k2czsnx","apiType":"Sql","creationTime":"2022-08-25T18:10:56Z","deletionTime":"2022-08-25T18:16:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cd9e2d6f-ae74-4a83-94de-c5b6c547ea71","creationTime":"2022-08-25T18:10:57Z","deletionTime":"2022-08-25T18:16:27Z"}]}},{"name":"dd296662-d32f-48ef-a55b-10d3cdd7d457","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd296662-d32f-48ef-a55b-10d3cdd7d457","properties":{"accountName":"cli2wmbvuvy7xzg","apiType":"Sql","creationTime":"2022-08-25T17:56:15Z","deletionTime":"2022-08-25T18:18:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"81a6ec53-ca56-4223-92b0-adeb6231e1f5","creationTime":"2022-08-25T17:56:16Z","deletionTime":"2022-08-25T18:18:29Z"}]}},{"name":"93d672c2-f060-4e22-b8a3-a1db21229e73","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/93d672c2-f060-4e22-b8a3-a1db21229e73","properties":{"accountName":"clij2xvz5zuhpth","apiType":"Sql","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"643a1596-40ff-494d-ac87-7a9f2b53a231","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z"}]}},{"name":"627d35df-1aff-4d0a-8d71-e7bb3ca16551","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/627d35df-1aff-4d0a-8d71-e7bb3ca16551","properties":{"accountName":"cliyvfzwxgzbt5qcsnarlf2gedbik7kuzpwoqqoz","apiType":"Sql","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7c3790de-2307-4aaf-8ccc-64f2aa7c2032","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z"}]}},{"name":"9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","properties":{"accountName":"cliomvsal633avs","apiType":"MongoDB","creationTime":"2022-09-01T17:22:23Z","deletionTime":"2022-09-01T17:27:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1ab7c41f-533d-4e8f-b819-6b8753eea8e4","creationTime":"2022-09-01T17:22:24Z","deletionTime":"2022-09-01T17:27:19Z"}]}},{"name":"437aa3e6-8920-42ef-b5df-2c8ee28bfe81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/437aa3e6-8920-42ef-b5df-2c8ee28bfe81","properties":{"accountName":"clit3zdheluo26r","apiType":"MongoDB","creationTime":"2022-09-01T17:29:41Z","deletionTime":"2022-09-01T17:35:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a878da74-6edd-43ad-a08c-f12a2c8b58e9","creationTime":"2022-09-01T17:29:42Z","deletionTime":"2022-09-01T17:35:19Z"}]}},{"name":"055ba6b8-c241-4ca5-bd2a-5905f5782029","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/055ba6b8-c241-4ca5-bd2a-5905f5782029","properties":{"accountName":"cliv6mcsfgjd4ak","apiType":"Sql","creationTime":"2022-09-01T17:42:11Z","deletionTime":"2022-09-01T17:48:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"f1c6d0cb-7dac-4d3d-839c-c1967da5d20d","creationTime":"2022-09-01T17:42:12Z","deletionTime":"2022-09-01T17:48:46Z"}]}},{"name":"596ccc7e-6212-4a58-a615-fdef3581a566","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/596ccc7e-6212-4a58-a615-fdef3581a566","properties":{"accountName":"clist343b7kqxgt","apiType":"Sql","creationTime":"2022-09-01T17:32:00Z","deletionTime":"2022-09-01T17:53:03Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"62004e01-add8-49ca-9482-c081d9dad32a","creationTime":"2022-09-01T17:32:01Z","deletionTime":"2022-09-01T17:53:03Z"}]}},{"name":"d4d26f2d-aacb-461d-9674-874533a35927","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d4d26f2d-aacb-461d-9674-874533a35927","properties":{"accountName":"cliim5efmvechgm","apiType":"Sql","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"326ab156-4292-46cd-b265-04b4da16880f","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z"}]}},{"name":"ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","properties":{"accountName":"cli5xjit35t3vmy","apiType":"Sql","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a26e214a-987d-4956-82e2-29581b698be7","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"6700db64-9dd4-4e0e-aedf-cc571d2556be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6700db64-9dd4-4e0e-aedf-cc571d2556be","properties":{"accountName":"cliusb2cpctd3jo","apiType":"Sql","creationTime":"2022-09-01T17:33:21Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bb5b12c1-d062-4ade-995f-56f3a5cebb51","creationTime":"2022-09-01T17:33:22Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"50161594-bab1-4110-bfc3-bb941822226b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/50161594-bab1-4110-bfc3-bb941822226b","properties":{"accountName":"cli6q2r7sebffac37t5lwk3cepyladzkkldjmxna","apiType":"Sql","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"765a32de-2b34-4333-be94-319a4fd75d2d","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z"}]}},{"name":"cf42a3c3-c50b-4110-bccf-a27131e4c240","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cf42a3c3-c50b-4110-bccf-a27131e4c240","properties":{"accountName":"cli3zz43bzjjsjy","apiType":"Sql","creationTime":"2022-09-08T17:13:37Z","deletionTime":"2022-09-08T17:20:31Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"836fb615-1694-4bb8-bb26-d4d7191a9826","creationTime":"2022-09-08T17:13:38Z","deletionTime":"2022-09-08T17:20:31Z"}]}},{"name":"3768a794-c2dc-4ed2-ac26-09eb8595b38f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3768a794-c2dc-4ed2-ac26-09eb8595b38f","properties":{"accountName":"cliblp3rryrjgkc","apiType":"MongoDB","creationTime":"2022-09-08T17:17:35Z","deletionTime":"2022-09-08T17:21:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a60fd3d-8d88-4ce2-9b59-cc33ee9bc199","creationTime":"2022-09-08T17:17:36Z","deletionTime":"2022-09-08T17:21:18Z"}]}},{"name":"16c01f3c-6319-4622-b8ef-72f587d939e7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16c01f3c-6319-4622-b8ef-72f587d939e7","properties":{"accountName":"clib2p6v5nnugvg","apiType":"MongoDB","creationTime":"2022-09-08T17:24:19Z","deletionTime":"2022-09-08T17:29:54Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab765683-a955-438f-a9f1-f88e6538f65b","creationTime":"2022-09-08T17:24:20Z","deletionTime":"2022-09-08T17:29:54Z"}]}},{"name":"c7000b77-291f-4d2b-a194-674e0956fb8f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c7000b77-291f-4d2b-a194-674e0956fb8f","properties":{"accountName":"cligri3ik55bve4","apiType":"Sql","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"2aaedea8-ce96-4549-8b59-686affcb1450","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z"}]}},{"name":"6c67aa75-0d9f-4818-bd33-84fb08b60307","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6c67aa75-0d9f-4818-bd33-84fb08b60307","properties":{"accountName":"clig74xujvvw7fw","apiType":"Sql","creationTime":"2022-09-08T17:38:49Z","deletionTime":"2022-09-08T17:43:36Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"065dc3e7-da03-4320-9923-d98bab3f3a32","creationTime":"2022-09-08T17:38:50Z","deletionTime":"2022-09-08T17:43:36Z"}]}},{"name":"59631687-f4e4-4b07-af3e-555c6e59150e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/59631687-f4e4-4b07-af3e-555c6e59150e","properties":{"accountName":"cliu5kch5swrzap","apiType":"Sql","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"eed5cfa5-76a9-4da1-8e28-70c1a3746f8a","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"c21bda24-fae1-44a2-ae1e-cb8fe570eea7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c21bda24-fae1-44a2-ae1e-cb8fe570eea7","properties":{"accountName":"clihdp4vf36xo2y","apiType":"Sql","creationTime":"2022-09-08T17:25:17Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b80a35a4-31c0-4bc0-ba5a-61c34833290f","creationTime":"2022-09-08T17:25:18Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"3aa72b82-66f2-4422-bff1-fcc6398e4872","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3aa72b82-66f2-4422-bff1-fcc6398e4872","properties":{"accountName":"cliiee5ncxczcvm","apiType":"Sql","creationTime":"2022-09-08T17:40:18Z","deletionTime":"2022-09-08T17:47:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5fc01c1b-02f7-4e2c-b66c-cc3b0d0136b5","creationTime":"2022-09-08T17:40:19Z","deletionTime":"2022-09-08T17:47:05Z"}]}},{"name":"cc64273d-9ac3-401b-8364-c9b5c222e16f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc64273d-9ac3-401b-8364-c9b5c222e16f","properties":{"accountName":"cli44be3onue5e3","apiType":"Sql","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b046012f-46f1-4076-9422-3e468b13b5bf","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"7080defb-7912-442c-8740-3474083d8bd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7080defb-7912-442c-8740-3474083d8bd1","properties":{"accountName":"cli6wl3roplqpwr","apiType":"Sql","creationTime":"2022-09-08T17:42:35Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"fe7a7ee6-e228-44cd-962d-c746cd1aaa0e","creationTime":"2022-09-08T17:42:36Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"a8165efd-ccef-4c75-aa24-7caf1f3075cc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a8165efd-ccef-4c75-aa24-7caf1f3075cc","properties":{"accountName":"clidl5m246s5argh5rxu3taw7ov2uioqp2xsyjb4","apiType":"Sql","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"663d7288-f394-4ba9-90ba-e562767e19bf","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z"}]}},{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","deletionTime":"2022-09-19T03:41:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z","deletionTime":"2022-09-19T03:41:22Z"}]}}]}'
+      string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Canada
+        Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"b324c6a4-f540-4fce-a04f-ee2b5a7640da","creationTime":"2022-10-28T21:16:24Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e34d6a9-58a3-4e20-9d71-1ab3ff745b3c","creationTime":"2022-10-28T21:11:19Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"dbb767b2-f3d5-4475-8c99-464e9779fec4","creationTime":"2022-10-28T21:08:44Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"11f4f056-5005-40c8-bac4-7cd287d38352","creationTime":"2022-10-28T21:02:42Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
+        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
+        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T02:04:41Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '26705'
+      - '68522'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 03:51:40 GMT
+      - Wed, 28 Dec 2022 02:04:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2088,8 +2167,6 @@ interactions:
       - ''
       - ''
       - ''
-      - ''
-      - ''
     status:
       code: 200
       message: OK
@@ -2097,8 +2174,8 @@ interactions:
     body: '{"location": "West US", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard", "apiProperties": {}, "createMode": "Restore", "restoreParameters":
-      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88",
-      "restoreTimestampInUtc": "2022-09-19T03:38:01.000Z"}}}'
+      {"restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca",
+      "restoreTimestampInUtc": "2022-12-28T01:51:22.000Z", "restoreMode": "PointInTime"}}}'
     headers:
       Accept:
       - application/json
@@ -2115,31 +2192,31 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T03:51:43.0887205Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"edb07b57-c581-4d66-95e6-334bea0e3b76","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:04:44.4397825Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","restoreTimestampInUtc":"2022-09-19T03:38:01Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T03:51:43.0887205Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T03:51:43.0887205Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:51:43.0887205Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T03:51:43.0887205Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2663'
+      - '2838'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:51:46 GMT
+      - Wed, 28 Dec 2022 02:04:47 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
       pragma:
       - no-cache
       server:
@@ -2155,7 +2232,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1194'
+      - '1198'
     status:
       code: 200
       message: Ok
@@ -2173,10 +2250,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2188,7 +2264,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:52:16 GMT
+      - Wed, 28 Dec 2022 02:05:17 GMT
       pragma:
       - no-cache
       server:
@@ -2220,10 +2296,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2235,7 +2310,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:52:46 GMT
+      - Wed, 28 Dec 2022 02:05:47 GMT
       pragma:
       - no-cache
       server:
@@ -2267,10 +2342,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2282,7 +2356,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:53:16 GMT
+      - Wed, 28 Dec 2022 02:06:17 GMT
       pragma:
       - no-cache
       server:
@@ -2314,10 +2388,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2329,7 +2402,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:53:46 GMT
+      - Wed, 28 Dec 2022 02:06:47 GMT
       pragma:
       - no-cache
       server:
@@ -2361,10 +2434,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2376,7 +2448,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:54:16 GMT
+      - Wed, 28 Dec 2022 02:07:17 GMT
       pragma:
       - no-cache
       server:
@@ -2408,10 +2480,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2423,7 +2494,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:54:47 GMT
+      - Wed, 28 Dec 2022 02:07:48 GMT
       pragma:
       - no-cache
       server:
@@ -2455,10 +2526,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2470,7 +2540,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:55:16 GMT
+      - Wed, 28 Dec 2022 02:08:18 GMT
       pragma:
       - no-cache
       server:
@@ -2502,10 +2572,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2517,7 +2586,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:55:47 GMT
+      - Wed, 28 Dec 2022 02:08:48 GMT
       pragma:
       - no-cache
       server:
@@ -2549,10 +2618,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2564,7 +2632,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:56:17 GMT
+      - Wed, 28 Dec 2022 02:09:18 GMT
       pragma:
       - no-cache
       server:
@@ -2596,10 +2664,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2611,7 +2678,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:56:47 GMT
+      - Wed, 28 Dec 2022 02:09:48 GMT
       pragma:
       - no-cache
       server:
@@ -2643,10 +2710,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2658,7 +2724,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:57:17 GMT
+      - Wed, 28 Dec 2022 02:10:18 GMT
       pragma:
       - no-cache
       server:
@@ -2690,10 +2756,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2705,7 +2770,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:57:47 GMT
+      - Wed, 28 Dec 2022 02:10:49 GMT
       pragma:
       - no-cache
       server:
@@ -2737,10 +2802,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2752,7 +2816,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:58:17 GMT
+      - Wed, 28 Dec 2022 02:11:19 GMT
       pragma:
       - no-cache
       server:
@@ -2784,10 +2848,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2799,7 +2862,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:58:47 GMT
+      - Wed, 28 Dec 2022 02:11:48 GMT
       pragma:
       - no-cache
       server:
@@ -2831,10 +2894,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2846,7 +2908,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:59:18 GMT
+      - Wed, 28 Dec 2022 02:12:18 GMT
       pragma:
       - no-cache
       server:
@@ -2878,10 +2940,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2893,7 +2954,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 03:59:48 GMT
+      - Wed, 28 Dec 2022 02:12:48 GMT
       pragma:
       - no-cache
       server:
@@ -2925,10 +2986,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2940,7 +3000,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:00:18 GMT
+      - Wed, 28 Dec 2022 02:13:18 GMT
       pragma:
       - no-cache
       server:
@@ -2972,10 +3032,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2987,7 +3046,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:00:48 GMT
+      - Wed, 28 Dec 2022 02:13:48 GMT
       pragma:
       - no-cache
       server:
@@ -3019,10 +3078,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3034,7 +3092,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:01:18 GMT
+      - Wed, 28 Dec 2022 02:14:19 GMT
       pragma:
       - no-cache
       server:
@@ -3066,10 +3124,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3081,7 +3138,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:01:48 GMT
+      - Wed, 28 Dec 2022 02:14:48 GMT
       pragma:
       - no-cache
       server:
@@ -3113,10 +3170,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3128,7 +3184,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:02:18 GMT
+      - Wed, 28 Dec 2022 02:15:19 GMT
       pragma:
       - no-cache
       server:
@@ -3160,10 +3216,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3175,7 +3230,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:02:49 GMT
+      - Wed, 28 Dec 2022 02:15:49 GMT
       pragma:
       - no-cache
       server:
@@ -3207,10 +3262,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3222,7 +3276,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:03:19 GMT
+      - Wed, 28 Dec 2022 02:16:19 GMT
       pragma:
       - no-cache
       server:
@@ -3254,10 +3308,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3269,7 +3322,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:03:49 GMT
+      - Wed, 28 Dec 2022 02:16:49 GMT
       pragma:
       - no-cache
       server:
@@ -3301,10 +3354,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3316,7 +3368,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:04:19 GMT
+      - Wed, 28 Dec 2022 02:17:19 GMT
       pragma:
       - no-cache
       server:
@@ -3348,10 +3400,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3363,7 +3414,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:04:50 GMT
+      - Wed, 28 Dec 2022 02:17:49 GMT
       pragma:
       - no-cache
       server:
@@ -3395,10 +3446,55 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/50b1d7a9-d28b-47f5-8294-62ae6e3c1ea2?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Wed, 28 Dec 2022 02:18:19 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb restore
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --account-name -g --restore-timestamp --location --target-database-account-name
+      User-Agent:
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -3410,7 +3506,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:05:19 GMT
+      - Wed, 28 Dec 2022 02:18:49 GMT
       pragma:
       - no-cache
       server:
@@ -3442,27 +3538,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:03:46.0088904Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"edb07b57-c581-4d66-95e6-334bea0e3b76","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","restoreTimestampInUtc":"2022-09-19T03:38:01Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2731'
+      - '2906'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:05:20 GMT
+      - Wed, 28 Dec 2022 02:18:49 GMT
       pragma:
       - no-cache
       server:
@@ -3494,27 +3590,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:03:46.0088904Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"edb07b57-c581-4d66-95e6-334bea0e3b76","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","restoreTimestampInUtc":"2022-09-19T03:38:01Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2731'
+      - '2906'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:05:20 GMT
+      - Wed, 28 Dec 2022 02:18:50 GMT
       pragma:
       - no-cache
       server:
@@ -3546,27 +3642,27 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:03:46.0088904Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"edb07b57-c581-4d66-95e6-334bea0e3b76","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","restoreTimestampInUtc":"2022-09-19T03:38:01Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:03:46.0088904Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2731'
+      - '2906'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:05:20 GMT
+      - Wed, 28 Dec 2022 02:18:51 GMT
       pragma:
       - no-cache
       server:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_deleted_account_restore.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_deleted_account_restore.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_deleted_account_restore000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001","name":"cli_test_cosmosdb_deleted_account_restore000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T01:45:15Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001","name":"cli_test_cosmosdb_deleted_account_restore000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T04:14:05Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:45:20 GMT
+      - Wed, 28 Dec 2022 04:14:08 GMT
       expires:
       - '-1'
       pragma:
@@ -45,8 +45,7 @@ interactions:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
       "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default",
-      "backupPolicy": {"type": "Continuous", "continuousModeProperties": {"tier":
-      "Continuous30Days"}}}}'
+      "backupPolicy": {"type": "Continuous"}}}'
     headers:
       Accept:
       - application/json
@@ -57,36 +56,36 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '342'
+      - '284'
       Content-Type:
       - application/json
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:45:25.6249607Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:14:12.7546081Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"9888fe83-f236-476e-adb0-4873756c34c5","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:45:25.6249607Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:14:12.7546081Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:14:12.7546081Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:14:12.7546081Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:14:12.7546081Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2258'
+      - '2116'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:45:28 GMT
+      - Wed, 28 Dec 2022 04:14:14 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -120,9 +119,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -134,7 +133,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:45:58 GMT
+      - Wed, 28 Dec 2022 04:14:44 GMT
       pragma:
       - no-cache
       server:
@@ -166,9 +165,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -180,7 +179,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:46:28 GMT
+      - Wed, 28 Dec 2022 04:15:14 GMT
       pragma:
       - no-cache
       server:
@@ -212,9 +211,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -226,7 +225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:46:58 GMT
+      - Wed, 28 Dec 2022 04:15:44 GMT
       pragma:
       - no-cache
       server:
@@ -258,9 +257,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -272,7 +271,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:47:29 GMT
+      - Wed, 28 Dec 2022 04:16:14 GMT
       pragma:
       - no-cache
       server:
@@ -304,9 +303,101 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d5a1771f-45ff-4eea-bb00-5baf32746662?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Wed, 28 Dec 2022 04:16:45 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations
+      User-Agent:
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Wed, 28 Dec 2022 04:17:15 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations
+      User-Agent:
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/ceb26cfa-4e3e-4569-9cd5-b026e3830970?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -318,7 +409,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:47:59 GMT
+      - Wed, 28 Dec 2022 04:17:45 GMT
       pragma:
       - no-cache
       server:
@@ -350,26 +441,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:16:45.6702816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"9888fe83-f236-476e-adb0-4873756c34c5","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2557'
+      - '2415'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:47:59 GMT
+      - Wed, 28 Dec 2022 04:17:45 GMT
       pragma:
       - no-cache
       server:
@@ -401,26 +492,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:16:45.6702816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"9888fe83-f236-476e-adb0-4873756c34c5","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2557'
+      - '2415'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:47:59 GMT
+      - Wed, 28 Dec 2022 04:17:45 GMT
       pragma:
       - no-cache
       server:
@@ -452,26 +543,26 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:47:21.9492161Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:16:45.6702816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"9888fe83-f236-476e-adb0-4873756c34c5","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:47:21.9492161Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:16:45.6702816Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2557'
+      - '2415'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:47:59 GMT
+      - Wed, 28 Dec 2022 04:17:46 GMT
       pragma:
       - no-cache
       server:
@@ -503,22 +594,22 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5?api-version=2022-08-15
   response:
     body:
-      string: '{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","oldestRestorableTime":"2022-12-28T01:47:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z"}]}}'
+      string: '{"name":"9888fe83-f236-476e-adb0-4873756c34c5","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T04:16:46Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b228bfb1-493a-48ce-8d2c-97c85172dadd","creationTime":"2022-12-28T04:16:48Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '611'
+      - '565'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:48:00 GMT
+      - Wed, 28 Dec 2022 04:17:46 GMT
       pragma:
       - no-cache
       server:
@@ -562,7 +653,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/81161c57-a9ef-411e-b684-1d17c2cf0e51?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -570,9 +661,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:48:01 GMT
+      - Wed, 28 Dec 2022 04:17:48 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/81161c57-a9ef-411e-b684-1d17c2cf0e51?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -604,7 +695,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/aa0c4c07-fc19-4098-8e6b-462f7992d971?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/81161c57-a9ef-411e-b684-1d17c2cf0e51?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -616,7 +707,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:48:32 GMT
+      - Wed, 28 Dec 2022 04:18:18 GMT
       pragma:
       - no-cache
       server:
@@ -653,7 +744,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"4xUfAA==","_self":"dbs/4xUfAA==/","_etag":"\"0000a600-0000-0700-0000-63aba0570000\"","_colls":"colls/","_users":"users/","_ts":1672192087}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"yotmAA==","_self":"dbs/yotmAA==/","_etag":"\"00005502-0000-0700-0000-63abc3720000\"","_colls":"colls/","_users":"users/","_ts":1672201074}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -662,7 +753,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:48:32 GMT
+      - Wed, 28 Dec 2022 04:18:18 GMT
       pragma:
       - no-cache
       server:
@@ -709,7 +800,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/49be9dfd-0e10-45cf-86a2-6f45479c3209?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -717,9 +808,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:48:34 GMT
+      - Wed, 28 Dec 2022 04:18:20 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/49be9dfd-0e10-45cf-86a2-6f45479c3209?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -731,7 +822,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 202
       message: Accepted
@@ -751,7 +842,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/1adedff8-c74a-42eb-a87d-f02405051274?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/49be9dfd-0e10-45cf-86a2-6f45479c3209?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -763,7 +854,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:49:04 GMT
+      - Wed, 28 Dec 2022 04:18:50 GMT
       pragma:
       - no-cache
       server:
@@ -800,7 +891,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"4xUfAMlJtew=","_ts":1672192119,"_self":"dbs/4xUfAA==/colls/4xUfAMlJtew=/","_etag":"\"0000a900-0000-0700-0000-63aba0770000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"yotmAMy9FQ0=","_ts":1672201107,"_self":"dbs/yotmAA==/colls/yotmAMy9FQ0=/","_etag":"\"00005802-0000-0700-0000-63abc3930000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -809,7 +900,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:49:05 GMT
+      - Wed, 28 Dec 2022 04:18:50 GMT
       pragma:
       - no-cache
       server:
@@ -851,7 +942,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -859,9 +950,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:54:06 GMT
+      - Wed, 28 Dec 2022 04:23:53 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationResults/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -893,7 +984,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -905,7 +996,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:54:37 GMT
+      - Wed, 28 Dec 2022 04:24:23 GMT
       pragma:
       - no-cache
       server:
@@ -939,7 +1030,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -951,7 +1042,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:55:07 GMT
+      - Wed, 28 Dec 2022 04:24:53 GMT
       pragma:
       - no-cache
       server:
@@ -985,7 +1076,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -997,7 +1088,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:55:37 GMT
+      - Wed, 28 Dec 2022 04:25:23 GMT
       pragma:
       - no-cache
       server:
@@ -1031,7 +1122,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1043,7 +1134,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:56:07 GMT
+      - Wed, 28 Dec 2022 04:25:54 GMT
       pragma:
       - no-cache
       server:
@@ -1077,7 +1168,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1089,7 +1180,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:56:37 GMT
+      - Wed, 28 Dec 2022 04:26:24 GMT
       pragma:
       - no-cache
       server:
@@ -1123,7 +1214,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1135,7 +1226,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:57:07 GMT
+      - Wed, 28 Dec 2022 04:26:53 GMT
       pragma:
       - no-cache
       server:
@@ -1169,7 +1260,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1181,7 +1272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:57:37 GMT
+      - Wed, 28 Dec 2022 04:27:24 GMT
       pragma:
       - no-cache
       server:
@@ -1215,7 +1306,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1227,7 +1318,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:58:07 GMT
+      - Wed, 28 Dec 2022 04:27:54 GMT
       pragma:
       - no-cache
       server:
@@ -1261,7 +1352,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1273,7 +1364,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:58:37 GMT
+      - Wed, 28 Dec 2022 04:28:24 GMT
       pragma:
       - no-cache
       server:
@@ -1307,7 +1398,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1319,7 +1410,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:59:08 GMT
+      - Wed, 28 Dec 2022 04:28:54 GMT
       pragma:
       - no-cache
       server:
@@ -1353,7 +1444,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1365,7 +1456,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:59:38 GMT
+      - Wed, 28 Dec 2022 04:29:25 GMT
       pragma:
       - no-cache
       server:
@@ -1399,7 +1490,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1411,7 +1502,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:00:07 GMT
+      - Wed, 28 Dec 2022 04:29:54 GMT
       pragma:
       - no-cache
       server:
@@ -1445,7 +1536,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1457,7 +1548,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:00:37 GMT
+      - Wed, 28 Dec 2022 04:30:24 GMT
       pragma:
       - no-cache
       server:
@@ -1491,7 +1582,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1503,7 +1594,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:01:08 GMT
+      - Wed, 28 Dec 2022 04:30:55 GMT
       pragma:
       - no-cache
       server:
@@ -1537,7 +1628,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1549,7 +1640,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:01:38 GMT
+      - Wed, 28 Dec 2022 04:31:25 GMT
       pragma:
       - no-cache
       server:
@@ -1583,7 +1674,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1595,7 +1686,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:02:08 GMT
+      - Wed, 28 Dec 2022 04:31:55 GMT
       pragma:
       - no-cache
       server:
@@ -1629,7 +1720,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1641,7 +1732,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:02:38 GMT
+      - Wed, 28 Dec 2022 04:32:24 GMT
       pragma:
       - no-cache
       server:
@@ -1675,7 +1766,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1687,7 +1778,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:03:08 GMT
+      - Wed, 28 Dec 2022 04:32:54 GMT
       pragma:
       - no-cache
       server:
@@ -1721,7 +1812,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1733,7 +1824,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:03:38 GMT
+      - Wed, 28 Dec 2022 04:33:25 GMT
       pragma:
       - no-cache
       server:
@@ -1767,7 +1858,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1779,7 +1870,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:04:09 GMT
+      - Wed, 28 Dec 2022 04:33:55 GMT
       pragma:
       - no-cache
       server:
@@ -1813,7 +1904,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/e19620a4-f82e-4b0c-924d-829d7e3d25eb?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/824f5da2-471f-4bef-be8f-3a02f8bfeec9?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1825,7 +1916,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:04:39 GMT
+      - Wed, 28 Dec 2022 04:34:25 GMT
       pragma:
       - no-cache
       server:
@@ -1857,62 +1948,62 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
   response:
     body:
       string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Canada
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","restorableLocations":[{"locationName":"Canada
         Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
@@ -1920,7 +2011,7 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"North
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","restorableLocations":[{"locationName":"North
         Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
@@ -1930,195 +2021,203 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:08Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:07Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:26Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:57Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:30:09Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:36:50Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:35:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:42:05Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:38:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:16:17Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:17:28Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:19:35Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:28:04Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:52:27Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
-        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-08-10T23:38:56Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
-        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","restorableLocations":[{"locationName":"West
         Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
-        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-04-07T00:48:08Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
-        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-07-28T01:55:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
-        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-11T05:19:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
-        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-23T23:06:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"clieolj556mixfn","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","properties":{"accountName":"clilpyp4mjvl6bn","apiType":"Sql","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cf57e498-b2e0-422e-9a07-7fccc56cdcc8","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z"}]}},{"name":"9304016f-8c21-4e84-b445-010366a777a9","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9304016f-8c21-4e84-b445-010366a777a9","properties":{"accountName":"cli2evrynjrraps","apiType":"Sql","creationTime":"2022-12-28T03:58:52Z","deletionTime":"2022-12-28T03:59:39Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e951cdc2-d12f-4351-a921-9a3ee757ddff","creationTime":"2022-12-28T03:58:52Z","deletionTime":"2022-12-28T03:59:39Z"}]}},{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cliigwpb4rcabs5","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","deletionTime":"2022-12-28T03:59:40Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z","deletionTime":"2022-12-28T03:59:40Z"}]}},{"name":"9888fe83-f236-476e-adb0-4873756c34c5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T04:16:46Z","deletionTime":"2022-12-28T04:24:08Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b228bfb1-493a-48ce-8d2c-97c85172dadd","creationTime":"2022-12-28T04:16:48Z","deletionTime":"2022-12-28T04:24:08Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
-        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T02:04:40Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
         Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
-        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T02:04:41Z","restorableLocations":[{"locationName":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","restorableLocations":[{"locationName":"Qatar
         Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '68522'
+      - '66468'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 02:04:41 GMT
+      - Wed, 28 Dec 2022 04:34:27 GMT
       expires:
       - '-1'
       pragma:
@@ -2174,8 +2273,8 @@ interactions:
     body: '{"location": "West US", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard", "apiProperties": {}, "createMode": "Restore", "restoreParameters":
-      {"restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca",
-      "restoreTimestampInUtc": "2022-12-28T01:51:22.000Z", "restoreMode": "PointInTime"}}}'
+      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5",
+      "restoreTimestampInUtc": "2022-12-28T04:20:46.000Z"}}}'
     headers:
       Accept:
       - application/json
@@ -2192,31 +2291,31 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:04:44.4397825Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:34:31.2604764Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"e6c8ece0-ae42-4938-81d7-696f4ea98eb1","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:04:44.4397825Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","restoreTimestampInUtc":"2022-12-28T04:20:46Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:34:31.2604764Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:34:31.2604764Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:34:31.2604764Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:34:31.2604764Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2838'
+      - '2696'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:04:47 GMT
+      - Wed, 28 Dec 2022 04:34:33 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -2232,7 +2331,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: Ok
@@ -2250,9 +2349,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2264,7 +2363,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:05:17 GMT
+      - Wed, 28 Dec 2022 04:35:04 GMT
       pragma:
       - no-cache
       server:
@@ -2296,9 +2395,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2310,7 +2409,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:05:47 GMT
+      - Wed, 28 Dec 2022 04:35:34 GMT
       pragma:
       - no-cache
       server:
@@ -2342,9 +2441,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2356,7 +2455,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:06:17 GMT
+      - Wed, 28 Dec 2022 04:36:04 GMT
       pragma:
       - no-cache
       server:
@@ -2388,9 +2487,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2402,7 +2501,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:06:47 GMT
+      - Wed, 28 Dec 2022 04:36:34 GMT
       pragma:
       - no-cache
       server:
@@ -2434,9 +2533,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2448,7 +2547,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:07:17 GMT
+      - Wed, 28 Dec 2022 04:37:04 GMT
       pragma:
       - no-cache
       server:
@@ -2480,9 +2579,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2494,7 +2593,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:07:48 GMT
+      - Wed, 28 Dec 2022 04:37:34 GMT
       pragma:
       - no-cache
       server:
@@ -2526,9 +2625,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2540,7 +2639,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:08:18 GMT
+      - Wed, 28 Dec 2022 04:38:04 GMT
       pragma:
       - no-cache
       server:
@@ -2572,9 +2671,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2586,7 +2685,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:08:48 GMT
+      - Wed, 28 Dec 2022 04:38:34 GMT
       pragma:
       - no-cache
       server:
@@ -2618,9 +2717,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2632,7 +2731,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:09:18 GMT
+      - Wed, 28 Dec 2022 04:39:04 GMT
       pragma:
       - no-cache
       server:
@@ -2664,9 +2763,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2678,7 +2777,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:09:48 GMT
+      - Wed, 28 Dec 2022 04:39:34 GMT
       pragma:
       - no-cache
       server:
@@ -2710,9 +2809,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2724,7 +2823,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:10:18 GMT
+      - Wed, 28 Dec 2022 04:40:04 GMT
       pragma:
       - no-cache
       server:
@@ -2756,9 +2855,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2770,7 +2869,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:10:49 GMT
+      - Wed, 28 Dec 2022 04:40:34 GMT
       pragma:
       - no-cache
       server:
@@ -2802,9 +2901,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2816,7 +2915,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:11:19 GMT
+      - Wed, 28 Dec 2022 04:41:04 GMT
       pragma:
       - no-cache
       server:
@@ -2848,9 +2947,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2862,7 +2961,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:11:48 GMT
+      - Wed, 28 Dec 2022 04:41:34 GMT
       pragma:
       - no-cache
       server:
@@ -2894,9 +2993,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2908,7 +3007,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:12:18 GMT
+      - Wed, 28 Dec 2022 04:42:04 GMT
       pragma:
       - no-cache
       server:
@@ -2940,9 +3039,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2954,7 +3053,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:12:48 GMT
+      - Wed, 28 Dec 2022 04:42:35 GMT
       pragma:
       - no-cache
       server:
@@ -2986,9 +3085,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3000,7 +3099,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:13:18 GMT
+      - Wed, 28 Dec 2022 04:43:05 GMT
       pragma:
       - no-cache
       server:
@@ -3032,9 +3131,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3046,7 +3145,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:13:48 GMT
+      - Wed, 28 Dec 2022 04:43:35 GMT
       pragma:
       - no-cache
       server:
@@ -3078,9 +3177,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3092,7 +3191,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:14:19 GMT
+      - Wed, 28 Dec 2022 04:44:05 GMT
       pragma:
       - no-cache
       server:
@@ -3124,9 +3223,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3138,7 +3237,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:14:48 GMT
+      - Wed, 28 Dec 2022 04:44:35 GMT
       pragma:
       - no-cache
       server:
@@ -3170,9 +3269,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3184,7 +3283,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:15:19 GMT
+      - Wed, 28 Dec 2022 04:45:05 GMT
       pragma:
       - no-cache
       server:
@@ -3216,9 +3315,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3230,7 +3329,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:15:49 GMT
+      - Wed, 28 Dec 2022 04:45:35 GMT
       pragma:
       - no-cache
       server:
@@ -3262,9 +3361,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3276,7 +3375,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:16:19 GMT
+      - Wed, 28 Dec 2022 04:46:06 GMT
       pragma:
       - no-cache
       server:
@@ -3308,9 +3407,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3322,7 +3421,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:16:49 GMT
+      - Wed, 28 Dec 2022 04:46:36 GMT
       pragma:
       - no-cache
       server:
@@ -3354,147 +3453,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Wed, 28 Dec 2022 02:17:19 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.14.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --account-name -g --restore-timestamp --location --target-database-account-name
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Wed, 28 Dec 2022 02:17:49 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.14.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --account-name -g --restore-timestamp --location --target-database-account-name
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Wed, 28 Dec 2022 02:18:19 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.14.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --account-name -g --restore-timestamp --location --target-database-account-name
-      User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/919eb713-4ce2-4178-b3c7-df4499dafc0c?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d23c27ab-d15c-4a02-b813-899c03298675?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -3506,7 +3467,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:18:49 GMT
+      - Wed, 28 Dec 2022 04:47:06 GMT
       pragma:
       - no-cache
       server:
@@ -3538,27 +3499,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:46:40.0055549Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"e6c8ece0-ae42-4938-81d7-696f4ea98eb1","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","restoreTimestampInUtc":"2022-12-28T04:20:46Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2906'
+      - '2764'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:18:49 GMT
+      - Wed, 28 Dec 2022 04:47:06 GMT
       pragma:
       - no-cache
       server:
@@ -3590,27 +3551,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:46:40.0055549Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"e6c8ece0-ae42-4938-81d7-696f4ea98eb1","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","restoreTimestampInUtc":"2022-12-28T04:20:46Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2906'
+      - '2764'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:18:50 GMT
+      - Wed, 28 Dec 2022 04:47:06 GMT
       pragma:
       - no-cache
       server:
@@ -3642,27 +3603,27 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_deleted_account_restore000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T02:18:28.4378868Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T04:46:40.0055549Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"e6c8ece0-ae42-4938-81d7-696f4ea98eb1","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","restoreTimestampInUtc":"2022-12-28T01:51:22Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T02:18:28.4378868Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9888fe83-f236-476e-adb0-4873756c34c5","restoreTimestampInUtc":"2022-12-28T04:20:46Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T04:46:40.0055549Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2906'
+      - '2764'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 02:18:51 GMT
+      - Wed, 28 Dec 2022 04:47:06 GMT
       pragma:
       - no-cache
       server:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_restore_command.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_restore_command.yaml
@@ -18,7 +18,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_command000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T01:18:56Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T03:36:37Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -27,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:19:00 GMT
+      - Wed, 28 Dec 2022 03:36:40 GMT
       expires:
       - '-1'
       pragma:
@@ -45,8 +45,7 @@ interactions:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
       "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default",
-      "backupPolicy": {"type": "Continuous", "continuousModeProperties": {"tier":
-      "Continuous30Days"}}}}'
+      "backupPolicy": {"type": "Continuous"}}}'
     headers:
       Accept:
       - application/json
@@ -57,36 +56,36 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '342'
+      - '284'
       Content-Type:
       - application/json
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:19:05.5518481Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:36:45.1580372Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0137418a-c927-4944-b541-86dd8cd56cc0","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:36:45.1580372Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:36:45.1580372Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:36:45.1580372Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:36:45.1580372Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2250'
+      - '2108'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:19:08 GMT
+      - Wed, 28 Dec 2022 03:36:47 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -120,9 +119,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -134,7 +133,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:19:38 GMT
+      - Wed, 28 Dec 2022 03:37:17 GMT
       pragma:
       - no-cache
       server:
@@ -166,9 +165,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -180,7 +179,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:20:08 GMT
+      - Wed, 28 Dec 2022 03:37:47 GMT
       pragma:
       - no-cache
       server:
@@ -212,9 +211,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -226,7 +225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:20:38 GMT
+      - Wed, 28 Dec 2022 03:38:17 GMT
       pragma:
       - no-cache
       server:
@@ -258,9 +257,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -272,7 +271,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:08 GMT
+      - Wed, 28 Dec 2022 03:38:48 GMT
       pragma:
       - no-cache
       server:
@@ -304,9 +303,55 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
+  response:
+    body:
+      string: '{"status":"Dequeued"}'
+    headers:
+      cache-control:
+      - no-store, no-cache
+      content-length:
+      - '21'
+      content-type:
+      - application/json
+      date:
+      - Wed, 28 Dec 2022 03:39:18 GMT
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-gatewayversion:
+      - version=2.14.0
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - cosmosdb create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --backup-policy-type --locations
+      User-Agent:
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/cdd14a10-0841-47bc-adc3-4743b20489ea?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -318,7 +363,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:38 GMT
+      - Wed, 28 Dec 2022 03:39:48 GMT
       pragma:
       - no-cache
       server:
@@ -350,26 +395,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:39:10.1316745Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0137418a-c927-4944-b541-86dd8cd56cc0","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2549'
+      - '2407'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:38 GMT
+      - Wed, 28 Dec 2022 03:39:48 GMT
       pragma:
       - no-cache
       server:
@@ -401,26 +446,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:39:10.1316745Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0137418a-c927-4944-b541-86dd8cd56cc0","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2549'
+      - '2407'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:38 GMT
+      - Wed, 28 Dec 2022 03:39:48 GMT
       pragma:
       - no-cache
       server:
@@ -452,26 +497,26 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:39:10.1316745Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0137418a-c927-4944-b541-86dd8cd56cc0","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:39:10.1316745Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2549'
+      - '2407'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:39 GMT
+      - Wed, 28 Dec 2022 03:39:49 GMT
       pragma:
       - no-cache
       server:
@@ -503,22 +548,22 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0?api-version=2022-08-15
   response:
     body:
-      string: '{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}}'
+      string: '{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '611'
+      - '565'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:41 GMT
+      - Wed, 28 Dec 2022 03:39:50 GMT
       pragma:
       - no-cache
       server:
@@ -550,62 +595,62 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
   response:
     body:
       string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Canada
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","restorableLocations":[{"locationName":"Canada
         Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
@@ -613,7 +658,7 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","restorableLocations":[{"locationName":"North
         Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
@@ -623,191 +668,199 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:08Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:07Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:26Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:57Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:30:09Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:36:50Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:35:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:42:05Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:38:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:16:17Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:17:28Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:19:35Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:28:04Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:52:27Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
-        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-08-10T23:38:56Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
-        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:43Z","restorableLocations":[{"locationName":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","restorableLocations":[{"locationName":"West
         Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
-        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-04-07T00:48:08Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
-        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-07-28T01:55:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
-        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-11T05:19:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
-        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-23T23:06:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"clieolj556mixfn","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","properties":{"accountName":"clilpyp4mjvl6bn","apiType":"Sql","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cf57e498-b2e0-422e-9a07-7fccc56cdcc8","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
-        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
         Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
-        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:43Z","restorableLocations":[{"locationName":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","restorableLocations":[{"locationName":"Qatar
         Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '67058'
+      - '65096'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:21:43 GMT
+      - Wed, 28 Dec 2022 03:39:52 GMT
       expires:
       - '-1'
       pragma:
@@ -873,62 +926,62 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
   response:
     body:
       string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Canada
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","restorableLocations":[{"locationName":"Canada
         Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
@@ -936,7 +989,7 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","restorableLocations":[{"locationName":"North
         Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
@@ -946,191 +999,199 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:08Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:07Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:26Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:57Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:30:09Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:36:50Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:35:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:42:05Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:38:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:16:17Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:17:28Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:19:35Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:28:04Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:52:27Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
-        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-08-10T23:38:56Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
-        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","restorableLocations":[{"locationName":"West
         Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
-        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-04-07T00:48:08Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
-        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-07-28T01:55:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
-        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-11T05:19:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
-        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-23T23:06:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"clieolj556mixfn","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","properties":{"accountName":"clilpyp4mjvl6bn","apiType":"Sql","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cf57e498-b2e0-422e-9a07-7fccc56cdcc8","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
-        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
         Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
-        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","restorableLocations":[{"locationName":"Qatar
         Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '67058'
+      - '65096'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:21:45 GMT
+      - Wed, 28 Dec 2022 03:39:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1196,62 +1257,62 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
   response:
     body:
       string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Canada
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","restorableLocations":[{"locationName":"Canada
         Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
@@ -1259,7 +1320,7 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","restorableLocations":[{"locationName":"North
         Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
@@ -1269,191 +1330,199 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:08Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:07Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:26Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:57Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:30:09Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:36:50Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:35:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:42:05Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:38:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:16:17Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:17:28Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:19:35Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:28:04Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:52:27Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
-        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-08-10T23:38:56Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
-        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","restorableLocations":[{"locationName":"West
         Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
-        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-04-07T00:48:08Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
-        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-07-28T01:55:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
-        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-11T05:19:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
-        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-23T23:06:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"clieolj556mixfn","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","properties":{"accountName":"clilpyp4mjvl6bn","apiType":"Sql","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cf57e498-b2e0-422e-9a07-7fccc56cdcc8","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
-        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
         Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
-        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:48Z","restorableLocations":[{"locationName":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","restorableLocations":[{"locationName":"Qatar
         Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '67058'
+      - '65096'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:21:48 GMT
+      - Wed, 28 Dec 2022 03:39:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1531,7 +1600,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5c6322f4-5912-4aa7-b47e-c5f69f1a672e?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1539,9 +1608,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:21:50 GMT
+      - Wed, 28 Dec 2022 03:39:57 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/5c6322f4-5912-4aa7-b47e-c5f69f1a672e?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -1573,7 +1642,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5c6322f4-5912-4aa7-b47e-c5f69f1a672e?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1585,7 +1654,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:22:20 GMT
+      - Wed, 28 Dec 2022 03:40:27 GMT
       pragma:
       - no-cache
       server:
@@ -1622,7 +1691,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"ZM9FAA==","_self":"dbs/ZM9FAA==/","_etag":"\"00009002-0000-0700-0000-63ab9a330000\"","_colls":"colls/","_users":"users/","_ts":1672190515}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"UtNUAA==","_self":"dbs/UtNUAA==/","_etag":"\"0000cb00-0000-0700-0000-63abba920000\"","_colls":"colls/","_users":"users/","_ts":1672198802}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1631,7 +1700,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:22:20 GMT
+      - Wed, 28 Dec 2022 03:40:27 GMT
       pragma:
       - no-cache
       server:
@@ -1678,7 +1747,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eded5e7d-5c94-4854-9923-24e686aae1ae?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1686,9 +1755,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:22:23 GMT
+      - Wed, 28 Dec 2022 03:40:28 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/eded5e7d-5c94-4854-9923-24e686aae1ae?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -1720,7 +1789,7 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/eded5e7d-5c94-4854-9923-24e686aae1ae?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1732,7 +1801,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:22:54 GMT
+      - Wed, 28 Dec 2022 03:40:59 GMT
       pragma:
       - no-cache
       server:
@@ -1769,7 +1838,7 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"ZM9FAJU7Rmw=","_ts":1672190548,"_self":"dbs/ZM9FAA==/colls/ZM9FAJU7Rmw=/","_etag":"\"00009302-0000-0700-0000-63ab9a540000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"UtNUAIOrGqA=","_ts":1672198834,"_self":"dbs/UtNUAA==/colls/UtNUAIOrGqA=/","_etag":"\"0000ce00-0000-0700-0000-63abbab20000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1778,7 +1847,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:22:54 GMT
+      - Wed, 28 Dec 2022 03:40:59 GMT
       pragma:
       - no-cache
       server:
@@ -1810,62 +1879,62 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
   response:
     body:
       string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","restorableLocations":[{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
-        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","restorableLocations":[{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Canada
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","restorableLocations":[{"locationName":"Canada
         Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
@@ -1873,7 +1942,7 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","restorableLocations":[{"locationName":"North
         Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
         US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
@@ -1883,191 +1952,199 @@ interactions:
         US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","restorableLocations":[{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:08Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:07Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-03T22:53:26Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:29:57Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:30:09Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:36:50Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:35:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:42:05Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-04T00:38:58Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:16:17Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:17:28Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T06:19:35Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:28:04Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
-        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-05-17T17:52:27Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
         US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
-        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-08-10T23:38:56Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
-        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","restorableLocations":[{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
-        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","restorableLocations":[{"locationName":"West
         Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
         US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
-        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-04-07T00:48:08Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
-        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-07-28T01:55:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
-        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-11T05:19:28Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
-        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        Sql","creationTime":"2022-08-23T23:06:53Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","restorableLocations":[{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
         US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
         US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
         Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0137418a-c927-4944-b541-86dd8cd56cc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T03:39:11Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"69d14b53-aa6d-4124-9046-04ab79e0a25c","creationTime":"2022-12-28T03:39:12Z"}]}},{"name":"85b52c24-6e96-40f4-984b-171fb8d06213","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/85b52c24-6e96-40f4-984b-171fb8d06213","properties":{"accountName":"clikyl7xz7omv4f","apiType":"Sql","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"721aab22-206e-413b-9dc7-53c8e2fecb16","creationTime":"2022-12-28T01:40:42Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"clil6trv2k2ns2v","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","deletionTime":"2022-12-28T01:41:33Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z","deletionTime":"2022-12-28T01:41:33Z"}]}},{"name":"3b1253b3-1beb-4c44-930b-eefe7bc0dfca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3b1253b3-1beb-4c44-930b-eefe7bc0dfca","properties":{"accountName":"clieolj556mixfn","apiType":"Sql","creationTime":"2022-12-28T01:47:22Z","deletionTime":"2022-12-28T01:54:21Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d686aea3-5594-45db-9c17-99f2235bd5ea","creationTime":"2022-12-28T01:47:23Z","deletionTime":"2022-12-28T01:54:21Z"}]}},{"name":"01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01ec1d83-3aa2-4ee9-ad5c-ed6f7358ee74","properties":{"accountName":"clilpyp4mjvl6bn","apiType":"Sql","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cf57e498-b2e0-422e-9a07-7fccc56cdcc8","creationTime":"2022-12-28T02:18:29Z","deletionTime":"2022-12-28T02:19:20Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
         US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
-        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","restorableLocations":[{"locationName":"East
         US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
         Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
         US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
-        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:27:57Z","restorableLocations":[{"locationName":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","restorableLocations":[{"locationName":"Qatar
         Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '67058'
+      - '65096'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 28 Dec 2022 01:27:56 GMT
+      - Wed, 28 Dec 2022 03:46:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2135,10 +2212,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0/restorableSqlResources?api-version=2022-08-15&restoreLocation=westus&restoreTimestampInUtc=2022-12-28%2001%3A25%3A05%2B00%3A00
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0/restorableSqlResources?api-version=2022-08-15&restoreLocation=westus&restoreTimestampInUtc=2022-12-28%2003%3A43%3A11%2B00%3A00
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0/restorableSqlResources/cli000005","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlResources","name":"cli000005","databaseName":"cli000005","collectionNames":["cli000002"]}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0/restorableSqlResources/cli000005","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlResources","name":"cli000005","databaseName":"cli000005","collectionNames":["cli000002"]}]}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -2147,7 +2224,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:27:58 GMT
+      - Wed, 28 Dec 2022 03:46:03 GMT
       pragma:
       - no-cache
       server:
@@ -2169,8 +2246,8 @@ interactions:
     body: '{"location": "West US", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard", "apiProperties": {}, "createMode": "Restore", "restoreParameters":
-      {"restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0",
-      "restoreTimestampInUtc": "2022-12-28T01:25:05.000Z", "restoreMode": "PointInTime"}}}'
+      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0",
+      "restoreTimestampInUtc": "2022-12-28T03:43:11.000Z"}}}'
     headers:
       Accept:
       - application/json
@@ -2187,31 +2264,31 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:28:02.0398354Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:46:07.0282635Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"9304016f-8c21-4e84-b445-010366a777a9","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","restoreTimestampInUtc":"2022-12-28T03:43:11Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:46:07.0282635Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:46:07.0282635Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:46:07.0282635Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:46:07.0282635Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2830'
+      - '2688'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:28:04 GMT
+      - Wed, 28 Dec 2022 03:46:09 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -2245,9 +2322,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2259,7 +2336,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:28:34 GMT
+      - Wed, 28 Dec 2022 03:46:39 GMT
       pragma:
       - no-cache
       server:
@@ -2291,9 +2368,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2305,7 +2382,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:29:05 GMT
+      - Wed, 28 Dec 2022 03:47:10 GMT
       pragma:
       - no-cache
       server:
@@ -2337,9 +2414,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2351,7 +2428,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:29:35 GMT
+      - Wed, 28 Dec 2022 03:47:40 GMT
       pragma:
       - no-cache
       server:
@@ -2383,9 +2460,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2397,7 +2474,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:30:05 GMT
+      - Wed, 28 Dec 2022 03:48:10 GMT
       pragma:
       - no-cache
       server:
@@ -2429,9 +2506,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2443,7 +2520,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:30:34 GMT
+      - Wed, 28 Dec 2022 03:48:40 GMT
       pragma:
       - no-cache
       server:
@@ -2475,9 +2552,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2489,7 +2566,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:31:05 GMT
+      - Wed, 28 Dec 2022 03:49:10 GMT
       pragma:
       - no-cache
       server:
@@ -2521,9 +2598,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2535,7 +2612,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:31:35 GMT
+      - Wed, 28 Dec 2022 03:49:40 GMT
       pragma:
       - no-cache
       server:
@@ -2567,9 +2644,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2581,7 +2658,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:32:05 GMT
+      - Wed, 28 Dec 2022 03:50:10 GMT
       pragma:
       - no-cache
       server:
@@ -2613,9 +2690,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2627,7 +2704,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:32:35 GMT
+      - Wed, 28 Dec 2022 03:50:41 GMT
       pragma:
       - no-cache
       server:
@@ -2659,9 +2736,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2673,7 +2750,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:33:05 GMT
+      - Wed, 28 Dec 2022 03:51:11 GMT
       pragma:
       - no-cache
       server:
@@ -2705,9 +2782,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2719,7 +2796,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:33:36 GMT
+      - Wed, 28 Dec 2022 03:51:41 GMT
       pragma:
       - no-cache
       server:
@@ -2751,9 +2828,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2765,7 +2842,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:34:06 GMT
+      - Wed, 28 Dec 2022 03:52:11 GMT
       pragma:
       - no-cache
       server:
@@ -2797,9 +2874,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2811,7 +2888,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:34:36 GMT
+      - Wed, 28 Dec 2022 03:52:41 GMT
       pragma:
       - no-cache
       server:
@@ -2843,9 +2920,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2857,7 +2934,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:35:07 GMT
+      - Wed, 28 Dec 2022 03:53:11 GMT
       pragma:
       - no-cache
       server:
@@ -2889,9 +2966,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2903,7 +2980,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:35:37 GMT
+      - Wed, 28 Dec 2022 03:53:41 GMT
       pragma:
       - no-cache
       server:
@@ -2935,9 +3012,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2949,7 +3026,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:36:07 GMT
+      - Wed, 28 Dec 2022 03:54:11 GMT
       pragma:
       - no-cache
       server:
@@ -2981,9 +3058,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2995,7 +3072,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:36:36 GMT
+      - Wed, 28 Dec 2022 03:54:41 GMT
       pragma:
       - no-cache
       server:
@@ -3027,9 +3104,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3041,7 +3118,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:37:06 GMT
+      - Wed, 28 Dec 2022 03:55:11 GMT
       pragma:
       - no-cache
       server:
@@ -3073,9 +3150,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3087,7 +3164,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:37:36 GMT
+      - Wed, 28 Dec 2022 03:55:41 GMT
       pragma:
       - no-cache
       server:
@@ -3119,9 +3196,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3133,7 +3210,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:38:07 GMT
+      - Wed, 28 Dec 2022 03:56:11 GMT
       pragma:
       - no-cache
       server:
@@ -3165,9 +3242,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3179,7 +3256,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:38:37 GMT
+      - Wed, 28 Dec 2022 03:56:42 GMT
       pragma:
       - no-cache
       server:
@@ -3211,9 +3288,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3225,7 +3302,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:39:07 GMT
+      - Wed, 28 Dec 2022 03:57:12 GMT
       pragma:
       - no-cache
       server:
@@ -3257,9 +3334,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3271,7 +3348,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:39:37 GMT
+      - Wed, 28 Dec 2022 03:57:42 GMT
       pragma:
       - no-cache
       server:
@@ -3303,9 +3380,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3317,7 +3394,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:40:08 GMT
+      - Wed, 28 Dec 2022 03:58:12 GMT
       pragma:
       - no-cache
       server:
@@ -3349,9 +3426,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -3363,7 +3440,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:40:38 GMT
+      - Wed, 28 Dec 2022 03:58:42 GMT
       pragma:
       - no-cache
       server:
@@ -3395,9 +3472,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/80dcd2c7-07be-4f76-b24e-3370bc8d34ee?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -3409,7 +3486,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:41:08 GMT
+      - Wed, 28 Dec 2022 03:59:12 GMT
       pragma:
       - no-cache
       server:
@@ -3441,27 +3518,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:58:51.9868249Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"9304016f-8c21-4e84-b445-010366a777a9","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","restoreTimestampInUtc":"2022-12-28T03:43:11Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2898'
+      - '2756'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:41:08 GMT
+      - Wed, 28 Dec 2022 03:59:12 GMT
       pragma:
       - no-cache
       server:
@@ -3493,27 +3570,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:58:51.9868249Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"9304016f-8c21-4e84-b445-010366a777a9","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","restoreTimestampInUtc":"2022-12-28T03:43:11Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2898'
+      - '2756'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:41:08 GMT
+      - Wed, 28 Dec 2022 03:59:13 GMT
       pragma:
       - no-cache
       server:
@@ -3545,27 +3622,27 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T03:58:51.9868249Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"9304016f-8c21-4e84-b445-010366a777a9","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
-        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0137418a-c927-4944-b541-86dd8cd56cc0","restoreTimestampInUtc":"2022-12-28T03:43:11Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T03:58:51.9868249Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2898'
+      - '2756'
       content-type:
       - application/json
       date:
-      - Wed, 28 Dec 2022 01:41:09 GMT
+      - Wed, 28 Dec 2022 03:59:13 GMT
       pragma:
       - no-cache
       server:

--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_restore_command.yaml
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/tests/latest/recordings/test_cosmosdb_restore_command.yaml
@@ -13,13 +13,12 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/cli_test_cosmosdb_restore_command000001?api-version=2021-04-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-09-19T04:56:31Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001","name":"cli_test_cosmosdb_restore_command000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2022-12-28T01:18:56Z"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -28,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 04:56:32 GMT
+      - Wed, 28 Dec 2022 01:19:00 GMT
       expires:
       - '-1'
       pragma:
@@ -46,7 +45,8 @@ interactions:
     body: '{"location": "westus", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0, "isZoneRedundant": false}],
       "databaseAccountOfferType": "Standard", "apiProperties": {}, "createMode": "Default",
-      "backupPolicy": {"type": "Continuous"}}}'
+      "backupPolicy": {"type": "Continuous", "continuousModeProperties": {"tier":
+      "Continuous30Days"}}}}'
     headers:
       Accept:
       - application/json
@@ -57,37 +57,36 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '284'
+      - '342'
       Content-Type:
       - application/json
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:56:36.2173357Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:19:05.5518481Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:56:36.2173357Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:56:36.2173357Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:56:36.2173357Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:56:36.2173357Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:19:05.5518481Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2108'
+      - '2250'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:56:37 GMT
+      - Wed, 28 Dec 2022 01:19:08 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/operationResults/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
       pragma:
       - no-cache
       server:
@@ -121,10 +120,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -136,7 +134,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:57:08 GMT
+      - Wed, 28 Dec 2022 01:19:38 GMT
       pragma:
       - no-cache
       server:
@@ -168,10 +166,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -183,7 +180,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:57:38 GMT
+      - Wed, 28 Dec 2022 01:20:08 GMT
       pragma:
       - no-cache
       server:
@@ -215,10 +212,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -230,7 +226,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:58:08 GMT
+      - Wed, 28 Dec 2022 01:20:38 GMT
       pragma:
       - no-cache
       server:
@@ -262,10 +258,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -277,7 +272,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:58:39 GMT
+      - Wed, 28 Dec 2022 01:21:08 GMT
       pragma:
       - no-cache
       server:
@@ -309,10 +304,9 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/d4a42c11-3eb1-47e2-86a5-de5e4fa66821?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/22cfbd22-3401-4f03-b6cd-c4dcd905aa1a?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -324,7 +318,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:09 GMT
+      - Wed, 28 Dec 2022 01:21:38 GMT
       pragma:
       - no-cache
       server:
@@ -356,27 +350,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:58:31.4570816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2407'
+      - '2549'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:09 GMT
+      - Wed, 28 Dec 2022 01:21:38 GMT
       pragma:
       - no-cache
       server:
@@ -408,27 +401,26 @@ interactions:
       ParameterSetName:
       - -n -g --backup-policy-type --locations
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:58:31.4570816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2407'
+      - '2549'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:09 GMT
+      - Wed, 28 Dec 2022 01:21:38 GMT
       pragma:
       - no-cache
       server:
@@ -460,27 +452,26 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003","name":"cli000003","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T04:58:31.4570816Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","createMode":"Default","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:21:04.0762305Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000003.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{"schemaType":"WellDefined"},"instanceId":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","createMode":"Default","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000003-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000003-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"networkAclBypassResourceIds":[],"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T04:58:31.4570816Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:21:04.0762305Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2407'
+      - '2549'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:09 GMT
+      - Wed, 28 Dec 2022 01:21:39 GMT
       pragma:
       - no-cache
       server:
@@ -512,23 +503,22 @@ interactions:
       ParameterSetName:
       - --location --instance-id
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"name":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T04:58:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4871270e-f89d-4b60-8a38-ac9eb36825ea","creationTime":"2022-09-19T04:58:33Z"}]}}'
+      string: '{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '565'
+      - '611'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:09 GMT
+      - Wed, 28 Dec 2022 01:21:41 GMT
       pragma:
       - no-cache
       server:
@@ -560,113 +550,264 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"value":[{"name":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T04:58:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4871270e-f89d-4b60-8a38-ac9eb36825ea","creationTime":"2022-09-19T04:58:33Z"}]}},{"name":"d6e5008d-fdcb-4927-98ee-3c2753c89ee7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6e5008d-fdcb-4927-98ee-3c2753c89ee7","properties":{"accountName":"clilc67z5wdqqx2","apiType":"Sql","creationTime":"2022-08-25T06:08:26Z","deletionTime":"2022-08-25T06:15:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"37af2dc0-2aa6-46d3-8e41-cfed196796f9","creationTime":"2022-08-25T06:08:27Z","deletionTime":"2022-08-25T06:15:27Z"}]}},{"name":"90bd51e7-1fe7-4315-87f6-c2407cc951b0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90bd51e7-1fe7-4315-87f6-c2407cc951b0","properties":{"accountName":"cliw23t2chyagy6","apiType":"Sql","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d7cf6cbf-d6a1-4888-a620-41a07f491415","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z"}]}},{"name":"6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","properties":{"accountName":"cli7bonjdjz73wj","apiType":"MongoDB","creationTime":"2022-08-25T06:41:30Z","deletionTime":"2022-08-25T06:47:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"08709870-877a-42ea-a849-210c0fda4ee1","creationTime":"2022-08-25T06:41:31Z","deletionTime":"2022-08-25T06:47:32Z"}]}},{"name":"deff6534-a2b9-404d-b4ba-2e5e22b32bfb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/deff6534-a2b9-404d-b4ba-2e5e22b32bfb","properties":{"accountName":"cliuis4anv3ycph","apiType":"MongoDB","creationTime":"2022-08-25T07:18:31Z","deletionTime":"2022-08-25T07:26:15Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"dafa935e-6ee4-4d4a-bc1d-c8e609d42a60","creationTime":"2022-08-25T07:18:32Z","deletionTime":"2022-08-25T07:26:15Z"}]}},{"name":"d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","properties":{"accountName":"cliz5zwclforhva","apiType":"Sql","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5982b098-fba7-49cc-9996-ad4ccb1b3d33","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z"}]}},{"name":"0ccdf2af-7bda-4f61-b6df-d734c6773db6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0ccdf2af-7bda-4f61-b6df-d734c6773db6","properties":{"accountName":"cli7c6gulakolbu","apiType":"Sql","creationTime":"2022-08-25T07:35:24Z","deletionTime":"2022-08-25T07:57:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"794c2fc6-6ac1-41ba-990f-bd2c07eb7b9f","creationTime":"2022-08-25T07:35:25Z","deletionTime":"2022-08-25T07:57:18Z"}]}},{"name":"00df9a41-faa9-41a7-b061-6e3e3c923456","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/00df9a41-faa9-41a7-b061-6e3e3c923456","properties":{"accountName":"clib7httb4gycob","apiType":"Sql","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b56217c5-6fa0-4c6d-9809-80899be99f51","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","properties":{"accountName":"cliddcu3cjrh6we","apiType":"Sql","creationTime":"2022-08-25T07:57:57Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"938063bf-8716-409c-894f-60bb99781705","creationTime":"2022-08-25T07:57:58Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"68ac0330-103f-43ea-a1de-37c94072a36e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68ac0330-103f-43ea-a1de-37c94072a36e","properties":{"accountName":"clik7kgspjf6bgm","apiType":"Sql","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ff7a4f80-356f-4371-b143-ee999b63eb80","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z"}]}},{"name":"7bb0479d-7652-434b-af5b-675da5d24d9d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7bb0479d-7652-434b-af5b-675da5d24d9d","properties":{"accountName":"cligi5y5fvohgv453w5z25icozd6527bpu5ecv4k","apiType":"Sql","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bcac751b-de78-4668-9ef3-adca14decc29","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z"}]}},{"name":"212beaac-388e-4ff4-981e-f9aef3516b64","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/212beaac-388e-4ff4-981e-f9aef3516b64","properties":{"accountName":"cliren6oja2hpwe","apiType":"Sql","creationTime":"2022-08-25T17:36:41Z","deletionTime":"2022-08-25T17:43:38Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cec6d4eb-e6cc-4e65-bb67-26fde7eabc6e","creationTime":"2022-08-25T17:36:42Z","deletionTime":"2022-08-25T17:43:38Z"}]}},{"name":"045f21c9-c8cc-4ee5-ae4c-c95a481280ce","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045f21c9-c8cc-4ee5-ae4c-c95a481280ce","properties":{"accountName":"cli642xlhclhjvr","apiType":"MongoDB","creationTime":"2022-08-25T17:48:15Z","deletionTime":"2022-08-25T17:54:51Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4da784b9-9142-4cd4-a3d4-7b3b941cef0b","creationTime":"2022-08-25T17:48:16Z","deletionTime":"2022-08-25T17:54:51Z"}]}},{"name":"fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","properties":{"accountName":"cli2hngjqysuyrk","apiType":"MongoDB","creationTime":"2022-08-25T17:50:19Z","deletionTime":"2022-08-25T17:55:12Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a756769-7f16-4210-9a86-1b6a51f4ecdf","creationTime":"2022-08-25T17:50:20Z","deletionTime":"2022-08-25T17:55:12Z"}]}},{"name":"6972bff7-7971-4723-ae56-5802b096e6e3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6972bff7-7971-4723-ae56-5802b096e6e3","properties":{"accountName":"clif3lyrerpi54g","apiType":"Sql","creationTime":"2022-08-25T18:01:13Z","deletionTime":"2022-08-25T18:04:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"726278c9-7c2c-4391-bce6-e3387dff8435","creationTime":"2022-08-25T18:01:14Z","deletionTime":"2022-08-25T18:04:46Z"}]}},{"name":"3c46a652-c177-4916-9731-50bffdba55ae","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3c46a652-c177-4916-9731-50bffdba55ae","properties":{"accountName":"clitkbja6qgwko3","apiType":"Sql","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"42ae6741-aa76-4b7e-a5fa-feea888179e3","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z"}]}},{"name":"3e04e5e9-6a8f-4a78-86e6-18dc643980fd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3e04e5e9-6a8f-4a78-86e6-18dc643980fd","properties":{"accountName":"clirbh766tdrcuo","apiType":"Sql","creationTime":"2022-08-25T17:51:16Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"472275c5-7d72-489b-8069-0a041e696841","creationTime":"2022-08-25T17:51:17Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"1a2988f6-5f19-452e-a6e1-30b3716c3eff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a2988f6-5f19-452e-a6e1-30b3716c3eff","properties":{"accountName":"cliprc22bdv72rz","apiType":"Sql","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab980699-c97f-48a7-ab13-a4c750ad4665","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"b2093d64-9617-4f32-9d61-e905534e21da","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2093d64-9617-4f32-9d61-e905534e21da","properties":{"accountName":"clipyaf3k2czsnx","apiType":"Sql","creationTime":"2022-08-25T18:10:56Z","deletionTime":"2022-08-25T18:16:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cd9e2d6f-ae74-4a83-94de-c5b6c547ea71","creationTime":"2022-08-25T18:10:57Z","deletionTime":"2022-08-25T18:16:27Z"}]}},{"name":"dd296662-d32f-48ef-a55b-10d3cdd7d457","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd296662-d32f-48ef-a55b-10d3cdd7d457","properties":{"accountName":"cli2wmbvuvy7xzg","apiType":"Sql","creationTime":"2022-08-25T17:56:15Z","deletionTime":"2022-08-25T18:18:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"81a6ec53-ca56-4223-92b0-adeb6231e1f5","creationTime":"2022-08-25T17:56:16Z","deletionTime":"2022-08-25T18:18:29Z"}]}},{"name":"93d672c2-f060-4e22-b8a3-a1db21229e73","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/93d672c2-f060-4e22-b8a3-a1db21229e73","properties":{"accountName":"clij2xvz5zuhpth","apiType":"Sql","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"643a1596-40ff-494d-ac87-7a9f2b53a231","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z"}]}},{"name":"627d35df-1aff-4d0a-8d71-e7bb3ca16551","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/627d35df-1aff-4d0a-8d71-e7bb3ca16551","properties":{"accountName":"cliyvfzwxgzbt5qcsnarlf2gedbik7kuzpwoqqoz","apiType":"Sql","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7c3790de-2307-4aaf-8ccc-64f2aa7c2032","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z"}]}},{"name":"9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","properties":{"accountName":"cliomvsal633avs","apiType":"MongoDB","creationTime":"2022-09-01T17:22:23Z","deletionTime":"2022-09-01T17:27:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1ab7c41f-533d-4e8f-b819-6b8753eea8e4","creationTime":"2022-09-01T17:22:24Z","deletionTime":"2022-09-01T17:27:19Z"}]}},{"name":"437aa3e6-8920-42ef-b5df-2c8ee28bfe81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/437aa3e6-8920-42ef-b5df-2c8ee28bfe81","properties":{"accountName":"clit3zdheluo26r","apiType":"MongoDB","creationTime":"2022-09-01T17:29:41Z","deletionTime":"2022-09-01T17:35:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a878da74-6edd-43ad-a08c-f12a2c8b58e9","creationTime":"2022-09-01T17:29:42Z","deletionTime":"2022-09-01T17:35:19Z"}]}},{"name":"055ba6b8-c241-4ca5-bd2a-5905f5782029","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/055ba6b8-c241-4ca5-bd2a-5905f5782029","properties":{"accountName":"cliv6mcsfgjd4ak","apiType":"Sql","creationTime":"2022-09-01T17:42:11Z","deletionTime":"2022-09-01T17:48:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"f1c6d0cb-7dac-4d3d-839c-c1967da5d20d","creationTime":"2022-09-01T17:42:12Z","deletionTime":"2022-09-01T17:48:46Z"}]}},{"name":"596ccc7e-6212-4a58-a615-fdef3581a566","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/596ccc7e-6212-4a58-a615-fdef3581a566","properties":{"accountName":"clist343b7kqxgt","apiType":"Sql","creationTime":"2022-09-01T17:32:00Z","deletionTime":"2022-09-01T17:53:03Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"62004e01-add8-49ca-9482-c081d9dad32a","creationTime":"2022-09-01T17:32:01Z","deletionTime":"2022-09-01T17:53:03Z"}]}},{"name":"d4d26f2d-aacb-461d-9674-874533a35927","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d4d26f2d-aacb-461d-9674-874533a35927","properties":{"accountName":"cliim5efmvechgm","apiType":"Sql","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"326ab156-4292-46cd-b265-04b4da16880f","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z"}]}},{"name":"ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","properties":{"accountName":"cli5xjit35t3vmy","apiType":"Sql","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a26e214a-987d-4956-82e2-29581b698be7","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"6700db64-9dd4-4e0e-aedf-cc571d2556be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6700db64-9dd4-4e0e-aedf-cc571d2556be","properties":{"accountName":"cliusb2cpctd3jo","apiType":"Sql","creationTime":"2022-09-01T17:33:21Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bb5b12c1-d062-4ade-995f-56f3a5cebb51","creationTime":"2022-09-01T17:33:22Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"50161594-bab1-4110-bfc3-bb941822226b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/50161594-bab1-4110-bfc3-bb941822226b","properties":{"accountName":"cli6q2r7sebffac37t5lwk3cepyladzkkldjmxna","apiType":"Sql","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"765a32de-2b34-4333-be94-319a4fd75d2d","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z"}]}},{"name":"cf42a3c3-c50b-4110-bccf-a27131e4c240","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cf42a3c3-c50b-4110-bccf-a27131e4c240","properties":{"accountName":"cli3zz43bzjjsjy","apiType":"Sql","creationTime":"2022-09-08T17:13:37Z","deletionTime":"2022-09-08T17:20:31Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"836fb615-1694-4bb8-bb26-d4d7191a9826","creationTime":"2022-09-08T17:13:38Z","deletionTime":"2022-09-08T17:20:31Z"}]}},{"name":"3768a794-c2dc-4ed2-ac26-09eb8595b38f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3768a794-c2dc-4ed2-ac26-09eb8595b38f","properties":{"accountName":"cliblp3rryrjgkc","apiType":"MongoDB","creationTime":"2022-09-08T17:17:35Z","deletionTime":"2022-09-08T17:21:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a60fd3d-8d88-4ce2-9b59-cc33ee9bc199","creationTime":"2022-09-08T17:17:36Z","deletionTime":"2022-09-08T17:21:18Z"}]}},{"name":"16c01f3c-6319-4622-b8ef-72f587d939e7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16c01f3c-6319-4622-b8ef-72f587d939e7","properties":{"accountName":"clib2p6v5nnugvg","apiType":"MongoDB","creationTime":"2022-09-08T17:24:19Z","deletionTime":"2022-09-08T17:29:54Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab765683-a955-438f-a9f1-f88e6538f65b","creationTime":"2022-09-08T17:24:20Z","deletionTime":"2022-09-08T17:29:54Z"}]}},{"name":"c7000b77-291f-4d2b-a194-674e0956fb8f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c7000b77-291f-4d2b-a194-674e0956fb8f","properties":{"accountName":"cligri3ik55bve4","apiType":"Sql","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"2aaedea8-ce96-4549-8b59-686affcb1450","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z"}]}},{"name":"6c67aa75-0d9f-4818-bd33-84fb08b60307","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6c67aa75-0d9f-4818-bd33-84fb08b60307","properties":{"accountName":"clig74xujvvw7fw","apiType":"Sql","creationTime":"2022-09-08T17:38:49Z","deletionTime":"2022-09-08T17:43:36Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"065dc3e7-da03-4320-9923-d98bab3f3a32","creationTime":"2022-09-08T17:38:50Z","deletionTime":"2022-09-08T17:43:36Z"}]}},{"name":"59631687-f4e4-4b07-af3e-555c6e59150e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/59631687-f4e4-4b07-af3e-555c6e59150e","properties":{"accountName":"cliu5kch5swrzap","apiType":"Sql","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"eed5cfa5-76a9-4da1-8e28-70c1a3746f8a","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"c21bda24-fae1-44a2-ae1e-cb8fe570eea7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c21bda24-fae1-44a2-ae1e-cb8fe570eea7","properties":{"accountName":"clihdp4vf36xo2y","apiType":"Sql","creationTime":"2022-09-08T17:25:17Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b80a35a4-31c0-4bc0-ba5a-61c34833290f","creationTime":"2022-09-08T17:25:18Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"3aa72b82-66f2-4422-bff1-fcc6398e4872","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3aa72b82-66f2-4422-bff1-fcc6398e4872","properties":{"accountName":"cliiee5ncxczcvm","apiType":"Sql","creationTime":"2022-09-08T17:40:18Z","deletionTime":"2022-09-08T17:47:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5fc01c1b-02f7-4e2c-b66c-cc3b0d0136b5","creationTime":"2022-09-08T17:40:19Z","deletionTime":"2022-09-08T17:47:05Z"}]}},{"name":"cc64273d-9ac3-401b-8364-c9b5c222e16f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc64273d-9ac3-401b-8364-c9b5c222e16f","properties":{"accountName":"cli44be3onue5e3","apiType":"Sql","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b046012f-46f1-4076-9422-3e468b13b5bf","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"7080defb-7912-442c-8740-3474083d8bd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7080defb-7912-442c-8740-3474083d8bd1","properties":{"accountName":"cli6wl3roplqpwr","apiType":"Sql","creationTime":"2022-09-08T17:42:35Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"fe7a7ee6-e228-44cd-962d-c746cd1aaa0e","creationTime":"2022-09-08T17:42:36Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"a8165efd-ccef-4c75-aa24-7caf1f3075cc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a8165efd-ccef-4c75-aa24-7caf1f3075cc","properties":{"accountName":"clidl5m246s5argh5rxu3taw7ov2uioqp2xsyjb4","apiType":"Sql","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"663d7288-f394-4ba9-90ba-e562767e19bf","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z"}]}},{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"clithefqeaoirb5","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","deletionTime":"2022-09-19T03:41:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z","deletionTime":"2022-09-19T03:41:22Z"}]}},{"name":"f6a8cecd-67d9-450c-9c05-af3dc4b46117","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f6a8cecd-67d9-450c-9c05-af3dc4b46117","properties":{"accountName":"cli6elql3v7h5g7","apiType":"MongoDB","creationTime":"2022-09-19T03:53:18Z","deletionTime":"2022-09-19T03:58:10Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"16a25cc5-fd89-4c8b-88cb-4bf6a1c49431","creationTime":"2022-09-19T03:53:19Z","deletionTime":"2022-09-19T03:58:10Z"}]}},{"name":"edb07b57-c581-4d66-95e6-334bea0e3b76","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edb07b57-c581-4d66-95e6-334bea0e3b76","properties":{"accountName":"clici2s34sbznka","apiType":"Sql","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7084d0e7-b7d5-4b39-b63f-ca1280a89039","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z"}]}},{"name":"2182ee4a-15c8-4413-ba83-6193a0faa0fe","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2182ee4a-15c8-4413-ba83-6193a0faa0fe","properties":{"accountName":"clig6fq3dxxrsfv","apiType":"MongoDB","creationTime":"2022-09-19T04:19:09Z","deletionTime":"2022-09-19T04:25:43Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"76d0c792-3259-4d4b-ae8c-cdf79308b135","creationTime":"2022-09-19T04:19:10Z","deletionTime":"2022-09-19T04:25:43Z"}]}},{"name":"e0ffece8-dc58-434b-9112-24c36fb6e02a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e0ffece8-dc58-434b-9112-24c36fb6e02a","properties":{"accountName":"clijz3bahnmjsgx","apiType":"Sql","creationTime":"2022-09-19T04:47:52Z","deletionTime":"2022-09-19T04:51:30Z","restorableLocations":[]}}]}'
+      string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Canada
+        Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"b324c6a4-f540-4fce-a04f-ee2b5a7640da","creationTime":"2022-10-28T21:16:24Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e34d6a9-58a3-4e20-9d71-1ab3ff745b3c","creationTime":"2022-10-28T21:11:19Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"dbb767b2-f3d5-4475-8c99-464e9779fec4","creationTime":"2022-10-28T21:08:44Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"11f4f056-5005-40c8-bac4-7cd287d38352","creationTime":"2022-10-28T21:02:42Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
+        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:43Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
+        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:42Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:43Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '29700'
+      - '67058'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 04:59:11 GMT
+      - Wed, 28 Dec 2022 01:21:43 GMT
       expires:
       - '-1'
       pragma:
@@ -678,8 +819,6 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - ''
-      - ''
       - ''
       - ''
       - ''
@@ -734,113 +873,264 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"value":[{"name":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T04:58:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4871270e-f89d-4b60-8a38-ac9eb36825ea","creationTime":"2022-09-19T04:58:33Z"}]}},{"name":"d6e5008d-fdcb-4927-98ee-3c2753c89ee7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6e5008d-fdcb-4927-98ee-3c2753c89ee7","properties":{"accountName":"clilc67z5wdqqx2","apiType":"Sql","creationTime":"2022-08-25T06:08:26Z","deletionTime":"2022-08-25T06:15:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"37af2dc0-2aa6-46d3-8e41-cfed196796f9","creationTime":"2022-08-25T06:08:27Z","deletionTime":"2022-08-25T06:15:27Z"}]}},{"name":"90bd51e7-1fe7-4315-87f6-c2407cc951b0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90bd51e7-1fe7-4315-87f6-c2407cc951b0","properties":{"accountName":"cliw23t2chyagy6","apiType":"Sql","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d7cf6cbf-d6a1-4888-a620-41a07f491415","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z"}]}},{"name":"6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","properties":{"accountName":"cli7bonjdjz73wj","apiType":"MongoDB","creationTime":"2022-08-25T06:41:30Z","deletionTime":"2022-08-25T06:47:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"08709870-877a-42ea-a849-210c0fda4ee1","creationTime":"2022-08-25T06:41:31Z","deletionTime":"2022-08-25T06:47:32Z"}]}},{"name":"deff6534-a2b9-404d-b4ba-2e5e22b32bfb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/deff6534-a2b9-404d-b4ba-2e5e22b32bfb","properties":{"accountName":"cliuis4anv3ycph","apiType":"MongoDB","creationTime":"2022-08-25T07:18:31Z","deletionTime":"2022-08-25T07:26:15Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"dafa935e-6ee4-4d4a-bc1d-c8e609d42a60","creationTime":"2022-08-25T07:18:32Z","deletionTime":"2022-08-25T07:26:15Z"}]}},{"name":"d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","properties":{"accountName":"cliz5zwclforhva","apiType":"Sql","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5982b098-fba7-49cc-9996-ad4ccb1b3d33","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z"}]}},{"name":"0ccdf2af-7bda-4f61-b6df-d734c6773db6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0ccdf2af-7bda-4f61-b6df-d734c6773db6","properties":{"accountName":"cli7c6gulakolbu","apiType":"Sql","creationTime":"2022-08-25T07:35:24Z","deletionTime":"2022-08-25T07:57:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"794c2fc6-6ac1-41ba-990f-bd2c07eb7b9f","creationTime":"2022-08-25T07:35:25Z","deletionTime":"2022-08-25T07:57:18Z"}]}},{"name":"00df9a41-faa9-41a7-b061-6e3e3c923456","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/00df9a41-faa9-41a7-b061-6e3e3c923456","properties":{"accountName":"clib7httb4gycob","apiType":"Sql","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b56217c5-6fa0-4c6d-9809-80899be99f51","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","properties":{"accountName":"cliddcu3cjrh6we","apiType":"Sql","creationTime":"2022-08-25T07:57:57Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"938063bf-8716-409c-894f-60bb99781705","creationTime":"2022-08-25T07:57:58Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"68ac0330-103f-43ea-a1de-37c94072a36e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68ac0330-103f-43ea-a1de-37c94072a36e","properties":{"accountName":"clik7kgspjf6bgm","apiType":"Sql","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ff7a4f80-356f-4371-b143-ee999b63eb80","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z"}]}},{"name":"7bb0479d-7652-434b-af5b-675da5d24d9d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7bb0479d-7652-434b-af5b-675da5d24d9d","properties":{"accountName":"cligi5y5fvohgv453w5z25icozd6527bpu5ecv4k","apiType":"Sql","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bcac751b-de78-4668-9ef3-adca14decc29","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z"}]}},{"name":"212beaac-388e-4ff4-981e-f9aef3516b64","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/212beaac-388e-4ff4-981e-f9aef3516b64","properties":{"accountName":"cliren6oja2hpwe","apiType":"Sql","creationTime":"2022-08-25T17:36:41Z","deletionTime":"2022-08-25T17:43:38Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cec6d4eb-e6cc-4e65-bb67-26fde7eabc6e","creationTime":"2022-08-25T17:36:42Z","deletionTime":"2022-08-25T17:43:38Z"}]}},{"name":"045f21c9-c8cc-4ee5-ae4c-c95a481280ce","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045f21c9-c8cc-4ee5-ae4c-c95a481280ce","properties":{"accountName":"cli642xlhclhjvr","apiType":"MongoDB","creationTime":"2022-08-25T17:48:15Z","deletionTime":"2022-08-25T17:54:51Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4da784b9-9142-4cd4-a3d4-7b3b941cef0b","creationTime":"2022-08-25T17:48:16Z","deletionTime":"2022-08-25T17:54:51Z"}]}},{"name":"fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","properties":{"accountName":"cli2hngjqysuyrk","apiType":"MongoDB","creationTime":"2022-08-25T17:50:19Z","deletionTime":"2022-08-25T17:55:12Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a756769-7f16-4210-9a86-1b6a51f4ecdf","creationTime":"2022-08-25T17:50:20Z","deletionTime":"2022-08-25T17:55:12Z"}]}},{"name":"6972bff7-7971-4723-ae56-5802b096e6e3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6972bff7-7971-4723-ae56-5802b096e6e3","properties":{"accountName":"clif3lyrerpi54g","apiType":"Sql","creationTime":"2022-08-25T18:01:13Z","deletionTime":"2022-08-25T18:04:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"726278c9-7c2c-4391-bce6-e3387dff8435","creationTime":"2022-08-25T18:01:14Z","deletionTime":"2022-08-25T18:04:46Z"}]}},{"name":"3c46a652-c177-4916-9731-50bffdba55ae","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3c46a652-c177-4916-9731-50bffdba55ae","properties":{"accountName":"clitkbja6qgwko3","apiType":"Sql","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"42ae6741-aa76-4b7e-a5fa-feea888179e3","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z"}]}},{"name":"3e04e5e9-6a8f-4a78-86e6-18dc643980fd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3e04e5e9-6a8f-4a78-86e6-18dc643980fd","properties":{"accountName":"clirbh766tdrcuo","apiType":"Sql","creationTime":"2022-08-25T17:51:16Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"472275c5-7d72-489b-8069-0a041e696841","creationTime":"2022-08-25T17:51:17Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"1a2988f6-5f19-452e-a6e1-30b3716c3eff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a2988f6-5f19-452e-a6e1-30b3716c3eff","properties":{"accountName":"cliprc22bdv72rz","apiType":"Sql","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab980699-c97f-48a7-ab13-a4c750ad4665","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"b2093d64-9617-4f32-9d61-e905534e21da","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2093d64-9617-4f32-9d61-e905534e21da","properties":{"accountName":"clipyaf3k2czsnx","apiType":"Sql","creationTime":"2022-08-25T18:10:56Z","deletionTime":"2022-08-25T18:16:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cd9e2d6f-ae74-4a83-94de-c5b6c547ea71","creationTime":"2022-08-25T18:10:57Z","deletionTime":"2022-08-25T18:16:27Z"}]}},{"name":"dd296662-d32f-48ef-a55b-10d3cdd7d457","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd296662-d32f-48ef-a55b-10d3cdd7d457","properties":{"accountName":"cli2wmbvuvy7xzg","apiType":"Sql","creationTime":"2022-08-25T17:56:15Z","deletionTime":"2022-08-25T18:18:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"81a6ec53-ca56-4223-92b0-adeb6231e1f5","creationTime":"2022-08-25T17:56:16Z","deletionTime":"2022-08-25T18:18:29Z"}]}},{"name":"93d672c2-f060-4e22-b8a3-a1db21229e73","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/93d672c2-f060-4e22-b8a3-a1db21229e73","properties":{"accountName":"clij2xvz5zuhpth","apiType":"Sql","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"643a1596-40ff-494d-ac87-7a9f2b53a231","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z"}]}},{"name":"627d35df-1aff-4d0a-8d71-e7bb3ca16551","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/627d35df-1aff-4d0a-8d71-e7bb3ca16551","properties":{"accountName":"cliyvfzwxgzbt5qcsnarlf2gedbik7kuzpwoqqoz","apiType":"Sql","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7c3790de-2307-4aaf-8ccc-64f2aa7c2032","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z"}]}},{"name":"9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","properties":{"accountName":"cliomvsal633avs","apiType":"MongoDB","creationTime":"2022-09-01T17:22:23Z","deletionTime":"2022-09-01T17:27:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1ab7c41f-533d-4e8f-b819-6b8753eea8e4","creationTime":"2022-09-01T17:22:24Z","deletionTime":"2022-09-01T17:27:19Z"}]}},{"name":"437aa3e6-8920-42ef-b5df-2c8ee28bfe81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/437aa3e6-8920-42ef-b5df-2c8ee28bfe81","properties":{"accountName":"clit3zdheluo26r","apiType":"MongoDB","creationTime":"2022-09-01T17:29:41Z","deletionTime":"2022-09-01T17:35:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a878da74-6edd-43ad-a08c-f12a2c8b58e9","creationTime":"2022-09-01T17:29:42Z","deletionTime":"2022-09-01T17:35:19Z"}]}},{"name":"055ba6b8-c241-4ca5-bd2a-5905f5782029","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/055ba6b8-c241-4ca5-bd2a-5905f5782029","properties":{"accountName":"cliv6mcsfgjd4ak","apiType":"Sql","creationTime":"2022-09-01T17:42:11Z","deletionTime":"2022-09-01T17:48:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"f1c6d0cb-7dac-4d3d-839c-c1967da5d20d","creationTime":"2022-09-01T17:42:12Z","deletionTime":"2022-09-01T17:48:46Z"}]}},{"name":"596ccc7e-6212-4a58-a615-fdef3581a566","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/596ccc7e-6212-4a58-a615-fdef3581a566","properties":{"accountName":"clist343b7kqxgt","apiType":"Sql","creationTime":"2022-09-01T17:32:00Z","deletionTime":"2022-09-01T17:53:03Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"62004e01-add8-49ca-9482-c081d9dad32a","creationTime":"2022-09-01T17:32:01Z","deletionTime":"2022-09-01T17:53:03Z"}]}},{"name":"d4d26f2d-aacb-461d-9674-874533a35927","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d4d26f2d-aacb-461d-9674-874533a35927","properties":{"accountName":"cliim5efmvechgm","apiType":"Sql","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"326ab156-4292-46cd-b265-04b4da16880f","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z"}]}},{"name":"ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","properties":{"accountName":"cli5xjit35t3vmy","apiType":"Sql","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a26e214a-987d-4956-82e2-29581b698be7","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"6700db64-9dd4-4e0e-aedf-cc571d2556be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6700db64-9dd4-4e0e-aedf-cc571d2556be","properties":{"accountName":"cliusb2cpctd3jo","apiType":"Sql","creationTime":"2022-09-01T17:33:21Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bb5b12c1-d062-4ade-995f-56f3a5cebb51","creationTime":"2022-09-01T17:33:22Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"50161594-bab1-4110-bfc3-bb941822226b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/50161594-bab1-4110-bfc3-bb941822226b","properties":{"accountName":"cli6q2r7sebffac37t5lwk3cepyladzkkldjmxna","apiType":"Sql","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"765a32de-2b34-4333-be94-319a4fd75d2d","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z"}]}},{"name":"cf42a3c3-c50b-4110-bccf-a27131e4c240","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cf42a3c3-c50b-4110-bccf-a27131e4c240","properties":{"accountName":"cli3zz43bzjjsjy","apiType":"Sql","creationTime":"2022-09-08T17:13:37Z","deletionTime":"2022-09-08T17:20:31Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"836fb615-1694-4bb8-bb26-d4d7191a9826","creationTime":"2022-09-08T17:13:38Z","deletionTime":"2022-09-08T17:20:31Z"}]}},{"name":"3768a794-c2dc-4ed2-ac26-09eb8595b38f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3768a794-c2dc-4ed2-ac26-09eb8595b38f","properties":{"accountName":"cliblp3rryrjgkc","apiType":"MongoDB","creationTime":"2022-09-08T17:17:35Z","deletionTime":"2022-09-08T17:21:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a60fd3d-8d88-4ce2-9b59-cc33ee9bc199","creationTime":"2022-09-08T17:17:36Z","deletionTime":"2022-09-08T17:21:18Z"}]}},{"name":"16c01f3c-6319-4622-b8ef-72f587d939e7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16c01f3c-6319-4622-b8ef-72f587d939e7","properties":{"accountName":"clib2p6v5nnugvg","apiType":"MongoDB","creationTime":"2022-09-08T17:24:19Z","deletionTime":"2022-09-08T17:29:54Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab765683-a955-438f-a9f1-f88e6538f65b","creationTime":"2022-09-08T17:24:20Z","deletionTime":"2022-09-08T17:29:54Z"}]}},{"name":"c7000b77-291f-4d2b-a194-674e0956fb8f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c7000b77-291f-4d2b-a194-674e0956fb8f","properties":{"accountName":"cligri3ik55bve4","apiType":"Sql","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"2aaedea8-ce96-4549-8b59-686affcb1450","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z"}]}},{"name":"6c67aa75-0d9f-4818-bd33-84fb08b60307","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6c67aa75-0d9f-4818-bd33-84fb08b60307","properties":{"accountName":"clig74xujvvw7fw","apiType":"Sql","creationTime":"2022-09-08T17:38:49Z","deletionTime":"2022-09-08T17:43:36Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"065dc3e7-da03-4320-9923-d98bab3f3a32","creationTime":"2022-09-08T17:38:50Z","deletionTime":"2022-09-08T17:43:36Z"}]}},{"name":"59631687-f4e4-4b07-af3e-555c6e59150e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/59631687-f4e4-4b07-af3e-555c6e59150e","properties":{"accountName":"cliu5kch5swrzap","apiType":"Sql","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"eed5cfa5-76a9-4da1-8e28-70c1a3746f8a","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"c21bda24-fae1-44a2-ae1e-cb8fe570eea7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c21bda24-fae1-44a2-ae1e-cb8fe570eea7","properties":{"accountName":"clihdp4vf36xo2y","apiType":"Sql","creationTime":"2022-09-08T17:25:17Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b80a35a4-31c0-4bc0-ba5a-61c34833290f","creationTime":"2022-09-08T17:25:18Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"3aa72b82-66f2-4422-bff1-fcc6398e4872","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3aa72b82-66f2-4422-bff1-fcc6398e4872","properties":{"accountName":"cliiee5ncxczcvm","apiType":"Sql","creationTime":"2022-09-08T17:40:18Z","deletionTime":"2022-09-08T17:47:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5fc01c1b-02f7-4e2c-b66c-cc3b0d0136b5","creationTime":"2022-09-08T17:40:19Z","deletionTime":"2022-09-08T17:47:05Z"}]}},{"name":"cc64273d-9ac3-401b-8364-c9b5c222e16f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc64273d-9ac3-401b-8364-c9b5c222e16f","properties":{"accountName":"cli44be3onue5e3","apiType":"Sql","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b046012f-46f1-4076-9422-3e468b13b5bf","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"7080defb-7912-442c-8740-3474083d8bd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7080defb-7912-442c-8740-3474083d8bd1","properties":{"accountName":"cli6wl3roplqpwr","apiType":"Sql","creationTime":"2022-09-08T17:42:35Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"fe7a7ee6-e228-44cd-962d-c746cd1aaa0e","creationTime":"2022-09-08T17:42:36Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"a8165efd-ccef-4c75-aa24-7caf1f3075cc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a8165efd-ccef-4c75-aa24-7caf1f3075cc","properties":{"accountName":"clidl5m246s5argh5rxu3taw7ov2uioqp2xsyjb4","apiType":"Sql","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"663d7288-f394-4ba9-90ba-e562767e19bf","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z"}]}},{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"clithefqeaoirb5","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","deletionTime":"2022-09-19T03:41:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z","deletionTime":"2022-09-19T03:41:22Z"}]}},{"name":"f6a8cecd-67d9-450c-9c05-af3dc4b46117","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f6a8cecd-67d9-450c-9c05-af3dc4b46117","properties":{"accountName":"cli6elql3v7h5g7","apiType":"MongoDB","creationTime":"2022-09-19T03:53:18Z","deletionTime":"2022-09-19T03:58:10Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"16a25cc5-fd89-4c8b-88cb-4bf6a1c49431","creationTime":"2022-09-19T03:53:19Z","deletionTime":"2022-09-19T03:58:10Z"}]}},{"name":"edb07b57-c581-4d66-95e6-334bea0e3b76","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edb07b57-c581-4d66-95e6-334bea0e3b76","properties":{"accountName":"clici2s34sbznka","apiType":"Sql","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7084d0e7-b7d5-4b39-b63f-ca1280a89039","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z"}]}},{"name":"2182ee4a-15c8-4413-ba83-6193a0faa0fe","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2182ee4a-15c8-4413-ba83-6193a0faa0fe","properties":{"accountName":"clig6fq3dxxrsfv","apiType":"MongoDB","creationTime":"2022-09-19T04:19:09Z","deletionTime":"2022-09-19T04:25:43Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"76d0c792-3259-4d4b-ae8c-cdf79308b135","creationTime":"2022-09-19T04:19:10Z","deletionTime":"2022-09-19T04:25:43Z"}]}},{"name":"e0ffece8-dc58-434b-9112-24c36fb6e02a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e0ffece8-dc58-434b-9112-24c36fb6e02a","properties":{"accountName":"clijz3bahnmjsgx","apiType":"Sql","creationTime":"2022-09-19T04:47:52Z","deletionTime":"2022-09-19T04:51:30Z","restorableLocations":[]}}]}'
+      string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"Canada
+        Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"b324c6a4-f540-4fce-a04f-ee2b5a7640da","creationTime":"2022-10-28T21:16:24Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e34d6a9-58a3-4e20-9d71-1ab3ff745b3c","creationTime":"2022-10-28T21:11:19Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"dbb767b2-f3d5-4475-8c99-464e9779fec4","creationTime":"2022-10-28T21:08:44Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"11f4f056-5005-40c8-bac4-7cd287d38352","creationTime":"2022-10-28T21:02:42Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:44Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
+        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
+        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:45Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '29700'
+      - '67058'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 04:59:13 GMT
+      - Wed, 28 Dec 2022 01:21:45 GMT
       expires:
       - '-1'
       pragma:
@@ -852,8 +1142,6 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - ''
-      - ''
       - ''
       - ''
       - ''
@@ -908,113 +1196,264 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"value":[{"name":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T04:58:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4871270e-f89d-4b60-8a38-ac9eb36825ea","creationTime":"2022-09-19T04:58:33Z"}]}},{"name":"d6e5008d-fdcb-4927-98ee-3c2753c89ee7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6e5008d-fdcb-4927-98ee-3c2753c89ee7","properties":{"accountName":"clilc67z5wdqqx2","apiType":"Sql","creationTime":"2022-08-25T06:08:26Z","deletionTime":"2022-08-25T06:15:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"37af2dc0-2aa6-46d3-8e41-cfed196796f9","creationTime":"2022-08-25T06:08:27Z","deletionTime":"2022-08-25T06:15:27Z"}]}},{"name":"90bd51e7-1fe7-4315-87f6-c2407cc951b0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90bd51e7-1fe7-4315-87f6-c2407cc951b0","properties":{"accountName":"cliw23t2chyagy6","apiType":"Sql","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d7cf6cbf-d6a1-4888-a620-41a07f491415","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z"}]}},{"name":"6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","properties":{"accountName":"cli7bonjdjz73wj","apiType":"MongoDB","creationTime":"2022-08-25T06:41:30Z","deletionTime":"2022-08-25T06:47:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"08709870-877a-42ea-a849-210c0fda4ee1","creationTime":"2022-08-25T06:41:31Z","deletionTime":"2022-08-25T06:47:32Z"}]}},{"name":"deff6534-a2b9-404d-b4ba-2e5e22b32bfb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/deff6534-a2b9-404d-b4ba-2e5e22b32bfb","properties":{"accountName":"cliuis4anv3ycph","apiType":"MongoDB","creationTime":"2022-08-25T07:18:31Z","deletionTime":"2022-08-25T07:26:15Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"dafa935e-6ee4-4d4a-bc1d-c8e609d42a60","creationTime":"2022-08-25T07:18:32Z","deletionTime":"2022-08-25T07:26:15Z"}]}},{"name":"d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","properties":{"accountName":"cliz5zwclforhva","apiType":"Sql","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5982b098-fba7-49cc-9996-ad4ccb1b3d33","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z"}]}},{"name":"0ccdf2af-7bda-4f61-b6df-d734c6773db6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0ccdf2af-7bda-4f61-b6df-d734c6773db6","properties":{"accountName":"cli7c6gulakolbu","apiType":"Sql","creationTime":"2022-08-25T07:35:24Z","deletionTime":"2022-08-25T07:57:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"794c2fc6-6ac1-41ba-990f-bd2c07eb7b9f","creationTime":"2022-08-25T07:35:25Z","deletionTime":"2022-08-25T07:57:18Z"}]}},{"name":"00df9a41-faa9-41a7-b061-6e3e3c923456","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/00df9a41-faa9-41a7-b061-6e3e3c923456","properties":{"accountName":"clib7httb4gycob","apiType":"Sql","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b56217c5-6fa0-4c6d-9809-80899be99f51","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","properties":{"accountName":"cliddcu3cjrh6we","apiType":"Sql","creationTime":"2022-08-25T07:57:57Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"938063bf-8716-409c-894f-60bb99781705","creationTime":"2022-08-25T07:57:58Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"68ac0330-103f-43ea-a1de-37c94072a36e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68ac0330-103f-43ea-a1de-37c94072a36e","properties":{"accountName":"clik7kgspjf6bgm","apiType":"Sql","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ff7a4f80-356f-4371-b143-ee999b63eb80","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z"}]}},{"name":"7bb0479d-7652-434b-af5b-675da5d24d9d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7bb0479d-7652-434b-af5b-675da5d24d9d","properties":{"accountName":"cligi5y5fvohgv453w5z25icozd6527bpu5ecv4k","apiType":"Sql","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bcac751b-de78-4668-9ef3-adca14decc29","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z"}]}},{"name":"212beaac-388e-4ff4-981e-f9aef3516b64","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/212beaac-388e-4ff4-981e-f9aef3516b64","properties":{"accountName":"cliren6oja2hpwe","apiType":"Sql","creationTime":"2022-08-25T17:36:41Z","deletionTime":"2022-08-25T17:43:38Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cec6d4eb-e6cc-4e65-bb67-26fde7eabc6e","creationTime":"2022-08-25T17:36:42Z","deletionTime":"2022-08-25T17:43:38Z"}]}},{"name":"045f21c9-c8cc-4ee5-ae4c-c95a481280ce","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045f21c9-c8cc-4ee5-ae4c-c95a481280ce","properties":{"accountName":"cli642xlhclhjvr","apiType":"MongoDB","creationTime":"2022-08-25T17:48:15Z","deletionTime":"2022-08-25T17:54:51Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4da784b9-9142-4cd4-a3d4-7b3b941cef0b","creationTime":"2022-08-25T17:48:16Z","deletionTime":"2022-08-25T17:54:51Z"}]}},{"name":"fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","properties":{"accountName":"cli2hngjqysuyrk","apiType":"MongoDB","creationTime":"2022-08-25T17:50:19Z","deletionTime":"2022-08-25T17:55:12Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a756769-7f16-4210-9a86-1b6a51f4ecdf","creationTime":"2022-08-25T17:50:20Z","deletionTime":"2022-08-25T17:55:12Z"}]}},{"name":"6972bff7-7971-4723-ae56-5802b096e6e3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6972bff7-7971-4723-ae56-5802b096e6e3","properties":{"accountName":"clif3lyrerpi54g","apiType":"Sql","creationTime":"2022-08-25T18:01:13Z","deletionTime":"2022-08-25T18:04:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"726278c9-7c2c-4391-bce6-e3387dff8435","creationTime":"2022-08-25T18:01:14Z","deletionTime":"2022-08-25T18:04:46Z"}]}},{"name":"3c46a652-c177-4916-9731-50bffdba55ae","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3c46a652-c177-4916-9731-50bffdba55ae","properties":{"accountName":"clitkbja6qgwko3","apiType":"Sql","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"42ae6741-aa76-4b7e-a5fa-feea888179e3","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z"}]}},{"name":"3e04e5e9-6a8f-4a78-86e6-18dc643980fd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3e04e5e9-6a8f-4a78-86e6-18dc643980fd","properties":{"accountName":"clirbh766tdrcuo","apiType":"Sql","creationTime":"2022-08-25T17:51:16Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"472275c5-7d72-489b-8069-0a041e696841","creationTime":"2022-08-25T17:51:17Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"1a2988f6-5f19-452e-a6e1-30b3716c3eff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a2988f6-5f19-452e-a6e1-30b3716c3eff","properties":{"accountName":"cliprc22bdv72rz","apiType":"Sql","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab980699-c97f-48a7-ab13-a4c750ad4665","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"b2093d64-9617-4f32-9d61-e905534e21da","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2093d64-9617-4f32-9d61-e905534e21da","properties":{"accountName":"clipyaf3k2czsnx","apiType":"Sql","creationTime":"2022-08-25T18:10:56Z","deletionTime":"2022-08-25T18:16:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cd9e2d6f-ae74-4a83-94de-c5b6c547ea71","creationTime":"2022-08-25T18:10:57Z","deletionTime":"2022-08-25T18:16:27Z"}]}},{"name":"dd296662-d32f-48ef-a55b-10d3cdd7d457","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd296662-d32f-48ef-a55b-10d3cdd7d457","properties":{"accountName":"cli2wmbvuvy7xzg","apiType":"Sql","creationTime":"2022-08-25T17:56:15Z","deletionTime":"2022-08-25T18:18:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"81a6ec53-ca56-4223-92b0-adeb6231e1f5","creationTime":"2022-08-25T17:56:16Z","deletionTime":"2022-08-25T18:18:29Z"}]}},{"name":"93d672c2-f060-4e22-b8a3-a1db21229e73","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/93d672c2-f060-4e22-b8a3-a1db21229e73","properties":{"accountName":"clij2xvz5zuhpth","apiType":"Sql","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"643a1596-40ff-494d-ac87-7a9f2b53a231","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z"}]}},{"name":"627d35df-1aff-4d0a-8d71-e7bb3ca16551","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/627d35df-1aff-4d0a-8d71-e7bb3ca16551","properties":{"accountName":"cliyvfzwxgzbt5qcsnarlf2gedbik7kuzpwoqqoz","apiType":"Sql","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7c3790de-2307-4aaf-8ccc-64f2aa7c2032","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z"}]}},{"name":"9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","properties":{"accountName":"cliomvsal633avs","apiType":"MongoDB","creationTime":"2022-09-01T17:22:23Z","deletionTime":"2022-09-01T17:27:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1ab7c41f-533d-4e8f-b819-6b8753eea8e4","creationTime":"2022-09-01T17:22:24Z","deletionTime":"2022-09-01T17:27:19Z"}]}},{"name":"437aa3e6-8920-42ef-b5df-2c8ee28bfe81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/437aa3e6-8920-42ef-b5df-2c8ee28bfe81","properties":{"accountName":"clit3zdheluo26r","apiType":"MongoDB","creationTime":"2022-09-01T17:29:41Z","deletionTime":"2022-09-01T17:35:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a878da74-6edd-43ad-a08c-f12a2c8b58e9","creationTime":"2022-09-01T17:29:42Z","deletionTime":"2022-09-01T17:35:19Z"}]}},{"name":"055ba6b8-c241-4ca5-bd2a-5905f5782029","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/055ba6b8-c241-4ca5-bd2a-5905f5782029","properties":{"accountName":"cliv6mcsfgjd4ak","apiType":"Sql","creationTime":"2022-09-01T17:42:11Z","deletionTime":"2022-09-01T17:48:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"f1c6d0cb-7dac-4d3d-839c-c1967da5d20d","creationTime":"2022-09-01T17:42:12Z","deletionTime":"2022-09-01T17:48:46Z"}]}},{"name":"596ccc7e-6212-4a58-a615-fdef3581a566","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/596ccc7e-6212-4a58-a615-fdef3581a566","properties":{"accountName":"clist343b7kqxgt","apiType":"Sql","creationTime":"2022-09-01T17:32:00Z","deletionTime":"2022-09-01T17:53:03Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"62004e01-add8-49ca-9482-c081d9dad32a","creationTime":"2022-09-01T17:32:01Z","deletionTime":"2022-09-01T17:53:03Z"}]}},{"name":"d4d26f2d-aacb-461d-9674-874533a35927","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d4d26f2d-aacb-461d-9674-874533a35927","properties":{"accountName":"cliim5efmvechgm","apiType":"Sql","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"326ab156-4292-46cd-b265-04b4da16880f","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z"}]}},{"name":"ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","properties":{"accountName":"cli5xjit35t3vmy","apiType":"Sql","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a26e214a-987d-4956-82e2-29581b698be7","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"6700db64-9dd4-4e0e-aedf-cc571d2556be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6700db64-9dd4-4e0e-aedf-cc571d2556be","properties":{"accountName":"cliusb2cpctd3jo","apiType":"Sql","creationTime":"2022-09-01T17:33:21Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bb5b12c1-d062-4ade-995f-56f3a5cebb51","creationTime":"2022-09-01T17:33:22Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"50161594-bab1-4110-bfc3-bb941822226b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/50161594-bab1-4110-bfc3-bb941822226b","properties":{"accountName":"cli6q2r7sebffac37t5lwk3cepyladzkkldjmxna","apiType":"Sql","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"765a32de-2b34-4333-be94-319a4fd75d2d","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z"}]}},{"name":"cf42a3c3-c50b-4110-bccf-a27131e4c240","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cf42a3c3-c50b-4110-bccf-a27131e4c240","properties":{"accountName":"cli3zz43bzjjsjy","apiType":"Sql","creationTime":"2022-09-08T17:13:37Z","deletionTime":"2022-09-08T17:20:31Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"836fb615-1694-4bb8-bb26-d4d7191a9826","creationTime":"2022-09-08T17:13:38Z","deletionTime":"2022-09-08T17:20:31Z"}]}},{"name":"3768a794-c2dc-4ed2-ac26-09eb8595b38f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3768a794-c2dc-4ed2-ac26-09eb8595b38f","properties":{"accountName":"cliblp3rryrjgkc","apiType":"MongoDB","creationTime":"2022-09-08T17:17:35Z","deletionTime":"2022-09-08T17:21:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a60fd3d-8d88-4ce2-9b59-cc33ee9bc199","creationTime":"2022-09-08T17:17:36Z","deletionTime":"2022-09-08T17:21:18Z"}]}},{"name":"16c01f3c-6319-4622-b8ef-72f587d939e7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16c01f3c-6319-4622-b8ef-72f587d939e7","properties":{"accountName":"clib2p6v5nnugvg","apiType":"MongoDB","creationTime":"2022-09-08T17:24:19Z","deletionTime":"2022-09-08T17:29:54Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab765683-a955-438f-a9f1-f88e6538f65b","creationTime":"2022-09-08T17:24:20Z","deletionTime":"2022-09-08T17:29:54Z"}]}},{"name":"c7000b77-291f-4d2b-a194-674e0956fb8f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c7000b77-291f-4d2b-a194-674e0956fb8f","properties":{"accountName":"cligri3ik55bve4","apiType":"Sql","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"2aaedea8-ce96-4549-8b59-686affcb1450","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z"}]}},{"name":"6c67aa75-0d9f-4818-bd33-84fb08b60307","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6c67aa75-0d9f-4818-bd33-84fb08b60307","properties":{"accountName":"clig74xujvvw7fw","apiType":"Sql","creationTime":"2022-09-08T17:38:49Z","deletionTime":"2022-09-08T17:43:36Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"065dc3e7-da03-4320-9923-d98bab3f3a32","creationTime":"2022-09-08T17:38:50Z","deletionTime":"2022-09-08T17:43:36Z"}]}},{"name":"59631687-f4e4-4b07-af3e-555c6e59150e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/59631687-f4e4-4b07-af3e-555c6e59150e","properties":{"accountName":"cliu5kch5swrzap","apiType":"Sql","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"eed5cfa5-76a9-4da1-8e28-70c1a3746f8a","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"c21bda24-fae1-44a2-ae1e-cb8fe570eea7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c21bda24-fae1-44a2-ae1e-cb8fe570eea7","properties":{"accountName":"clihdp4vf36xo2y","apiType":"Sql","creationTime":"2022-09-08T17:25:17Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b80a35a4-31c0-4bc0-ba5a-61c34833290f","creationTime":"2022-09-08T17:25:18Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"3aa72b82-66f2-4422-bff1-fcc6398e4872","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3aa72b82-66f2-4422-bff1-fcc6398e4872","properties":{"accountName":"cliiee5ncxczcvm","apiType":"Sql","creationTime":"2022-09-08T17:40:18Z","deletionTime":"2022-09-08T17:47:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5fc01c1b-02f7-4e2c-b66c-cc3b0d0136b5","creationTime":"2022-09-08T17:40:19Z","deletionTime":"2022-09-08T17:47:05Z"}]}},{"name":"cc64273d-9ac3-401b-8364-c9b5c222e16f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc64273d-9ac3-401b-8364-c9b5c222e16f","properties":{"accountName":"cli44be3onue5e3","apiType":"Sql","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b046012f-46f1-4076-9422-3e468b13b5bf","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"7080defb-7912-442c-8740-3474083d8bd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7080defb-7912-442c-8740-3474083d8bd1","properties":{"accountName":"cli6wl3roplqpwr","apiType":"Sql","creationTime":"2022-09-08T17:42:35Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"fe7a7ee6-e228-44cd-962d-c746cd1aaa0e","creationTime":"2022-09-08T17:42:36Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"a8165efd-ccef-4c75-aa24-7caf1f3075cc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a8165efd-ccef-4c75-aa24-7caf1f3075cc","properties":{"accountName":"clidl5m246s5argh5rxu3taw7ov2uioqp2xsyjb4","apiType":"Sql","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"663d7288-f394-4ba9-90ba-e562767e19bf","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z"}]}},{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"clithefqeaoirb5","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","deletionTime":"2022-09-19T03:41:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z","deletionTime":"2022-09-19T03:41:22Z"}]}},{"name":"f6a8cecd-67d9-450c-9c05-af3dc4b46117","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f6a8cecd-67d9-450c-9c05-af3dc4b46117","properties":{"accountName":"cli6elql3v7h5g7","apiType":"MongoDB","creationTime":"2022-09-19T03:53:18Z","deletionTime":"2022-09-19T03:58:10Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"16a25cc5-fd89-4c8b-88cb-4bf6a1c49431","creationTime":"2022-09-19T03:53:19Z","deletionTime":"2022-09-19T03:58:10Z"}]}},{"name":"edb07b57-c581-4d66-95e6-334bea0e3b76","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edb07b57-c581-4d66-95e6-334bea0e3b76","properties":{"accountName":"clici2s34sbznka","apiType":"Sql","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7084d0e7-b7d5-4b39-b63f-ca1280a89039","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z"}]}},{"name":"2182ee4a-15c8-4413-ba83-6193a0faa0fe","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2182ee4a-15c8-4413-ba83-6193a0faa0fe","properties":{"accountName":"clig6fq3dxxrsfv","apiType":"MongoDB","creationTime":"2022-09-19T04:19:09Z","deletionTime":"2022-09-19T04:25:43Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"76d0c792-3259-4d4b-ae8c-cdf79308b135","creationTime":"2022-09-19T04:19:10Z","deletionTime":"2022-09-19T04:25:43Z"}]}},{"name":"e0ffece8-dc58-434b-9112-24c36fb6e02a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e0ffece8-dc58-434b-9112-24c36fb6e02a","properties":{"accountName":"clijz3bahnmjsgx","apiType":"Sql","creationTime":"2022-09-19T04:47:52Z","deletionTime":"2022-09-19T04:51:30Z","restorableLocations":[]}}]}'
+      string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Canada
+        Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"b324c6a4-f540-4fce-a04f-ee2b5a7640da","creationTime":"2022-10-28T21:16:24Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e34d6a9-58a3-4e20-9d71-1ab3ff745b3c","creationTime":"2022-10-28T21:11:19Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"dbb767b2-f3d5-4475-8c99-464e9779fec4","creationTime":"2022-10-28T21:08:44Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"11f4f056-5005-40c8-bac4-7cd287d38352","creationTime":"2022-10-28T21:02:42Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
+        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
+        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:21:47Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:21:48Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '29700'
+      - '67058'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 04:59:15 GMT
+      - Wed, 28 Dec 2022 01:21:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1026,8 +1465,6 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - ''
-      - ''
       - ''
       - ''
       - ''
@@ -1086,8 +1523,7 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
@@ -1095,7 +1531,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/276545ad-b65e-4ac3-b563-2beb0954289e?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1103,9 +1539,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:16 GMT
+      - Wed, 28 Dec 2022 01:21:50 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/276545ad-b65e-4ac3-b563-2beb0954289e?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/operationResults/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -1117,7 +1553,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -1135,10 +1571,9 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/276545ad-b65e-4ac3-b563-2beb0954289e?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/5725d18e-122b-4534-b482-e213de4762d8?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1150,7 +1585,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:46 GMT
+      - Wed, 28 Dec 2022 01:22:20 GMT
       pragma:
       - no-cache
       server:
@@ -1182,13 +1617,12 @@ interactions:
       ParameterSetName:
       - -g -a -n
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"rEsGAA==","_self":"dbs/rEsGAA==/","_etag":"\"0000e92a-0000-0700-0000-6327f7290000\"","_colls":"colls/","_users":"users/","_ts":1663563561}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases","name":"cli000005","properties":{"resource":{"id":"cli000005","_rid":"ZM9FAA==","_self":"dbs/ZM9FAA==/","_etag":"\"00009002-0000-0700-0000-63ab9a330000\"","_colls":"colls/","_users":"users/","_ts":1672190515}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1197,7 +1631,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:47 GMT
+      - Wed, 28 Dec 2022 01:22:20 GMT
       pragma:
       - no-cache
       server:
@@ -1236,8 +1670,7 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
@@ -1245,7 +1678,7 @@ interactions:
       string: '{"status":"Enqueued"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/da2a4ca4-78e6-426d-a7b4-4ed17b47386a?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
       cache-control:
       - no-store, no-cache
       content-length:
@@ -1253,9 +1686,9 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 04:59:47 GMT
+      - Wed, 28 Dec 2022 01:22:23 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/da2a4ca4-78e6-426d-a7b4-4ed17b47386a?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002/operationResults/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
       pragma:
       - no-cache
       server:
@@ -1267,7 +1700,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1197'
+      - '1199'
     status:
       code: 202
       message: Accepted
@@ -1285,10 +1718,9 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/da2a4ca4-78e6-426d-a7b4-4ed17b47386a?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/debf4ecf-985c-468f-96ff-9d51a093fdc6?api-version=2022-08-15
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -1300,7 +1732,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:00:18 GMT
+      - Wed, 28 Dec 2022 01:22:54 GMT
       pragma:
       - no-cache
       server:
@@ -1332,13 +1764,12 @@ interactions:
       ParameterSetName:
       - -g -a -d -n -p
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002?api-version=2022-08-15
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"rEsGAO0lzT0=","_ts":1663563593,"_self":"dbs/rEsGAA==/colls/rEsGAO0lzT0=/","_etag":"\"0000ec2a-0000-0700-0000-6327f7490000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000003/sqlDatabases/cli000005/containers/cli000002","type":"Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers","name":"cli000002","properties":{"resource":{"id":"cli000002","indexingPolicy":{"indexingMode":"consistent","automatic":true,"includedPaths":[{"path":"/*"}],"excludedPaths":[{"path":"/\"_etag\"/?"}]},"partitionKey":{"paths":["/pk"],"kind":"Hash"},"uniqueKeyPolicy":{"uniqueKeys":[]},"conflictResolutionPolicy":{"mode":"LastWriterWins","conflictResolutionPath":"/_ts","conflictResolutionProcedure":""},"backupPolicy":{"type":1},"geospatialConfig":{"type":"Geography"},"_rid":"ZM9FAJU7Rmw=","_ts":1672190548,"_self":"dbs/ZM9FAA==/colls/ZM9FAJU7Rmw=/","_etag":"\"00009302-0000-0700-0000-63ab9a540000\"","_docs":"docs/","_sprocs":"sprocs/","_triggers":"triggers/","_udfs":"udfs/","_conflicts":"conflicts/","statistics":[{"id":"0","sizeInKB":0,"documentCount":0,"sampledDistinctPartitionKeyCount":0,"partitionKeys":[]}]}}}'
     headers:
       cache-control:
       - no-store, no-cache
@@ -1347,7 +1778,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:00:18 GMT
+      - Wed, 28 Dec 2022 01:22:54 GMT
       pragma:
       - no-cache
       server:
@@ -1379,114 +1810,264 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/restorableDatabaseAccounts?api-version=2022-08-15-preview
   response:
     body:
-      string: '{"value":[{"name":"c9ce8123-9af3-47bc-bee9-c08ea1bc206d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-09-19T04:58:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4871270e-f89d-4b60-8a38-ac9eb36825ea","creationTime":"2022-09-19T04:58:33Z"}]}},{"name":"d6e5008d-fdcb-4927-98ee-3c2753c89ee7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d6e5008d-fdcb-4927-98ee-3c2753c89ee7","properties":{"accountName":"clilc67z5wdqqx2","apiType":"Sql","creationTime":"2022-08-25T06:08:26Z","deletionTime":"2022-08-25T06:15:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"37af2dc0-2aa6-46d3-8e41-cfed196796f9","creationTime":"2022-08-25T06:08:27Z","deletionTime":"2022-08-25T06:15:27Z"}]}},{"name":"90bd51e7-1fe7-4315-87f6-c2407cc951b0","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/90bd51e7-1fe7-4315-87f6-c2407cc951b0","properties":{"accountName":"cliw23t2chyagy6","apiType":"Sql","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"d7cf6cbf-d6a1-4888-a620-41a07f491415","creationTime":"2022-08-25T06:37:47Z","deletionTime":"2022-08-25T06:38:23Z"}]}},{"name":"6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6414bd72-dbe9-4e25-92eb-1d0092c5f5c7","properties":{"accountName":"cli7bonjdjz73wj","apiType":"MongoDB","creationTime":"2022-08-25T06:41:30Z","deletionTime":"2022-08-25T06:47:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"08709870-877a-42ea-a849-210c0fda4ee1","creationTime":"2022-08-25T06:41:31Z","deletionTime":"2022-08-25T06:47:32Z"}]}},{"name":"deff6534-a2b9-404d-b4ba-2e5e22b32bfb","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/deff6534-a2b9-404d-b4ba-2e5e22b32bfb","properties":{"accountName":"cliuis4anv3ycph","apiType":"MongoDB","creationTime":"2022-08-25T07:18:31Z","deletionTime":"2022-08-25T07:26:15Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"dafa935e-6ee4-4d4a-bc1d-c8e609d42a60","creationTime":"2022-08-25T07:18:32Z","deletionTime":"2022-08-25T07:26:15Z"}]}},{"name":"d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d2cd12ee-b49e-4cc0-a92e-56e0a73b8bc8","properties":{"accountName":"cliz5zwclforhva","apiType":"Sql","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5982b098-fba7-49cc-9996-ad4ccb1b3d33","creationTime":"2022-08-25T07:46:50Z","deletionTime":"2022-08-25T07:52:23Z"}]}},{"name":"0ccdf2af-7bda-4f61-b6df-d734c6773db6","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0ccdf2af-7bda-4f61-b6df-d734c6773db6","properties":{"accountName":"cli7c6gulakolbu","apiType":"Sql","creationTime":"2022-08-25T07:35:24Z","deletionTime":"2022-08-25T07:57:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"794c2fc6-6ac1-41ba-990f-bd2c07eb7b9f","creationTime":"2022-08-25T07:35:25Z","deletionTime":"2022-08-25T07:57:18Z"}]}},{"name":"00df9a41-faa9-41a7-b061-6e3e3c923456","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/00df9a41-faa9-41a7-b061-6e3e3c923456","properties":{"accountName":"clib7httb4gycob","apiType":"Sql","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b56217c5-6fa0-4c6d-9809-80899be99f51","creationTime":"2022-08-25T08:19:30Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/8e54bee7-b3b3-4e46-9683-d8be2b0d0ab1","properties":{"accountName":"cliddcu3cjrh6we","apiType":"Sql","creationTime":"2022-08-25T07:57:57Z","deletionTime":"2022-08-25T08:20:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"938063bf-8716-409c-894f-60bb99781705","creationTime":"2022-08-25T07:57:58Z","deletionTime":"2022-08-25T08:20:14Z"}]}},{"name":"68ac0330-103f-43ea-a1de-37c94072a36e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68ac0330-103f-43ea-a1de-37c94072a36e","properties":{"accountName":"clik7kgspjf6bgm","apiType":"Sql","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ff7a4f80-356f-4371-b143-ee999b63eb80","creationTime":"2022-08-25T08:36:01Z","deletionTime":"2022-08-25T08:41:29Z"}]}},{"name":"7bb0479d-7652-434b-af5b-675da5d24d9d","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7bb0479d-7652-434b-af5b-675da5d24d9d","properties":{"accountName":"cligi5y5fvohgv453w5z25icozd6527bpu5ecv4k","apiType":"Sql","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bcac751b-de78-4668-9ef3-adca14decc29","creationTime":"2022-08-25T10:00:01Z","deletionTime":"2022-08-25T10:01:39Z"}]}},{"name":"212beaac-388e-4ff4-981e-f9aef3516b64","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/212beaac-388e-4ff4-981e-f9aef3516b64","properties":{"accountName":"cliren6oja2hpwe","apiType":"Sql","creationTime":"2022-08-25T17:36:41Z","deletionTime":"2022-08-25T17:43:38Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cec6d4eb-e6cc-4e65-bb67-26fde7eabc6e","creationTime":"2022-08-25T17:36:42Z","deletionTime":"2022-08-25T17:43:38Z"}]}},{"name":"045f21c9-c8cc-4ee5-ae4c-c95a481280ce","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/045f21c9-c8cc-4ee5-ae4c-c95a481280ce","properties":{"accountName":"cli642xlhclhjvr","apiType":"MongoDB","creationTime":"2022-08-25T17:48:15Z","deletionTime":"2022-08-25T17:54:51Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"4da784b9-9142-4cd4-a3d4-7b3b941cef0b","creationTime":"2022-08-25T17:48:16Z","deletionTime":"2022-08-25T17:54:51Z"}]}},{"name":"fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/fe1117e2-9e7d-4f48-94db-1c97ee1d6d81","properties":{"accountName":"cli2hngjqysuyrk","apiType":"MongoDB","creationTime":"2022-08-25T17:50:19Z","deletionTime":"2022-08-25T17:55:12Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a756769-7f16-4210-9a86-1b6a51f4ecdf","creationTime":"2022-08-25T17:50:20Z","deletionTime":"2022-08-25T17:55:12Z"}]}},{"name":"6972bff7-7971-4723-ae56-5802b096e6e3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6972bff7-7971-4723-ae56-5802b096e6e3","properties":{"accountName":"clif3lyrerpi54g","apiType":"Sql","creationTime":"2022-08-25T18:01:13Z","deletionTime":"2022-08-25T18:04:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"726278c9-7c2c-4391-bce6-e3387dff8435","creationTime":"2022-08-25T18:01:14Z","deletionTime":"2022-08-25T18:04:46Z"}]}},{"name":"3c46a652-c177-4916-9731-50bffdba55ae","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3c46a652-c177-4916-9731-50bffdba55ae","properties":{"accountName":"clitkbja6qgwko3","apiType":"Sql","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"42ae6741-aa76-4b7e-a5fa-feea888179e3","creationTime":"2022-08-25T18:06:02Z","deletionTime":"2022-08-25T18:07:02Z"}]}},{"name":"3e04e5e9-6a8f-4a78-86e6-18dc643980fd","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3e04e5e9-6a8f-4a78-86e6-18dc643980fd","properties":{"accountName":"clirbh766tdrcuo","apiType":"Sql","creationTime":"2022-08-25T17:51:16Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"472275c5-7d72-489b-8069-0a041e696841","creationTime":"2022-08-25T17:51:17Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"1a2988f6-5f19-452e-a6e1-30b3716c3eff","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1a2988f6-5f19-452e-a6e1-30b3716c3eff","properties":{"accountName":"cliprc22bdv72rz","apiType":"Sql","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab980699-c97f-48a7-ab13-a4c750ad4665","creationTime":"2022-08-25T18:10:32Z","deletionTime":"2022-08-25T18:12:07Z"}]}},{"name":"b2093d64-9617-4f32-9d61-e905534e21da","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b2093d64-9617-4f32-9d61-e905534e21da","properties":{"accountName":"clipyaf3k2czsnx","apiType":"Sql","creationTime":"2022-08-25T18:10:56Z","deletionTime":"2022-08-25T18:16:27Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"cd9e2d6f-ae74-4a83-94de-c5b6c547ea71","creationTime":"2022-08-25T18:10:57Z","deletionTime":"2022-08-25T18:16:27Z"}]}},{"name":"dd296662-d32f-48ef-a55b-10d3cdd7d457","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/dd296662-d32f-48ef-a55b-10d3cdd7d457","properties":{"accountName":"cli2wmbvuvy7xzg","apiType":"Sql","creationTime":"2022-08-25T17:56:15Z","deletionTime":"2022-08-25T18:18:29Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"81a6ec53-ca56-4223-92b0-adeb6231e1f5","creationTime":"2022-08-25T17:56:16Z","deletionTime":"2022-08-25T18:18:29Z"}]}},{"name":"93d672c2-f060-4e22-b8a3-a1db21229e73","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/93d672c2-f060-4e22-b8a3-a1db21229e73","properties":{"accountName":"clij2xvz5zuhpth","apiType":"Sql","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"643a1596-40ff-494d-ac87-7a9f2b53a231","creationTime":"2022-08-25T18:17:54Z","deletionTime":"2022-08-25T18:18:32Z"}]}},{"name":"627d35df-1aff-4d0a-8d71-e7bb3ca16551","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/627d35df-1aff-4d0a-8d71-e7bb3ca16551","properties":{"accountName":"cliyvfzwxgzbt5qcsnarlf2gedbik7kuzpwoqqoz","apiType":"Sql","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7c3790de-2307-4aaf-8ccc-64f2aa7c2032","creationTime":"2022-08-25T18:52:43Z","deletionTime":"2022-08-25T18:53:23Z"}]}},{"name":"9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9dd2e0a4-133c-4fd3-aecd-9bea3b072df3","properties":{"accountName":"cliomvsal633avs","apiType":"MongoDB","creationTime":"2022-09-01T17:22:23Z","deletionTime":"2022-09-01T17:27:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"1ab7c41f-533d-4e8f-b819-6b8753eea8e4","creationTime":"2022-09-01T17:22:24Z","deletionTime":"2022-09-01T17:27:19Z"}]}},{"name":"437aa3e6-8920-42ef-b5df-2c8ee28bfe81","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/437aa3e6-8920-42ef-b5df-2c8ee28bfe81","properties":{"accountName":"clit3zdheluo26r","apiType":"MongoDB","creationTime":"2022-09-01T17:29:41Z","deletionTime":"2022-09-01T17:35:19Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a878da74-6edd-43ad-a08c-f12a2c8b58e9","creationTime":"2022-09-01T17:29:42Z","deletionTime":"2022-09-01T17:35:19Z"}]}},{"name":"055ba6b8-c241-4ca5-bd2a-5905f5782029","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/055ba6b8-c241-4ca5-bd2a-5905f5782029","properties":{"accountName":"cliv6mcsfgjd4ak","apiType":"Sql","creationTime":"2022-09-01T17:42:11Z","deletionTime":"2022-09-01T17:48:46Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"f1c6d0cb-7dac-4d3d-839c-c1967da5d20d","creationTime":"2022-09-01T17:42:12Z","deletionTime":"2022-09-01T17:48:46Z"}]}},{"name":"596ccc7e-6212-4a58-a615-fdef3581a566","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/596ccc7e-6212-4a58-a615-fdef3581a566","properties":{"accountName":"clist343b7kqxgt","apiType":"Sql","creationTime":"2022-09-01T17:32:00Z","deletionTime":"2022-09-01T17:53:03Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"62004e01-add8-49ca-9482-c081d9dad32a","creationTime":"2022-09-01T17:32:01Z","deletionTime":"2022-09-01T17:53:03Z"}]}},{"name":"d4d26f2d-aacb-461d-9674-874533a35927","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d4d26f2d-aacb-461d-9674-874533a35927","properties":{"accountName":"cliim5efmvechgm","apiType":"Sql","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"326ab156-4292-46cd-b265-04b4da16880f","creationTime":"2022-09-01T17:52:15Z","deletionTime":"2022-09-01T17:53:04Z"}]}},{"name":"ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ec0c1f87-2308-46e8-bf6f-6cc59b6302e8","properties":{"accountName":"cli5xjit35t3vmy","apiType":"Sql","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"a26e214a-987d-4956-82e2-29581b698be7","creationTime":"2022-09-01T17:55:35Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"6700db64-9dd4-4e0e-aedf-cc571d2556be","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6700db64-9dd4-4e0e-aedf-cc571d2556be","properties":{"accountName":"cliusb2cpctd3jo","apiType":"Sql","creationTime":"2022-09-01T17:33:21Z","deletionTime":"2022-09-01T17:57:14Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"bb5b12c1-d062-4ade-995f-56f3a5cebb51","creationTime":"2022-09-01T17:33:22Z","deletionTime":"2022-09-01T17:57:14Z"}]}},{"name":"50161594-bab1-4110-bfc3-bb941822226b","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/50161594-bab1-4110-bfc3-bb941822226b","properties":{"accountName":"cli6q2r7sebffac37t5lwk3cepyladzkkldjmxna","apiType":"Sql","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"765a32de-2b34-4333-be94-319a4fd75d2d","creationTime":"2022-09-01T18:02:07Z","deletionTime":"2022-09-01T18:04:13Z"}]}},{"name":"cf42a3c3-c50b-4110-bccf-a27131e4c240","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cf42a3c3-c50b-4110-bccf-a27131e4c240","properties":{"accountName":"cli3zz43bzjjsjy","apiType":"Sql","creationTime":"2022-09-08T17:13:37Z","deletionTime":"2022-09-08T17:20:31Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"836fb615-1694-4bb8-bb26-d4d7191a9826","creationTime":"2022-09-08T17:13:38Z","deletionTime":"2022-09-08T17:20:31Z"}]}},{"name":"3768a794-c2dc-4ed2-ac26-09eb8595b38f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3768a794-c2dc-4ed2-ac26-09eb8595b38f","properties":{"accountName":"cliblp3rryrjgkc","apiType":"MongoDB","creationTime":"2022-09-08T17:17:35Z","deletionTime":"2022-09-08T17:21:18Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9a60fd3d-8d88-4ce2-9b59-cc33ee9bc199","creationTime":"2022-09-08T17:17:36Z","deletionTime":"2022-09-08T17:21:18Z"}]}},{"name":"16c01f3c-6319-4622-b8ef-72f587d939e7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/16c01f3c-6319-4622-b8ef-72f587d939e7","properties":{"accountName":"clib2p6v5nnugvg","apiType":"MongoDB","creationTime":"2022-09-08T17:24:19Z","deletionTime":"2022-09-08T17:29:54Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"ab765683-a955-438f-a9f1-f88e6538f65b","creationTime":"2022-09-08T17:24:20Z","deletionTime":"2022-09-08T17:29:54Z"}]}},{"name":"c7000b77-291f-4d2b-a194-674e0956fb8f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c7000b77-291f-4d2b-a194-674e0956fb8f","properties":{"accountName":"cligri3ik55bve4","apiType":"Sql","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"2aaedea8-ce96-4549-8b59-686affcb1450","creationTime":"2022-09-08T17:42:51Z","deletionTime":"2022-09-08T17:43:33Z"}]}},{"name":"6c67aa75-0d9f-4818-bd33-84fb08b60307","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6c67aa75-0d9f-4818-bd33-84fb08b60307","properties":{"accountName":"clig74xujvvw7fw","apiType":"Sql","creationTime":"2022-09-08T17:38:49Z","deletionTime":"2022-09-08T17:43:36Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"065dc3e7-da03-4320-9923-d98bab3f3a32","creationTime":"2022-09-08T17:38:50Z","deletionTime":"2022-09-08T17:43:36Z"}]}},{"name":"59631687-f4e4-4b07-af3e-555c6e59150e","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/59631687-f4e4-4b07-af3e-555c6e59150e","properties":{"accountName":"cliu5kch5swrzap","apiType":"Sql","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"eed5cfa5-76a9-4da1-8e28-70c1a3746f8a","creationTime":"2022-09-08T17:45:29Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"c21bda24-fae1-44a2-ae1e-cb8fe570eea7","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c21bda24-fae1-44a2-ae1e-cb8fe570eea7","properties":{"accountName":"clihdp4vf36xo2y","apiType":"Sql","creationTime":"2022-09-08T17:25:17Z","deletionTime":"2022-09-08T17:47:01Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b80a35a4-31c0-4bc0-ba5a-61c34833290f","creationTime":"2022-09-08T17:25:18Z","deletionTime":"2022-09-08T17:47:01Z"}]}},{"name":"3aa72b82-66f2-4422-bff1-fcc6398e4872","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3aa72b82-66f2-4422-bff1-fcc6398e4872","properties":{"accountName":"cliiee5ncxczcvm","apiType":"Sql","creationTime":"2022-09-08T17:40:18Z","deletionTime":"2022-09-08T17:47:05Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"5fc01c1b-02f7-4e2c-b66c-cc3b0d0136b5","creationTime":"2022-09-08T17:40:19Z","deletionTime":"2022-09-08T17:47:05Z"}]}},{"name":"cc64273d-9ac3-401b-8364-c9b5c222e16f","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc64273d-9ac3-401b-8364-c9b5c222e16f","properties":{"accountName":"cli44be3onue5e3","apiType":"Sql","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"b046012f-46f1-4076-9422-3e468b13b5bf","creationTime":"2022-09-08T18:01:51Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"7080defb-7912-442c-8740-3474083d8bd1","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/7080defb-7912-442c-8740-3474083d8bd1","properties":{"accountName":"cli6wl3roplqpwr","apiType":"Sql","creationTime":"2022-09-08T17:42:35Z","deletionTime":"2022-09-08T18:02:49Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"fe7a7ee6-e228-44cd-962d-c746cd1aaa0e","creationTime":"2022-09-08T17:42:36Z","deletionTime":"2022-09-08T18:02:49Z"}]}},{"name":"a8165efd-ccef-4c75-aa24-7caf1f3075cc","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a8165efd-ccef-4c75-aa24-7caf1f3075cc","properties":{"accountName":"clidl5m246s5argh5rxu3taw7ov2uioqp2xsyjb4","apiType":"Sql","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"663d7288-f394-4ba9-90ba-e562767e19bf","creationTime":"2022-09-08T18:19:18Z","deletionTime":"2022-09-08T18:20:00Z"}]}},{"name":"04379736-7bb7-49ea-aca7-dadd462cde88","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/04379736-7bb7-49ea-aca7-dadd462cde88","properties":{"accountName":"clithefqeaoirb5","apiType":"Sql","creationTime":"2022-09-19T03:34:01Z","deletionTime":"2022-09-19T03:41:22Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"af10c5cf-527e-4601-9f8a-885bb592a047","creationTime":"2022-09-19T03:34:02Z","deletionTime":"2022-09-19T03:41:22Z"}]}},{"name":"f6a8cecd-67d9-450c-9c05-af3dc4b46117","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f6a8cecd-67d9-450c-9c05-af3dc4b46117","properties":{"accountName":"cli6elql3v7h5g7","apiType":"MongoDB","creationTime":"2022-09-19T03:53:18Z","deletionTime":"2022-09-19T03:58:10Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"16a25cc5-fd89-4c8b-88cb-4bf6a1c49431","creationTime":"2022-09-19T03:53:19Z","deletionTime":"2022-09-19T03:58:10Z"}]}},{"name":"edb07b57-c581-4d66-95e6-334bea0e3b76","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/edb07b57-c581-4d66-95e6-334bea0e3b76","properties":{"accountName":"clici2s34sbznka","apiType":"Sql","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"7084d0e7-b7d5-4b39-b63f-ca1280a89039","creationTime":"2022-09-19T04:03:47Z","deletionTime":"2022-09-19T04:06:45Z"}]}},{"name":"2182ee4a-15c8-4413-ba83-6193a0faa0fe","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2182ee4a-15c8-4413-ba83-6193a0faa0fe","properties":{"accountName":"clig6fq3dxxrsfv","apiType":"MongoDB","creationTime":"2022-09-19T04:19:09Z","deletionTime":"2022-09-19T04:25:43Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"76d0c792-3259-4d4b-ae8c-cdf79308b135","creationTime":"2022-09-19T04:19:10Z","deletionTime":"2022-09-19T04:25:43Z"}]}},{"name":"e0ffece8-dc58-434b-9112-24c36fb6e02a","location":"West
-        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/e0ffece8-dc58-434b-9112-24c36fb6e02a","properties":{"accountName":"clijz3bahnmjsgx","apiType":"Sql","creationTime":"2022-09-19T04:47:52Z","deletionTime":"2022-09-19T04:51:30Z","restorableLocations":[{"locationName":"West
-        US","regionalDatabaseAccountInstanceId":"9de236ba-34bb-47c6-a741-25f91b6ed7cf","creationTime":"2022-09-19T04:47:53Z","deletionTime":"2022-09-19T04:51:30Z"}]}}]}'
+      string: '{"value":[{"name":"22c487b3-d5c7-45de-be94-38fecee66cd3","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/22c487b3-d5c7-45de-be94-38fecee66cd3","properties":{"accountName":"barprod-systemid-sw-1109027095","apiType":"Sql","creationTime":"2022-12-13T19:12:35Z","oldestRestorableTime":"2022-12-13T19:12:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"debbeba6-2699-44df-a689-5e9a867f51e5","creationTime":"2022-12-13T19:12:36Z"}]}},{"name":"2b49ac91-ad60-4807-9b6b-4041645b4f5e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/2b49ac91-ad60-4807-9b6b-4041645b4f5e","properties":{"accountName":"barprod-systemid-sw-1109027095-rl1","apiType":"Sql","creationTime":"2022-12-13T19:33:35Z","oldestRestorableTime":"2022-12-13T19:33:35Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f5bd4a33-9470-4496-a2ba-6d31b52ff4b1","creationTime":"2022-12-13T19:33:35Z"}]}},{"name":"13e27035-3df0-42e7-8048-6d0cbd5c7f80","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/13e27035-3df0-42e7-8048-6d0cbd5c7f80","properties":{"accountName":"barprod-systemid-sw-1305567950","apiType":"Sql","creationTime":"2022-12-13T21:09:30Z","oldestRestorableTime":"2022-12-13T21:09:30Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"fc983ed2-abe6-4914-a686-46bcdc85a54e","creationTime":"2022-12-13T21:09:31Z"}]}},{"name":"a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/a4d1077a-fa34-4bd8-b6c9-f70ac378e2f9","properties":{"accountName":"barprod-systemid-sw-1305567950-rl1","apiType":"Sql","creationTime":"2022-12-13T21:30:58Z","oldestRestorableTime":"2022-12-13T21:30:58Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"2438a28c-af6b-4e7f-9984-6a644cf0e897","creationTime":"2022-12-13T21:30:58Z"}]}},{"name":"84e4a829-6f5a-4ca5-bdc5-86b650e38aea","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/84e4a829-6f5a-4ca5-bdc5-86b650e38aea","properties":{"accountName":"vinh-restore-fail","apiType":"Sql","creationTime":"2022-12-13T22:07:03Z","oldestRestorableTime":"2022-12-13T22:07:03Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"f4eed423-2ade-4121-94a1-22c3aa3f7a17","creationTime":"2022-12-13T22:07:03Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"7e65fe9b-5294-457b-b74f-baca135009e4","creationTime":"2022-12-16T02:16:43Z","deletionTime":"2022-12-21T21:04:26Z"}]}},{"name":"d494b442-7138-4a38-8f78-b301967b497b","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/d494b442-7138-4a38-8f78-b301967b497b","properties":{"accountName":"vinh-restore-fail2","apiType":"Sql","creationTime":"2022-12-13T22:10:55Z","oldestRestorableTime":"2022-12-13T22:10:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"c49dc5ba-6bdb-4470-b8b3-afa33fe3112a","creationTime":"2022-12-13T22:10:55Z"}]}},{"name":"9e46844f-6285-4408-b60f-9de3c6aab0cf","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/9e46844f-6285-4408-b60f-9de3c6aab0cf","properties":{"accountName":"vinh-restore-not-fail3","apiType":"Sql","creationTime":"2022-12-13T23:32:55Z","oldestRestorableTime":"2022-12-13T23:32:55Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"9131c392-b756-489b-aafd-0f9227b15fc6","creationTime":"2022-12-13T23:32:55Z"}]}},{"name":"cda8d0bd-bdb7-4fd6-857f-b7295a59340e","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/cda8d0bd-bdb7-4fd6-857f-b7295a59340e","properties":{"accountName":"barprod-systemid-pr-1524514730","apiType":"Sql","creationTime":"2022-12-13T23:39:49Z","oldestRestorableTime":"2022-12-13T23:39:49Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"1e7ac46b-a449-44fd-a6de-e80658a98410","creationTime":"2022-12-13T23:39:49Z"}]}},{"name":"49c3f2e6-d728-41f9-8dff-257140ec7aa1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/49c3f2e6-d728-41f9-8dff-257140ec7aa1","properties":{"accountName":"barprod-systemid-sw-1525116479","apiType":"Sql","creationTime":"2022-12-13T23:28:39Z","oldestRestorableTime":"2022-12-13T23:28:39Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"6ab357f4-901f-4b4d-b01f-25fd52c525d7","creationTime":"2022-12-13T23:28:40Z"}]}},{"name":"24dd6ee0-d69d-4f3b-b14c-319245f75a1a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/24dd6ee0-d69d-4f3b-b14c-319245f75a1a","properties":{"accountName":"barprod-systemid-sw-1526492563","apiType":"Sql","creationTime":"2022-12-13T23:30:14Z","oldestRestorableTime":"2022-12-13T23:30:14Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"d91ab187-9143-4584-9a21-e7ffab1a8b51","creationTime":"2022-12-13T23:30:15Z"}]}},{"name":"f6c79664-838d-45f6-82dc-58dd1ea6aa69","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/f6c79664-838d-45f6-82dc-58dd1ea6aa69","properties":{"accountName":"barprod-systemid-sw-1526492563-rl1","apiType":"Sql","creationTime":"2022-12-13T23:51:46Z","oldestRestorableTime":"2022-12-13T23:51:46Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"550716f8-9a42-4512-bd9f-d8a864df27c2","creationTime":"2022-12-13T23:51:46Z"}]}},{"name":"db48bc7b-8dae-4fcd-a131-b3220fac8b0a","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/db48bc7b-8dae-4fcd-a131-b3220fac8b0a","properties":{"accountName":"barprod-systemid-sw-1525116479-rl1","apiType":"Sql","creationTime":"2022-12-13T23:54:20Z","oldestRestorableTime":"2022-12-13T23:54:20Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"a416d1a0-a506-4baa-b833-460653ff60c4","creationTime":"2022-12-13T23:54:20Z"}]}},{"name":"3c95a287-aaeb-464e-a79d-cad370f919b1","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/3c95a287-aaeb-464e-a79d-cad370f919b1","properties":{"accountName":"vinh-restore-fail-2identities","apiType":"Sql","creationTime":"2022-12-16T01:32:31Z","oldestRestorableTime":"2022-12-16T01:32:31Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"5dc84958-10f0-4c44-b51d-b860e41c4801","creationTime":"2022-12-16T01:32:31Z"}]}},{"name":"74662748-2ad4-4ec3-b748-21558c8797ad","location":"West
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westcentralus/restorableDatabaseAccounts/74662748-2ad4-4ec3-b748-21558c8797ad","properties":{"accountName":"barprod-systemid-sw-1335082832","apiType":"Sql","creationTime":"2022-12-13T21:38:28Z","deletionTime":"2022-12-13T21:41:57Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"89e59323-fae6-4ed9-93b4-8e643a682c3f","creationTime":"2022-12-13T21:38:29Z","deletionTime":"2022-12-13T21:41:57Z"}]}},{"name":"d88e6a3c-687d-4990-a516-da739070bf81","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/d88e6a3c-687d-4990-a516-da739070bf81","properties":{"accountName":"kal-continuous7","apiType":"Sql","creationTime":"2022-06-07T20:09:38Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"09904716-38a7-46f3-bf7e-486b79c84510","creationTime":"2022-06-07T20:09:39Z"}]}},{"name":"4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/4dcbac33-7fe1-498b-8a8d-165bbdc6ede5","properties":{"accountName":"kal-continuous7-restored1","apiType":"Sql","creationTime":"2022-06-10T19:23:44Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"5075a7fd-3ed4-415d-ac3d-b4391350887f","creationTime":"2022-06-10T19:23:44Z"}]}},{"name":"82a1f64c-cea7-473e-827b-6fde3e1debde","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/82a1f64c-cea7-473e-827b-6fde3e1debde","properties":{"accountName":"kal-continuous7-demorestore","apiType":"Sql","creationTime":"2022-06-10T21:20:46Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"de3fa8f6-f2b3-487f-acc1-ea8850240997","creationTime":"2022-06-10T21:20:46Z"}]}},{"name":"fc911c8e-ddac-45d1-a0e6-2217c593bb7e","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/fc911c8e-ddac-45d1-a0e6-2217c593bb7e","properties":{"accountName":"test-billing-continuous30","apiType":"Sql","creationTime":"2022-07-28T21:54:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"d0605cd3-ba26-434e-acdd-61b7f64fb1e0","creationTime":"2022-07-28T21:54:21Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ae751a67-5fdf-4f38-bcdd-4f6cee0cf44f","creationTime":"2022-08-31T21:09:14Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"15b05286-8b06-430f-bb5e-c192eb6a98c9","creationTime":"2022-08-31T22:24:21Z"}]}},{"name":"e84733a9-ee18-456c-b12b-1d37e542608b","location":"North
+        Central US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/northcentralus/restorableDatabaseAccounts/e84733a9-ee18-456c-b12b-1d37e542608b","properties":{"accountName":"new-cosmsosdb-account","apiType":"Sql","creationTime":"2022-08-31T20:34:40Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"af27e000-3eb9-45db-ab59-d21f99e3826c","creationTime":"2022-08-31T20:34:40Z"}]}},{"name":"2414c009-8022-442c-9ab6-81c276eb2a99","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/2414c009-8022-442c-9ab6-81c276eb2a99","properties":{"accountName":"vinh-periodic","apiType":"Sql","creationTime":"2022-06-06T19:53:54Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"20f9a62e-6ab7-4bc7-b537-d43eb766c2e4","creationTime":"2022-06-06T19:53:54Z"}]}},{"name":"5716280d-381e-4045-b936-d0edbfc7317b","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/5716280d-381e-4045-b936-d0edbfc7317b","properties":{"accountName":"databaseaccount9284","apiType":"Sql","creationTime":"2022-09-20T05:50:05Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"8c0d58ba-f16e-42f8-8277-0f7f5657be62","creationTime":"2022-09-20T05:50:06Z"}]}},{"name":"34a9cb27-53a5-4143-9af7-810285110075","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/34a9cb27-53a5-4143-9af7-810285110075","properties":{"accountName":"databaseaccount6234","apiType":"Sql","creationTime":"2022-09-20T09:04:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"87bf458d-04cf-44cd-9b49-b4776e535776","creationTime":"2022-09-20T09:04:23Z"}]}},{"name":"0bf6dfd3-45bb-4318-907a-fcdb00f35b31","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/0bf6dfd3-45bb-4318-907a-fcdb00f35b31","properties":{"accountName":"databaseaccount8251","apiType":"Sql","creationTime":"2022-09-20T16:29:44Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"e40ce1fd-96a4-4d23-9173-12352893944a","creationTime":"2022-09-20T16:29:45Z"}]}},{"name":"4c06cd3d-c6dc-43fe-999a-fb725a80184f","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4c06cd3d-c6dc-43fe-999a-fb725a80184f","properties":{"accountName":"amisiprodmultiregionmongopitracc","apiType":"MongoDB","creationTime":"2022-10-28T20:59:06Z","deletionTime":"2022-12-01T19:01:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Canada
+        Central","regionalDatabaseAccountInstanceId":"8a27bf59-48ca-4ffe-bdbe-0eb6228a3e30","creationTime":"2022-10-28T21:27:29Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7a829864-055e-4fa2-9ace-ccf1a872635b","creationTime":"2022-10-28T21:23:39Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"3cd99369-573c-48af-a156-2242c6d64d22","creationTime":"2022-10-28T21:19:33Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"b324c6a4-f540-4fce-a04f-ee2b5a7640da","creationTime":"2022-10-28T21:16:24Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"f0dd9a30-557a-490a-afbf-78837dd6a4c5","creationTime":"2022-10-28T21:13:03Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"82157827-02bb-45d1-b7ca-e7f5e03f7e28","creationTime":"2022-10-28T21:08:48Z","deletionTime":"2022-12-01T19:01:22Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"74bd29fc-047d-42a5-b86b-d6011d1ba2c3","creationTime":"2022-10-28T20:59:07Z","deletionTime":"2022-12-01T19:01:22Z"}]}},{"name":"e9b38548-f608-4e03-992e-b0d994ccb5f8","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/e9b38548-f608-4e03-992e-b0d994ccb5f8","properties":{"accountName":"amisiprodmultiregionpitracc","apiType":"Sql","creationTime":"2022-10-28T20:51:18Z","deletionTime":"2022-12-01T19:01:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"North
+        Europe","regionalDatabaseAccountInstanceId":"ea5f6334-78f1-472c-9b81-d9d275fca1c4","creationTime":"2022-11-06T01:56:07Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US 3","regionalDatabaseAccountInstanceId":"cd9965f3-5142-4e5f-9fc4-ffa8a54c516d","creationTime":"2022-11-06T01:50:52Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"ecfdc27e-3d85-4d3b-b603-37f0bc87e1f4","creationTime":"2022-10-28T21:16:23Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2e34d6a9-58a3-4e20-9d71-1ab3ff745b3c","creationTime":"2022-10-28T21:11:19Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"West
+        Central US","regionalDatabaseAccountInstanceId":"dbb767b2-f3d5-4475-8c99-464e9779fec4","creationTime":"2022-10-28T21:08:44Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"11f4f056-5005-40c8-bac4-7cd287d38352","creationTime":"2022-10-28T21:02:42Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8f67fcd6-5cc1-47fa-a659-3ff3dbce8aa8","creationTime":"2022-10-28T21:00:30Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7215599-788f-4b71-b187-6642ce454d8e","creationTime":"2022-10-28T20:58:15Z","deletionTime":"2022-12-01T19:01:23Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"29a61891-7020-46d4-a7e1-77a2ff62d698","creationTime":"2022-10-28T20:51:19Z","deletionTime":"2022-12-01T19:01:23Z"}]}},{"name":"4d4f7eee-3fc3-4540-8010-df63b41a33f5","location":"Central
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/centralus/restorableDatabaseAccounts/4d4f7eee-3fc3-4540-8010-df63b41a33f5","properties":{"accountName":"amisitestacc","apiType":"Sql","creationTime":"2022-12-02T19:44:35Z","deletionTime":"2022-12-06T17:29:19Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"197b8ddd-4b58-4932-ade9-2c81cc6eb7e6","creationTime":"2022-12-02T19:51:15Z","deletionTime":"2022-12-06T17:29:19Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"257c8d62-dc5c-4311-aa66-fb29aa45fdd7","creationTime":"2022-12-02T19:44:36Z","deletionTime":"2022-12-06T17:29:19Z"}]}},{"name":"0be166a4-3d75-478d-b427-7b0d05fa800b","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/0be166a4-3d75-478d-b427-7b0d05fa800b","properties":{"accountName":"databaseaccount2058","apiType":"MongoDB","creationTime":"2022-04-14T02:10:48Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9d4cc1c0-9c27-4c3e-bc20-7da1e6a7bfed","creationTime":"2022-04-14T02:10:49Z"}]}},{"name":"fce807d5-4358-4ea1-8130-0439181f6be0","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fce807d5-4358-4ea1-8130-0439181f6be0","properties":{"accountName":"vinh-demo-periodic","apiType":"Sql","creationTime":"2022-05-26T04:53:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"cff0fc89-a51f-4cd4-940c-00fe4222616d","creationTime":"2022-05-26T04:53:41Z"}]}},{"name":"fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/fd507b20-6cc3-4138-b3c0-c8a9b406ab9c","properties":{"accountName":"vinh-demo-continous30","apiType":"Sql","creationTime":"2022-05-26T03:29:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"9923c156-acee-40b7-a90a-8d33c6c05006","creationTime":"2022-05-26T03:29:42Z"}]}},{"name":"9177692a-0db9-4c0c-af1d-af0310418b43","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/9177692a-0db9-4c0c-af1d-af0310418b43","properties":{"accountName":"vinh-demo-continous7","apiType":"Sql","creationTime":"2022-05-26T04:14:49Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"d6119954-fcde-4d83-af4e-2a0768ac1f33","creationTime":"2022-05-26T04:14:50Z"}]}},{"name":"957160c2-96d5-4ce2-843c-1d2977e952ec","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/957160c2-96d5-4ce2-843c-1d2977e952ec","properties":{"accountName":"vinh-demo-periodic2","apiType":"Sql","creationTime":"2022-05-26T18:12:07Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"3e0be6bc-420e-4f35-b7d5-f01a21069d18","creationTime":"2022-05-26T18:12:07Z"}]}},{"name":"3c7c638a-a7a0-4bb9-a285-946a6f55a57f","location":"West
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus2/restorableDatabaseAccounts/3c7c638a-a7a0-4bb9-a285-946a6f55a57f","properties":{"accountName":"vinh-demo-continous7-2","apiType":"Sql","creationTime":"2022-05-26T18:05:53Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"02d51bf7-eca0-424e-8080-7282b03118a7","creationTime":"2022-05-26T18:05:53Z"}]}},{"name":"09271ecb-ce2a-476f-8d30-15f582e31c9d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/09271ecb-ce2a-476f-8d30-15f582e31c9d","properties":{"accountName":"cliseqmx4qwqgz6","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:08Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"84b71b06-0aa1-4ced-853e-1c1437e69583","creationTime":"2022-05-03T22:53:09Z"}]}},{"name":"cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/cf13ea81-3bff-4da1-bfea-5a4ef0cd989d","properties":{"accountName":"cligwsozpx4fztp","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"fe50db55-0b1f-46c9-98f7-b671c7f420be","creationTime":"2022-05-03T22:53:08Z"}]}},{"name":"a3a54e66-571a-47c3-99b5-ecccb9d250d0","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a3a54e66-571a-47c3-99b5-ecccb9d250d0","properties":{"accountName":"cli7byqi7kruftb","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-03T22:53:26Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"74db88cc-62ab-4b73-9df4-fcb3f9723949","creationTime":"2022-05-03T22:53:26Z"}]}},{"name":"5773970a-8e87-4d97-af36-9e8819b2edc1","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/5773970a-8e87-4d97-af36-9e8819b2edc1","properties":{"accountName":"climfmg5nu4yiqu","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"6c63be1d-c39c-45f9-9268-0b7aefec313e","creationTime":"2022-05-04T00:29:59Z"}]}},{"name":"00dd2ecf-88dd-4580-9635-0591bf649b4e","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/00dd2ecf-88dd-4580-9635-0591bf649b4e","properties":{"accountName":"cliknjdofhusdwk","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:29:57Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b6a5f3e2-52e5-43fc-a506-96eb81bd0f0a","creationTime":"2022-05-04T00:29:58Z"}]}},{"name":"0fd004bd-843d-4e7c-a7ea-027b73a174ee","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0fd004bd-843d-4e7c-a7ea-027b73a174ee","properties":{"accountName":"clidawljzz35z4a","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:30:09Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"9bc6084d-a7bb-4bcd-82c0-20586810b44d","creationTime":"2022-05-04T00:30:10Z"}]}},{"name":"d90cd299-302b-4601-b43d-191e05d95379","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/d90cd299-302b-4601-b43d-191e05d95379","properties":{"accountName":"clix4bwfn2cmc2p","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:36:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"bfff1b0c-efa8-489d-96bc-84beaa3beba8","creationTime":"2022-05-04T00:36:51Z"}]}},{"name":"25d83fe9-1d12-40fd-b71d-1286c2f163f4","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/25d83fe9-1d12-40fd-b71d-1286c2f163f4","properties":{"accountName":"clizdh3madpx4fz","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:35:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"a786986a-aa71-44a9-a1bf-8d26196225c9","creationTime":"2022-05-04T00:35:59Z"}]}},{"name":"64f832dc-e297-416f-a99f-fbb973cb1b19","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/64f832dc-e297-416f-a99f-fbb973cb1b19","properties":{"accountName":"clir3r76qsku7p4","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:42:05Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"511ace38-c070-4058-82e0-206c1a2c2cd6","creationTime":"2022-05-04T00:42:06Z"}]}},{"name":"770893c0-75df-420a-92e4-efe9cd5bdb1f","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/770893c0-75df-420a-92e4-efe9cd5bdb1f","properties":{"accountName":"clilml2rt6i6j2n","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-04T00:38:58Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"c552a323-d13d-4c6a-ba5d-2959641d008f","creationTime":"2022-05-04T00:38:59Z"}]}},{"name":"98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/98e5e8d7-d769-465a-a7ad-8ab8d7aafbec","properties":{"accountName":"climmubb2c6smaj","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:16:17Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"61ffdc8c-237f-4a96-8272-cdd0c48e9500","creationTime":"2022-05-17T06:16:19Z"}]}},{"name":"0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/0d6fcf9a-5c13-437f-b85a-bfa6fe1675be","properties":{"accountName":"clijocmuqf3f3f5","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:17:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"ea2fd688-28a1-4ca4-91f5-e5ed61c2c14a","creationTime":"2022-05-17T06:17:29Z"}]}},{"name":"a7bcd684-9cff-44bc-9d16-f99ceae2c227","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/a7bcd684-9cff-44bc-9d16-f99ceae2c227","properties":{"accountName":"cliluyq2or6ph3u","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T06:19:35Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"3c56de8c-15d7-4356-b392-86fc2d5f6bbe","creationTime":"2022-05-17T06:19:36Z"}]}},{"name":"2054589d-df7b-44d5-a288-dec641442645","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/2054589d-df7b-44d5-a288-dec641442645","properties":{"accountName":"cli3rjdzuahfe7f","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:28:04Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"25705f32-0d8f-4779-8a06-e707099a5c8e","creationTime":"2022-05-17T17:28:05Z"}]}},{"name":"c8bfa28a-38ae-4260-ba27-52b2c0429eba","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c8bfa28a-38ae-4260-ba27-52b2c0429eba","properties":{"accountName":"clii7cy4lxe4njd","apiType":"Gremlin,
+        Sql","creationTime":"2022-05-17T17:52:27Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d974d441-d147-47c1-93a1-622d01257fc1","creationTime":"2022-05-17T17:52:27Z"}]}},{"name":"c0c50529-2b86-47ba-b50a-5817e24a3e11","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/c0c50529-2b86-47ba-b50a-5817e24a3e11","properties":{"accountName":"cli-continuous30-hqdvwklz","apiType":"Sql","creationTime":"2022-05-17T17:43:41Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"d7498e86-8f05-42bd-81bd-97e8af92b33c","creationTime":"2022-05-17T17:43:41Z"}]}},{"name":"9346b32f-e684-4b5e-9254-c638f28d0142","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/9346b32f-e684-4b5e-9254-c638f28d0142","properties":{"accountName":"clifqivpoiuqvwt","apiType":"Gremlin,
+        Sql","creationTime":"2022-08-10T23:38:56Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"2f629714-b2d1-49b4-aeba-fc5e6792074e","creationTime":"2022-08-10T23:38:58Z"}]}},{"name":"026c274c-c0cf-446d-a357-8791eadaa88a","location":"East
+        US 2","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus2/restorableDatabaseAccounts/026c274c-c0cf-446d-a357-8791eadaa88a","properties":{"accountName":"clisa25sp6jxute","apiType":"MongoDB","creationTime":"2022-08-10T23:39:13Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"b56fa059-22bb-441a-9daa-d2b2c04eab78","creationTime":"2022-08-10T23:39:15Z"}]}},{"name":"f4004a76-8173-4d36-9590-6090cce37a4d","location":"West
+        Europe","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westeurope/restorableDatabaseAccounts/f4004a76-8173-4d36-9590-6090cce37a4d","properties":{"accountName":"aholdtest","apiType":"MongoDB","creationTime":"2021-07-01T19:34:24Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        Europe","regionalDatabaseAccountInstanceId":"f7a9416f-25a2-45fd-902d-f3679e08854e","creationTime":"2021-07-01T19:34:25Z"}]}},{"name":"3564d9f8-5f2d-4d00-a66f-5d370d970371","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3564d9f8-5f2d-4d00-a66f-5d370d970371","properties":{"accountName":"targetacct112","apiType":"Sql","creationTime":"2021-03-01T10:33:41Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2eb33e65-1263-4a25-a18a-e7a85875f2a8","creationTime":"2021-03-01T10:33:41Z"}]}},{"name":"74ebfb99-1914-4ea9-b802-736b5bda12a7","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/74ebfb99-1914-4ea9-b802-736b5bda12a7","properties":{"accountName":"pitrmongotest","apiType":"MongoDB","creationTime":"2020-10-01T17:27:22Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"73ef95f2-a338-4afc-8bb2-6fc3b0071d58","creationTime":"2020-10-01T17:27:23Z"}]}},{"name":"a081024d-5e38-45c1-b1cb-9c99552d42b3","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a081024d-5e38-45c1-b1cb-9c99552d42b3","properties":{"accountName":"pitrmongowithsnapshots","apiType":"MongoDB","creationTime":"2021-01-07T19:45:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cef7a5af-c690-49cd-b661-53f9241552bf","creationTime":"2021-01-07T19:45:07Z"}]}},{"name":"36d321ce-5c39-4d66-9347-47beebff1142","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/36d321ce-5c39-4d66-9347-47beebff1142","properties":{"accountName":"test0319-r1","apiType":"Sql","creationTime":"2021-07-07T21:28:13Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"bf97db02-ef6b-4af0-9a5e-3d4ef9f1d5de","creationTime":"2021-07-07T21:28:13Z"},{"locationName":"West
+        US 2","regionalDatabaseAccountInstanceId":"225506b6-641c-47a5-b7a4-2fa096d68535","creationTime":"2021-07-07T21:28:13Z"}]}},{"name":"1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1e2bec8e-adcc-4c5a-aa5b-82091d6c8a37","properties":{"accountName":"pitracctdemo2","apiType":"Sql","creationTime":"2020-08-11T02:34:23Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7419408f-e6af-4596-a76b-c31ca62a54ca","creationTime":"2020-08-11T02:34:24Z"}]}},{"name":"b4c688c1-2ea7-477e-b994-4affe5d3ea35","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4c688c1-2ea7-477e-b994-4affe5d3ea35","properties":{"accountName":"ptr-target","apiType":"Sql","creationTime":"2021-01-05T22:25:24Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1f68340e-49a4-45df-9a2a-804cd8ab1795","creationTime":"2021-01-05T22:25:24Z"}]}},{"name":"9905e7ca-6f2d-4b24-a4c5-8e7529036a74","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/9905e7ca-6f2d-4b24-a4c5-8e7529036a74","properties":{"accountName":"pitrmongotest-restore","apiType":"MongoDB","creationTime":"2020-10-01T21:24:45Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75c41286-d7f2-4594-b9f2-87f6c9843cf8","creationTime":"2020-10-01T21:24:45Z"}]}},{"name":"6fd844b3-71af-4e89-9b9d-f829945272bf","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/6fd844b3-71af-4e89-9b9d-f829945272bf","properties":{"accountName":"pitrdemo1015","apiType":"Sql","creationTime":"2020-10-15T17:28:59Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"af26f717-b6ff-4eac-864c-17e759891ae8","creationTime":"2020-10-15T17:29:00Z"}]}},{"name":"3f392004-9f83-4ae9-ac1c-fa5f6542f245","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3f392004-9f83-4ae9-ac1c-fa5f6542f245","properties":{"accountName":"pitrdemorestored1015","apiType":"Sql","creationTime":"2020-10-15T17:37:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2f4857ad-25c3-4e2f-883a-abe35c5f5e0c","creationTime":"2020-10-15T17:37:20Z"}]}},{"name":"23e99a35-cd36-4df4-9614-f767a03b9995","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/23e99a35-cd36-4df4-9614-f767a03b9995","properties":{"accountName":"subbannageeta","apiType":"Sql","creationTime":"2020-08-08T01:04:53Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"30701557-ecf8-43ce-8810-2c8be01dccf9","creationTime":"2020-08-08T01:04:53Z"},{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"8283b088-b67d-4975-bfbe-0705e3e7a599","creationTime":"2020-08-08T01:15:44Z"}]}},{"name":"afe6a47d-1fbd-41e1-992b-db16beeeae3c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/afe6a47d-1fbd-41e1-992b-db16beeeae3c","properties":{"accountName":"scottkirill","apiType":"Sql","creationTime":"2021-04-15T17:21:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"e3dcb79a-b56a-4dff-9f8e-76a29285e724","creationTime":"2021-04-15T17:21:20Z"}]}},{"name":"01c9a078-6ca2-43fd-92c7-632167c86590","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01c9a078-6ca2-43fd-92c7-632167c86590","properties":{"accountName":"test0319-pitr-r1","apiType":"Sql","creationTime":"2021-07-07T21:54:07Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1074b897-ee89-466c-8a35-a1e695d7f3b9","creationTime":"2021-07-07T21:54:07Z"}]}},{"name":"a925da4f-b83a-434a-a3fc-b07d85f08211","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/a925da4f-b83a-434a-a3fc-b07d85f08211","properties":{"accountName":"vinhperiodic","apiType":"Sql","creationTime":"2021-09-24T19:11:18Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"75cf60fb-0d91-4e97-9219-f1d8c3464c5b","creationTime":"2021-09-24T19:11:18Z"}]}},{"name":"35b64b76-2e55-4fa5-a1de-724c60f5deca","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/35b64b76-2e55-4fa5-a1de-724c60f5deca","properties":{"accountName":"onboardingtestaccount0124","apiType":"Sql","creationTime":"2022-01-24T20:24:43Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6621e19d-f0d1-48f0-a767-bd5ec0c0c1cf","creationTime":"2022-01-24T20:24:44Z"}]}},{"name":"3a8ddfcb-1b82-47f3-9577-971315b7427f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3a8ddfcb-1b82-47f3-9577-971315b7427f","properties":{"accountName":"onboardingtestaccount0124-restored","apiType":"Sql","creationTime":"2022-01-24T20:48:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0cfd50fd-bb27-4b8f-9123-20b438a41cb1","creationTime":"2022-01-24T20:48:23Z"}]}},{"name":"01652628-d4ef-449d-846e-38e8250f0b9a","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/01652628-d4ef-449d-846e-38e8250f0b9a","properties":{"accountName":"vinh-table2-restore","apiType":"Table,
+        Sql","creationTime":"2022-04-07T00:48:08Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8ca19196-24d1-4153-b5ee-d879baa33be6","creationTime":"2022-04-07T00:48:08Z"}]}},{"name":"4b754475-3b23-4485-9205-87ac1661af13","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/4b754475-3b23-4485-9205-87ac1661af13","properties":{"accountName":"vinhpitr30-cli","apiType":"Sql","creationTime":"2022-04-29T23:50:20Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"94b37f83-7256-4645-8cbb-72b101f7a0a1","creationTime":"2022-04-29T23:50:21Z"}]}},{"name":"ce240906-61b1-41c3-a54c-bd90e3d8ec70","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ce240906-61b1-41c3-a54c-bd90e3d8ec70","properties":{"accountName":"vinhperiodic3-cli","apiType":"Sql","creationTime":"2022-06-03T17:21:23Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"2afbd7a9-dcda-4918-9f95-12c08764ac49","creationTime":"2022-06-03T17:21:23Z"}]}},{"name":"023add2e-531e-4574-a7df-4d09c97d548d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/023add2e-531e-4574-a7df-4d09c97d548d","properties":{"accountName":"vinh-pitr7-portal","apiType":"Sql","creationTime":"2022-05-31T19:24:32Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"46e03f50-a458-4cb9-8b02-dbf1b7677291","creationTime":"2022-05-31T19:24:34Z"}]}},{"name":"b67f7b8c-2b1b-417d-833d-1e3e393b192c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b67f7b8c-2b1b-417d-833d-1e3e393b192c","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7","apiType":"Sql","creationTime":"2022-05-31T23:36:11Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"5e6569c6-8716-4984-bf16-74085c75c705","creationTime":"2022-05-31T23:36:11Z"}]}},{"name":"d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d69f8bdc-b00e-43f3-99b1-9ffac0a1b6bc","properties":{"accountName":"vinh-periodic-portal-tobemigrated-to-7-porta","apiType":"Sql","creationTime":"2022-06-03T18:42:58Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"8a8401fa-5297-4189-ba47-a7b172ea489b","creationTime":"2022-06-03T18:42:58Z"}]}},{"name":"3808b68e-7cae-4b91-901b-e29b35b311be","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3808b68e-7cae-4b91-901b-e29b35b311be","properties":{"accountName":"vinh-periodic-again","apiType":"Sql","creationTime":"2022-06-10T20:01:48Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"a519926d-1463-4af1-ba30-a1b6ef5d3989","creationTime":"2022-06-10T20:01:48Z"}]}},{"name":"cc09ab90-3342-4aa9-a95d-3f6677cfd792","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/cc09ab90-3342-4aa9-a95d-3f6677cfd792","properties":{"accountName":"vinh-periodic-again2","apiType":"Sql","creationTime":"2022-06-10T23:57:37Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"b8bed17e-e976-498a-98ef-02b76476dead","creationTime":"2022-06-10T23:57:37Z"}]}},{"name":"ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ab685c1f-be91-4cf0-89bb-c7c64a0aebf6","properties":{"accountName":"sql-continuous30","apiType":"Sql","creationTime":"2022-07-07T19:46:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"78917820-b4ec-422e-b2c0-248a900c3709","creationTime":"2022-07-07T19:46:29Z"}]}},{"name":"68a9778b-299a-42b5-8548-5628d7dea4ac","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/68a9778b-299a-42b5-8548-5628d7dea4ac","properties":{"accountName":"p2pitr-03","apiType":"Sql","creationTime":"2022-07-21T00:54:31Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"7415e27e-72db-4607-9df4-1018a72bd87b","creationTime":"2022-07-21T00:54:31Z"}]}},{"name":"83b9ed65-b665-45e6-b06f-baf9b0205304","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/83b9ed65-b665-45e6-b06f-baf9b0205304","properties":{"accountName":"vinh-gremlin-again","apiType":"Gremlin,
+        Sql","creationTime":"2022-07-28T01:55:28Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"9df9dde5-97a0-4404-9f07-31997cd4b8b4","creationTime":"2022-07-28T01:55:28Z"}]}},{"name":"df774a43-6e6f-4725-82d0-67c18c69a906","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/df774a43-6e6f-4725-82d0-67c18c69a906","properties":{"accountName":"vinh-table-tennis-cli-0190","apiType":"Table,
+        Sql","creationTime":"2022-08-11T05:19:28Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1bc9461e-3e52-4108-90ac-a99375fc0e81","creationTime":"2022-08-11T05:19:28Z"}]}},{"name":"c85c88ec-eaa1-441b-a6cb-0c099592b07f","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c85c88ec-eaa1-441b-a6cb-0c099592b07f","properties":{"accountName":"table-continuous7","apiType":"Table,
+        Sql","creationTime":"2022-08-23T23:06:53Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"564a3256-9f90-4c2d-af6c-4ea89e057f5d","creationTime":"2022-08-23T23:06:54Z"}]}},{"name":"efb6f20c-f187-4fed-ad82-af21b6930a6b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/efb6f20c-f187-4fed-ad82-af21b6930a6b","properties":{"accountName":"cliudmzxkhidd6w","apiType":"MongoDB","creationTime":"2022-09-27T06:21:10Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"5482ec4b-0d8b-4008-81bb-c2c79aa88df2","creationTime":"2022-09-27T06:21:11Z"}]}},{"name":"1cb0c196-c10e-424b-8da7-c7840cee6ecd","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/1cb0c196-c10e-424b-8da7-c7840cee6ecd","properties":{"accountName":"clircty6r4uaciq","apiType":"Sql","creationTime":"2022-09-27T16:01:47Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"b815d6b9-dd1b-4dc5-8ec0-ab8083591f7d","creationTime":"2022-09-27T16:01:48Z"}]}},{"name":"f8c9b302-e047-4f58-b920-fd92e5fbaa3d","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/f8c9b302-e047-4f58-b920-fd92e5fbaa3d","properties":{"accountName":"ddhamothsqlpitracc","apiType":"Sql","creationTime":"2022-10-12T07:15:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"936e589a-70ad-4853-b983-64629561b40c","creationTime":"2022-10-12T07:15:51Z"}]}},{"name":"ca7a5371-47b2-4ae2-b0a4-307fb80273fb","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/ca7a5371-47b2-4ae2-b0a4-307fb80273fb","properties":{"accountName":"ddhamothmongopitracc","apiType":"MongoDB","creationTime":"2022-10-12T07:18:54Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"ce33f178-92b2-42a4-9b0e-5aed43d00f6d","creationTime":"2022-10-12T07:18:55Z"}]}},{"name":"847ea1b0-fe40-404a-a5e1-e32e7e0ea588","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/847ea1b0-fe40-404a-a5e1-e32e7e0ea588","properties":{"accountName":"dsapaligadbkeytest","apiType":"Sql","creationTime":"2022-10-27T16:53:54Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"c0d16b9e-d2b7-4350-969d-9ed321868f1f","creationTime":"2022-10-27T16:53:56Z"}]}},{"name":"b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/b4818c5d-d2d7-4a8f-bde1-8f3601d20a55","properties":{"accountName":"dsapaliga-rcg-migrationtest","apiType":"Sql","creationTime":"2022-11-15T16:10:18Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"86b7955b-e750-4bcf-b931-16164d11cd62","creationTime":"2022-11-15T16:10:18Z"}]}},{"name":"3bd6c3ea-33e5-49a7-b67f-be767d228c41","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/3bd6c3ea-33e5-49a7-b67f-be767d228c41","properties":{"accountName":"ddhamothpitrsqlacc2","apiType":"Sql","creationTime":"2022-11-15T21:30:17Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"00d5a7da-4291-4ea6-8c30-c0c9cdb954fc","creationTime":"2022-11-15T21:30:18Z"}]}},{"name":"019422e0-378d-4191-b142-4f23fd0c1d0c","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/019422e0-378d-4191-b142-4f23fd0c1d0c","properties":{"accountName":"vinkumsql","apiType":"Sql","creationTime":"2022-12-06T19:35:15Z","oldestRestorableTime":"2022-12-06T19:35:15Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"6f8e2ead-8114-4853-b60f-30b6b0d8e200","creationTime":"2022-12-06T19:35:16Z"}]}},{"name":"d524b3ab-15dc-4d7e-a233-61f1f2fd0194","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d524b3ab-15dc-4d7e-a233-61f1f2fd0194","properties":{"accountName":"dsapaliga-restore-test","apiType":"Sql","creationTime":"2022-12-08T21:21:36Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"82b01793-5308-4cfe-b0a5-0f04cfe54847","creationTime":"2022-12-08T21:21:36Z"}]}},{"name":"d5e8f5f9-66d2-4417-b752-9c46e28b78f5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d5e8f5f9-66d2-4417-b752-9c46e28b78f5","properties":{"accountName":"dsapaliga-monitor-test2","apiType":"Sql","creationTime":"2022-12-09T16:57:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"cb1bb6e0-898f-4c43-b69f-932bd87a74ac","creationTime":"2022-12-09T16:57:51Z"}]}},{"name":"75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/75f0ac0c-06d2-4c6b-8eca-1e8c6fae3dff","properties":{"accountName":"nikhiltestmig","apiType":"Sql","creationTime":"2022-12-15T19:23:56Z","oldestRestorableTime":"2022-12-15T19:23:56Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"785f9939-a7bc-4696-bdd2-d8e2e2f55d72","creationTime":"2022-12-15T19:23:56Z"},{"locationName":"East
+        US 2","regionalDatabaseAccountInstanceId":"efe37686-f44b-4a3e-8955-40f46c101f47","creationTime":"2022-12-19T06:05:45Z"}]}},{"name":"2bf685e1-2106-4a9c-a218-7f5e49d008a5","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/2bf685e1-2106-4a9c-a218-7f5e49d008a5","properties":{"accountName":"nikhil-multi-region-pitr","apiType":"Sql","creationTime":"2022-12-19T06:00:50Z","oldestRestorableTime":"2022-12-19T06:00:50Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"930298bb-0c4f-43ee-b7d9-365fbd6e96d5","creationTime":"2022-12-19T06:00:52Z"}]}},{"name":"d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/d8b6f189-ccac-48f3-b8c1-ac0fc219cf4b","properties":{"accountName":"test-account23","apiType":"Sql","creationTime":"2022-12-24T18:24:52Z","oldestRestorableTime":"2022-12-24T18:24:52Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"0ecde616-a04b-4a95-8340-69ee01bff25f","creationTime":"2022-12-24T18:24:53Z"},{"locationName":"North
+        Central US","regionalDatabaseAccountInstanceId":"bcd3a857-d005-4eb9-b83b-d50878cc58a4","creationTime":"2022-12-24T18:27:11Z"}]}},{"name":"c0e85028-dfc8-4f38-acb6-9230bf01f3ad","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c0e85028-dfc8-4f38-acb6-9230bf01f3ad","properties":{"accountName":"testpitr","apiType":"Sql","creationTime":"2022-12-27T20:37:00Z","oldestRestorableTime":"2022-12-27T20:37:00Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"d031c28c-cbdd-4c87-b5ae-88bbf4bc28bf","creationTime":"2022-12-27T20:37:02Z"}]}},{"name":"0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","location":"West
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","properties":{"accountName":"cli000003","apiType":"Sql","creationTime":"2022-12-28T01:21:05Z","oldestRestorableTime":"2022-12-28T01:21:05Z","restorableLocations":[{"locationName":"West
+        US","regionalDatabaseAccountInstanceId":"1c5418a8-d2ee-4095-bf7f-3e5b5b1dcfcd","creationTime":"2022-12-28T01:21:06Z"}]}},{"name":"83caf7f5-b220-4b0a-980a-2e8e7e6184d3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/83caf7f5-b220-4b0a-980a-2e8e7e6184d3","properties":{"accountName":"drop-continuous7","apiType":"Sql","creationTime":"2022-05-26T18:49:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"a7725382-1f4c-426c-b51b-72acad407539","creationTime":"2022-05-26T18:49:52Z"}]}},{"name":"8b0701eb-0f38-4c72-a076-5ecb75ab55b3","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/8b0701eb-0f38-4c72-a076-5ecb75ab55b3","properties":{"accountName":"periodicacctdrop","apiType":"Sql","creationTime":"2022-08-24T22:57:51Z","oldestRestorableTime":"2022-12-21T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"653cea6a-f643-47cf-a6ef-65704fa35acd","creationTime":"2022-08-24T22:57:51Z"}]}},{"name":"ee16f791-77f8-40d4-89ad-91495b853ac0","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/ee16f791-77f8-40d4-89ad-91495b853ac0","properties":{"accountName":"periodicacctdrop2","apiType":"Sql","creationTime":"2022-05-26T20:16:50Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"e8fe590a-1d27-407d-9e1f-28787d021b84","creationTime":"2022-05-26T20:16:50Z"}]}},{"name":"36d58919-3ef5-4e13-806c-29912602ecf5","location":"East
+        US","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/eastus/restorableDatabaseAccounts/36d58919-3ef5-4e13-806c-29912602ecf5","properties":{"accountName":"ksh-gremlin-acc","apiType":"Gremlin,
+        Sql","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z","oldestRestorableTime":"2022-11-28T01:27:56Z","restorableLocations":[{"locationName":"East
+        US","regionalDatabaseAccountInstanceId":"d946a7eb-843b-4e81-99b1-8002f342ee0b","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"South
+        Central US","regionalDatabaseAccountInstanceId":"0e2ee12b-4986-485d-9df3-f7be8317ad6e","creationTime":"2022-11-21T20:45:05Z","deletionTime":"2022-11-28T21:52:10Z"},{"locationName":"Central
+        US","regionalDatabaseAccountInstanceId":"40e6201e-ac7b-44ed-ba78-40bd0981d493","creationTime":"2022-11-21T23:37:04Z","deletionTime":"2022-11-28T21:52:10Z"}]}},{"name":"23ff311a-2493-4bd7-b1c9-ac4549ae4567","location":"Qatar
+        Central","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts","id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/qatarcentral/restorableDatabaseAccounts/23ff311a-2493-4bd7-b1c9-ac4549ae4567","properties":{"accountName":"vinh-cmk-qatar-actual-res-live-sysid-res2","apiType":"Sql","creationTime":"2022-09-29T05:44:13Z","oldestRestorableTime":"2022-11-28T01:27:57Z","restorableLocations":[{"locationName":"Qatar
+        Central","regionalDatabaseAccountInstanceId":"3bf0dcac-7a5a-4602-bdf4-3edcbcbbcb5b","creationTime":"2022-09-29T05:44:13Z"}]}}]}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '29877'
+      - '67058'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 19 Sep 2022 05:05:20 GMT
+      - Wed, 28 Dec 2022 01:27:56 GMT
       expires:
       - '-1'
       pragma:
@@ -1498,8 +2079,6 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-original-request-ids:
-      - ''
-      - ''
       - ''
       - ''
       - ''
@@ -1554,22 +2133,21 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/West%20US/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d/restorableSqlResources?api-version=2022-08-15&restoreLocation=westus&restoreTimestampInUtc=2022-09-19%2005%3A02%3A32%2B00%3A00
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0/restorableSqlResources?api-version=2022-08-15&restoreLocation=westus&restoreTimestampInUtc=2022-12-28%2001%3A25%3A05%2B00%3A00
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/West%20US/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d/restorableSqlResources/cli000005","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlResources","name":"cli000005","databaseName":"cli000005","collectionNames":["cli000002"]}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0/restorableSqlResources/cli000005","type":"Microsoft.DocumentDB/locations/restorableDatabaseAccounts/restorableSqlResources","name":"cli000005","databaseName":"cli000005","collectionNames":["cli000002"]}]}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '388'
+      - '385'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:05:20 GMT
+      - Wed, 28 Dec 2022 01:27:58 GMT
       pragma:
       - no-cache
       server:
@@ -1591,8 +2169,8 @@ interactions:
     body: '{"location": "West US", "kind": "GlobalDocumentDB", "properties": {"locations":
       [{"locationName": "westus", "failoverPriority": 0}], "databaseAccountOfferType":
       "Standard", "apiProperties": {}, "createMode": "Restore", "restoreParameters":
-      {"restoreMode": "PointInTime", "restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d",
-      "restoreTimestampInUtc": "2022-09-19T05:02:32.000Z"}}}'
+      {"restoreSource": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0",
+      "restoreTimestampInUtc": "2022-12-28T01:25:05.000Z", "restoreMode": "PointInTime"}}}'
     headers:
       Accept:
       - application/json
@@ -1609,31 +2187,31 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: PUT
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T05:05:22.7733692Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"52ce4c3b-b907-4c88-82a3-215e2002429d","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:28:02.0398354Z"},"properties":{"provisioningState":"Creating","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000003-westus.documents.azure.com:443/","provisioningState":"Creating","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","restoreTimestampInUtc":"2022-09-19T05:02:32Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T05:05:22.7733692Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T05:05:22.7733692Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:05:22.7733692Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:05:22.7733692Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:28:02.0398354Z"}}},"identity":{"type":"None"}}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2655'
+      - '2830'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:05:24 GMT
+      - Wed, 28 Dec 2022 01:28:04 GMT
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004/operationResults/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
       pragma:
       - no-cache
       server:
@@ -1649,7 +2227,7 @@ interactions:
       x-ms-gatewayversion:
       - version=2.14.0
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1195'
+      - '1199'
     status:
       code: 200
       message: Ok
@@ -1667,10 +2245,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1682,7 +2259,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:05:55 GMT
+      - Wed, 28 Dec 2022 01:28:34 GMT
       pragma:
       - no-cache
       server:
@@ -1714,10 +2291,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1729,7 +2305,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:06:25 GMT
+      - Wed, 28 Dec 2022 01:29:05 GMT
       pragma:
       - no-cache
       server:
@@ -1761,10 +2337,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1776,7 +2351,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:06:55 GMT
+      - Wed, 28 Dec 2022 01:29:35 GMT
       pragma:
       - no-cache
       server:
@@ -1808,10 +2383,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1823,7 +2397,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:07:25 GMT
+      - Wed, 28 Dec 2022 01:30:05 GMT
       pragma:
       - no-cache
       server:
@@ -1855,10 +2429,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1870,7 +2443,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:07:55 GMT
+      - Wed, 28 Dec 2022 01:30:34 GMT
       pragma:
       - no-cache
       server:
@@ -1902,10 +2475,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1917,7 +2489,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:08:26 GMT
+      - Wed, 28 Dec 2022 01:31:05 GMT
       pragma:
       - no-cache
       server:
@@ -1949,10 +2521,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -1964,7 +2535,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:08:56 GMT
+      - Wed, 28 Dec 2022 01:31:35 GMT
       pragma:
       - no-cache
       server:
@@ -1996,10 +2567,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2011,7 +2581,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:09:26 GMT
+      - Wed, 28 Dec 2022 01:32:05 GMT
       pragma:
       - no-cache
       server:
@@ -2043,10 +2613,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2058,7 +2627,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:09:56 GMT
+      - Wed, 28 Dec 2022 01:32:35 GMT
       pragma:
       - no-cache
       server:
@@ -2090,10 +2659,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2105,7 +2673,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:10:25 GMT
+      - Wed, 28 Dec 2022 01:33:05 GMT
       pragma:
       - no-cache
       server:
@@ -2137,10 +2705,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2152,7 +2719,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:10:56 GMT
+      - Wed, 28 Dec 2022 01:33:36 GMT
       pragma:
       - no-cache
       server:
@@ -2184,10 +2751,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2199,7 +2765,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:11:26 GMT
+      - Wed, 28 Dec 2022 01:34:06 GMT
       pragma:
       - no-cache
       server:
@@ -2231,10 +2797,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2246,7 +2811,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:11:56 GMT
+      - Wed, 28 Dec 2022 01:34:36 GMT
       pragma:
       - no-cache
       server:
@@ -2278,10 +2843,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2293,7 +2857,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:12:26 GMT
+      - Wed, 28 Dec 2022 01:35:07 GMT
       pragma:
       - no-cache
       server:
@@ -2325,10 +2889,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2340,7 +2903,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:12:56 GMT
+      - Wed, 28 Dec 2022 01:35:37 GMT
       pragma:
       - no-cache
       server:
@@ -2372,10 +2935,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2387,7 +2949,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:13:26 GMT
+      - Wed, 28 Dec 2022 01:36:07 GMT
       pragma:
       - no-cache
       server:
@@ -2419,10 +2981,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2434,7 +2995,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:13:56 GMT
+      - Wed, 28 Dec 2022 01:36:36 GMT
       pragma:
       - no-cache
       server:
@@ -2466,10 +3027,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2481,7 +3041,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:14:27 GMT
+      - Wed, 28 Dec 2022 01:37:06 GMT
       pragma:
       - no-cache
       server:
@@ -2513,10 +3073,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2528,7 +3087,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:14:57 GMT
+      - Wed, 28 Dec 2022 01:37:36 GMT
       pragma:
       - no-cache
       server:
@@ -2560,10 +3119,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2575,7 +3133,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:15:27 GMT
+      - Wed, 28 Dec 2022 01:38:07 GMT
       pragma:
       - no-cache
       server:
@@ -2607,10 +3165,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2622,7 +3179,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:15:57 GMT
+      - Wed, 28 Dec 2022 01:38:37 GMT
       pragma:
       - no-cache
       server:
@@ -2654,10 +3211,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2669,7 +3225,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:16:27 GMT
+      - Wed, 28 Dec 2022 01:39:07 GMT
       pragma:
       - no-cache
       server:
@@ -2701,10 +3257,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2716,7 +3271,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:16:58 GMT
+      - Wed, 28 Dec 2022 01:39:37 GMT
       pragma:
       - no-cache
       server:
@@ -2748,10 +3303,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2763,7 +3317,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:17:28 GMT
+      - Wed, 28 Dec 2022 01:40:08 GMT
       pragma:
       - no-cache
       server:
@@ -2795,10 +3349,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Dequeued"}'
@@ -2810,7 +3363,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:17:57 GMT
+      - Wed, 28 Dec 2022 01:40:38 GMT
       pragma:
       - no-cache
       server:
@@ -2842,57 +3395,9 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
-  response:
-    body:
-      string: '{"status":"Dequeued"}'
-    headers:
-      cache-control:
-      - no-store, no-cache
-      content-length:
-      - '21'
-      content-type:
-      - application/json
-      date:
-      - Mon, 19 Sep 2022 05:18:27 GMT
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-gatewayversion:
-      - version=2.14.0
-    status:
-      code: 200
-      message: Ok
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - cosmosdb restore
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - --account-name -g --restore-timestamp --location --target-database-account-name
-      User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/02b2abb0-7c6c-4d0b-a7a1-7fe41e6a0110?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/operationsStatus/51d4c137-b21c-4d49-9b63-0b41d098cbf6?api-version=2022-08-15-preview
   response:
     body:
       string: '{"status":"Succeeded"}'
@@ -2904,7 +3409,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:18:57 GMT
+      - Wed, 28 Dec 2022 01:41:08 GMT
       pragma:
       - no-cache
       server:
@@ -2936,27 +3441,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T05:18:26.4609822Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"52ce4c3b-b907-4c88-82a3-215e2002429d","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","restoreTimestampInUtc":"2022-09-19T05:02:32Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2723'
+      - '2898'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:18:57 GMT
+      - Wed, 28 Dec 2022 01:41:08 GMT
       pragma:
       - no-cache
       server:
@@ -2988,27 +3493,27 @@ interactions:
       ParameterSetName:
       - --account-name -g --restore-timestamp --location --target-database-account-name
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T05:18:26.4609822Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"52ce4c3b-b907-4c88-82a3-215e2002429d","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","restoreTimestampInUtc":"2022-09-19T05:02:32Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2723'
+      - '2898'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:18:58 GMT
+      - Wed, 28 Dec 2022 01:41:08 GMT
       pragma:
       - no-cache
       server:
@@ -3040,27 +3545,27 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.40.0 azsdk-python-mgmt-cosmosdb/8.0.0 Python/3.10.6 (Linux-5.15.0-1019-azure-x86_64-with-glibc2.31)
-        VSTS_0fb41ef4-5012-48a9-bf39-4ee3de03ee35_build_4949_0
+      - AZURECLI/2.43.0 azsdk-python-mgmt-cosmosdb/0.7.0 Python/3.10.4 (Windows-10-10.0.22623-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004?api-version=2022-08-15-preview
   response:
     body:
       string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/cli_test_cosmosdb_restore_command000001/providers/Microsoft.DocumentDB/databaseAccounts/cli000004","name":"cli000004","location":"West
-        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-09-19T05:18:26.4609822Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"52ce4c3b-b907-4c88-82a3-215e2002429d","createMode":"Restore","databaseAccountOfferType":"Standard","defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
+        US","type":"Microsoft.DocumentDB/databaseAccounts","kind":"GlobalDocumentDB","tags":{},"systemData":{"createdAt":"2022-12-28T01:40:41.2349182Z"},"properties":{"provisioningState":"Succeeded","documentEndpoint":"https://cli000004.documents.azure.com:443/","publicNetworkAccess":"Enabled","enableAutomaticFailover":false,"enableMultipleWriteLocations":false,"enablePartitionKeyMonitor":false,"isVirtualNetworkFilterEnabled":false,"virtualNetworkRules":[],"EnabledApiTypes":"Sql","disableKeyBasedMetadataWriteAccess":false,"enableFreeTier":false,"enableAnalyticalStorage":false,"analyticalStorageConfiguration":{},"instanceId":"85b52c24-6e96-40f4-984b-171fb8d06213","createMode":"Restore","databaseAccountOfferType":"Standard","enableMaterializedViews":false,"defaultIdentity":"FirstPartyIdentity","networkAclBypass":"None","disableLocalAuth":false,"enablePartitionMerge":false,"consistencyPolicy":{"defaultConsistencyLevel":"Session","maxIntervalInSeconds":5,"maxStalenessPrefix":100},"configurationOverrides":{},"writeLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"readLocations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"locations":[{"id":"cli000004-westus","locationName":"West
         US","documentEndpoint":"https://cli000004-westus.documents.azure.com:443/","provisioningState":"Succeeded","failoverPriority":0,"isZoneRedundant":false}],"failoverPolicies":[{"id":"cli000004-westus","locationName":"West
-        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous"},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/c9ce8123-9af3-47bc-bee9-c08ea1bc206d","restoreTimestampInUtc":"2022-09-19T05:02:32Z","databasesToRestore":[]},"networkAclBypassResourceIds":[],"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-09-19T05:18:26.4609822Z"}}},"identity":{"type":"None"}}'
+        US","failoverPriority":0}],"cors":[],"capabilities":[],"ipRules":[],"backupPolicy":{"type":"Continuous","continuousModeProperties":{"tier":"Continuous30Days"}},"restoreParameters":{"restoreMode":"PointInTime","restoreSource":"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.DocumentDB/locations/westus/restorableDatabaseAccounts/0013bcd6-95c9-4814-9d62-b72b9bfa4fc0","restoreTimestampInUtc":"2022-12-28T01:25:05Z","sourceBackupLocation":"West
+        US","databasesToRestore":[]},"networkAclBypassResourceIds":[],"diagnosticLogSettings":{"enableFullTextQuery":"None"},"capacity":{"totalThroughputLimit":-1},"keysMetadata":{"primaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"primaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"},"secondaryReadonlyMasterKey":{"generationTime":"2022-12-28T01:40:41.2349182Z"}}},"identity":{"type":"None"}}'
     headers:
       cache-control:
       - no-store, no-cache
       content-length:
-      - '2723'
+      - '2898'
       content-type:
       - application/json
       date:
-      - Mon, 19 Sep 2022 05:18:58 GMT
+      - Wed, 28 Dec 2022 01:41:09 GMT
       pragma:
       - no-cache
       server:


### PR DESCRIPTION
When performing a PITR restore, if the user was given a specific permission to restore the account, then the permission check might fail due to the "Location" returned by the PITR restorable database API is not normalized.  This PR fixes this by normalizing the location name.

**Related command**
az cosmosdb restore

**Description**<!--Mandatory-->

**Testing Guide**

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
