### PR TITLE
[AKS] Mark AAD-legacy properties deprecated

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -132,12 +132,15 @@ parameters:
   - name: --aad-client-app-id
     type: string
     short-summary: The ID of an Azure Active Directory client application of type "Native". This application is for user login via kubectl.
+    long-summary: --aad-client-app-id is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-server-app-id
     type: string
     short-summary: The ID of an Azure Active Directory server application of type "Web app/API". This application represents the managed cluster's apiserver (Server application).
+    long-summary: --aad-server-app-id is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-server-app-secret
     type: string
     short-summary: The secret of an Azure Active Directory server application.
+    long-summary: --aad-server-app-secret is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-tenant-id
     type: string
     short-summary: The ID of an Azure Active Directory tenant.
@@ -1233,15 +1236,19 @@ parameters:
   - name: --reset-aad
     type: string
     short-summary: Reset Azure Active Directory configuration for a managed cluster.
+    long-summary: --reset-aad is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-server-app-id
     type: string
     short-summary: The ID of an Azure Active Directory server application. This argument is required if `--reset-aad` is specified.
+    long-summary: --aad-server-app-id is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-server-app-secret
     type: string
     short-summary: The secret of an Azure Active Directory server application. This argument is required if `--reset-aad` is specified.
+    long-summary: --aad-server-app-secret is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-client-app-id
     type: string
     short-summary: The ID of an Azure Active Directory client application. This argument is required if `--reset-aad` is specified.
+    long-summary: --aad-client-app-id is deprecated. See https://aka.ms/aks/aad-legacy for details.
   - name: --aad-tenant-id
     type: string
     short-summary: Tenant ID associated with Azure Active Directory.
@@ -1249,8 +1256,6 @@ parameters:
 examples:
   - name: Update an existing Kubernetes cluster with new service principal.
     text: az aks update-credentials -g MyResourceGroup -n MyManagedCluster --reset-service-principal --service-principal MyNewServicePrincipalID --client-secret MyNewServicePrincipalSecret
-  - name: Update an existing Azure Active Directory Kubernetes cluster with new server app secret key.
-    text: az aks update-credentials -g MyResourceGroup -n MyManagedCluster --reset-aad --aad-server-app-id MyExistingAADServerAppID --aad-server-app-secret MyNewAADServerAppSecret --aad-client-app-id MyExistingAADClientAppID --aad-tenant-id MyAADTenantID
 """
 
 helps['aks upgrade'] = """

--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -191,9 +191,9 @@ def load_arguments(self, _):
         c.argument('assign_kubelet_identity', validator=validate_assign_kubelet_identity)
         c.argument('enable_aad', action='store_true')
         c.argument('enable_azure_rbac', action='store_true')
-        c.argument('aad_client_app_id')
-        c.argument('aad_server_app_id')
-        c.argument('aad_server_app_secret')
+        c.argument('aad_client_app_id', deprecate_info=c.deprecate(target='--aad-client-app-id', hide=True))
+        c.argument('aad_server_app_id', deprecate_info=c.deprecate(target='--aad-server-app-id', hide=True))
+        c.argument('aad_server_app_secret', deprecate_info=c.deprecate(target='--aad-server-app-secret', hide=True))
         c.argument('aad_tenant_id')
         c.argument('aad_admin_group_object_ids')
         c.argument('enable_oidc_issuer', action='store_true')
@@ -378,11 +378,11 @@ def load_arguments(self, _):
         c.argument('client_secret')
 
     with self.argument_context('aks update-credentials', arg_group='AAD') as c:
-        c.argument('reset_aad', action='store_true')
-        c.argument('aad_client_app_id')
-        c.argument('aad_server_app_id')
-        c.argument('aad_server_app_secret')
-        c.argument('aad_tenant_id')
+        c.argument('reset_aad', action='store_true', deprecate_info=c.deprecate(target='--reset-aad', hide=True))
+        c.argument('aad_client_app_id', deprecate_info=c.deprecate(target='--aad-client-app-id', hide=True))
+        c.argument('aad_server_app_id', deprecate_info=c.deprecate(target='--aad-server-app-id', hide=True))
+        c.argument('aad_server_app_secret', deprecate_info=c.deprecate(target='--aad-server-app-secret', hide=True))
+        c.argument('aad_tenant_id', deprecate_info=c.deprecate(target='--aad-tenant-id', hide=True))
 
     with self.argument_context('aks upgrade', resource_type=ResourceType.MGMT_CONTAINERSERVICE, operation_group='managed_clusters') as c:
         c.argument('kubernetes_version', completer=get_k8s_upgrades_completion_list)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks create --aad-client-app-id {} --aad-server-app-id {} --aad-server-app-secret {}`

`az aks update-credentials --reset-aad --aad-client-app-id {} --aad-server-app-id {} --aad-server-app-secret {}`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The [legacy way of integrate Azure Active Directory with AKS](https://learn.microsoft.com/en-us/azure/aks/azure-ad-integration-cli) is deprecated. This PR is to make the related properties deprecated in Azure CLI.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] `az aks create`: Deprecate parameters `--aad-client-app-id`, `--aad-server-app-id` and `--aad-server-app-secret`
[AKS] `az aks update-credentials`: Deprecate parameters `--reset-aad`, `--aad-client-app-id`, `--aad-server-app-id` and `--aad-server-app-secret`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
