### PR TITLE
{AKS} Add error message for nodepool add w/o os type for Windows SKU's

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -479,7 +479,6 @@ class AKSAgentPoolContext(BaseAKSContext):
             snapshot = self.get_snapshot()
             if snapshot:
                 value_obtained_from_snapshot = snapshot.os_type
-        
         # set default value
         if value_obtained_from_agentpool is not None:
             os_type = value_obtained_from_agentpool
@@ -489,7 +488,6 @@ class AKSAgentPoolContext(BaseAKSContext):
             os_type = value_obtained_from_snapshot
         else:
             os_type = CONST_DEFAULT_NODE_OS_TYPE
-        
         # validation
         if (
             self.agentpool_decorator_mode == AgentPoolDecoratorMode.MANAGED_CLUSTER and
@@ -497,18 +495,16 @@ class AKSAgentPoolContext(BaseAKSContext):
         ):
             if os_type.lower() == "windows":
                 raise InvalidArgumentValueError("System node pool must be linux.")
-        
         # validation of Windows OS SKU's against OS Type 
         if (
             self.agentpool_decorator_mode == AgentPoolDecoratorMode.STANDALONE and
             self.decorator_mode == DecoratorMode.CREATE and
             os_type == CONST_DEFAULT_NODE_OS_TYPE
-        ):            
+        ):
             # read the original value passed by the command
             raw_os_sku = self.raw_param.get("os_sku")
             if raw_os_sku == CONST_OS_SKU_WINDOWS2019 or raw_os_sku == CONST_OS_SKU_WINDOWS2022:
                 raise InvalidArgumentValueError("OS SKU is invalid for Linux OS Type. Please specify '--os-type Windows' for Windows SKUs")
-
         return os_type
 
     def get_os_type(self) -> Union[str, None]:
@@ -549,8 +545,7 @@ class AKSAgentPoolContext(BaseAKSContext):
         elif not read_only and value_obtained_from_snapshot is not None:
             os_sku = value_obtained_from_snapshot
         else:
-            os_sku = raw_value
-        
+            os_sku = raw_value        
         # this parameter does not need validation
         return os_sku
 

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -503,10 +503,13 @@ class AKSAgentPoolContext(BaseAKSContext):
         ):
             # read the original value passed by the command
             raw_os_sku = self.raw_param.get("os_sku")
-            raw_sku_2019 = CONST_OS_SKU_WINDOWS2019
-            raw_sku_2022 = CONST_OS_SKU_WINDOWS2022
-            if raw_os_sku == raw_sku_2019 or raw_os_sku == raw_sku_2022:
-                raise InvalidArgumentValueError("OS SKU is invalid for Linux OS Type. Please specify '--os-type Windows' for Windows SKUs")
+            sku_2019 = CONST_OS_SKU_WINDOWS2019
+            sku_2022 = CONST_OS_SKU_WINDOWS2022
+            if raw_os_sku == sku_2019 or raw_os_sku == sku_2022:
+                raise InvalidArgumentValueError(
+                    "OS SKU is invalid for Linux OS Type." 
+                    "Please specify '--os-type Windows' for Windows SKUs"
+                    )
         return os_type
 
     def get_os_type(self) -> Union[str, None]:

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -21,6 +21,8 @@ from azure.cli.command_modules.acs._consts import (
     CONST_SCALE_SET_PRIORITY_SPOT,
     CONST_SPOT_EVICTION_POLICY_DELETE,
     CONST_VIRTUAL_MACHINE_SCALE_SETS,
+    CONST_OS_SKU_WINDOWS2019,
+    CONST_OS_SKU_WINDOWS2022,
     AgentPoolDecoratorMode,
     DecoratorEarlyExitException,
     DecoratorMode,
@@ -477,7 +479,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             snapshot = self.get_snapshot()
             if snapshot:
                 value_obtained_from_snapshot = snapshot.os_type
-
+        
         # set default value
         if value_obtained_from_agentpool is not None:
             os_type = value_obtained_from_agentpool
@@ -487,7 +489,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             os_type = value_obtained_from_snapshot
         else:
             os_type = CONST_DEFAULT_NODE_OS_TYPE
-
+        
         # validation
         if (
             self.agentpool_decorator_mode == AgentPoolDecoratorMode.MANAGED_CLUSTER and
@@ -495,6 +497,18 @@ class AKSAgentPoolContext(BaseAKSContext):
         ):
             if os_type.lower() == "windows":
                 raise InvalidArgumentValueError("System node pool must be linux.")
+        
+        # validation of Windows OS SKU's against OS Type 
+        if (
+            self.agentpool_decorator_mode == AgentPoolDecoratorMode.STANDALONE and
+            self.decorator_mode == DecoratorMode.CREATE and
+            os_type == CONST_DEFAULT_NODE_OS_TYPE
+        ):            
+            # read the original value passed by the command
+            raw_os_sku = self.raw_param.get("os_sku")
+            if raw_os_sku == CONST_OS_SKU_WINDOWS2019 or raw_os_sku == CONST_OS_SKU_WINDOWS2022:
+                raise InvalidArgumentValueError("OS SKU is invalid for Linux OS Type. Please specify '--os-type Windows' for Windows SKUs")
+
         return os_type
 
     def get_os_type(self) -> Union[str, None]:
@@ -536,7 +550,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             os_sku = value_obtained_from_snapshot
         else:
             os_sku = raw_value
-
+        
         # this parameter does not need validation
         return os_sku
 

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -503,7 +503,9 @@ class AKSAgentPoolContext(BaseAKSContext):
         ):
             # read the original value passed by the command
             raw_os_sku = self.raw_param.get("os_sku")
-            if raw_os_sku == CONST_OS_SKU_WINDOWS2019 or raw_os_sku == CONST_OS_SKU_WINDOWS2022:
+            raw_sku_2019 = CONST_OS_SKU_WINDOWS2019
+            raw_sku_2022 = CONST_OS_SKU_WINDOWS2022
+            if raw_os_sku == raw_sku_2019 or raw_os_sku == raw_sku_2022:
                 raise InvalidArgumentValueError("OS SKU is invalid for Linux OS Type. Please specify '--os-type Windows' for Windows SKUs")
         return os_type
 

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -507,7 +507,7 @@ class AKSAgentPoolContext(BaseAKSContext):
             sku_2022 = CONST_OS_SKU_WINDOWS2022
             if raw_os_sku == sku_2019 or raw_os_sku == sku_2022:
                 raise InvalidArgumentValueError(
-                    "OS SKU is invalid for Linux OS Type." 
+                    "OS SKU is invalid for Linux OS Type."
                     " Please specify '--os-type Windows' for Windows SKUs"
                 )
         return os_type

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -508,8 +508,8 @@ class AKSAgentPoolContext(BaseAKSContext):
             if raw_os_sku == sku_2019 or raw_os_sku == sku_2022:
                 raise InvalidArgumentValueError(
                     "OS SKU is invalid for Linux OS Type." 
-                    "Please specify '--os-type Windows' for Windows SKUs"
-                    )
+                    " Please specify '--os-type Windows' for Windows SKUs"
+                )
         return os_type
 
     def get_os_type(self) -> Union[str, None]:

--- a/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/agentpool_decorator.py
@@ -495,7 +495,7 @@ class AKSAgentPoolContext(BaseAKSContext):
         ):
             if os_type.lower() == "windows":
                 raise InvalidArgumentValueError("System node pool must be linux.")
-        # validation of Windows OS SKU's against OS Type 
+        # validation of Windows OS SKU's against OS Type
         if (
             self.agentpool_decorator_mode == AgentPoolDecoratorMode.STANDALONE and
             self.decorator_mode == DecoratorMode.CREATE and
@@ -545,7 +545,7 @@ class AKSAgentPoolContext(BaseAKSContext):
         elif not read_only and value_obtained_from_snapshot is not None:
             os_sku = value_obtained_from_snapshot
         else:
-            os_sku = raw_value        
+            os_sku = raw_value
         # this parameter does not need validation
         return os_sku
 


### PR DESCRIPTION
**Related command**
`az aks nodepool add -g {} --cluster-name {} --os-sku Windows2019 -n {} (w/o --os-type Windows)`

**Description**<!--Mandatory-->
Add error message for nodepool add w/o os type for Windows SKU's
`az aks nodepool add -g {} --cluster-name {} --os-sku Windows2019 -n {} (w/o --os-type Windows)`
Fixes GitHub Issue [24966](https://github.com/Azure/azure-cli/issues/24966)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).