### PR TITLE
{CI} Bump certifi from 2021.10.8 to 2022.12.7

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -92,7 +92,7 @@ azure-synapse-artifacts==0.14.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2021.10.8
+certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -92,7 +92,7 @@ azure-synapse-artifacts==0.14.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2021.10.8
+certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -92,7 +92,7 @@ azure-synapse-artifacts==0.14.0
 azure-synapse-managedprivateendpoints==0.3.0
 azure-synapse-spark==0.2.0
 bcrypt==3.2.0
-certifi==2021.10.8
+certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4


### PR DESCRIPTION
Certifi 2022.12.07 removes root certificates from "TrustCor" from the root store. These are in the process of being removed from Mozilla's trust store.

TrustCor's root certificates are being removed pursuant to an investigation prompted by media reporting that TrustCor's ownership also operated a business that produced spyware. Conclusions of Mozilla's investigation can be found [here](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ).