### PR TITLE
[ARM] `az bicep`: Add configs to allow disabling version checks and using Bicep CLI from PATH

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -62,7 +62,7 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
         from shutil import which
 
         if which("bicep") is None:
-            raise ValidationError('Could not find the "bicep" executable on PATH.')
+            raise ValidationError('Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".')
 
         bicep_version_message = _run_command("bicep", "--version")
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -209,7 +209,7 @@ def _bicep_installed_in_ci():
 
 def _use_binary_from_path(cli_ctx):
     use_binary_from_path = cli_ctx.config.get("bicep", "use_binary_from_path", "if_found_in_ci").lower()
-    
+
     _logger.debug('Current value of "use_binary_from_path": %s.', use_binary_from_path)
 
     if use_binary_from_path == "if_found_in_ci":

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -199,13 +199,18 @@ def supports_bicep_publish():
 def _bicep_installed_in_ci():
     if "GITHUB_ACTIONS" in os.environ or "TF_BUILD" in os.environ:
         from shutil import which
+        installed = which("bicep") is not None
 
-        return which("bicep") is not None
+        _logger.debug("Running in a CI environment. Bicep CLI available on PATH: %s.", installed)
+
+        return installed
     return False
 
 
 def _use_binary_from_path(cli_ctx):
     use_binary_from_path = cli_ctx.config.get("bicep", "use_binary_from_path", "if_found_in_ci").lower()
+    
+    _logger.debug('Current value of "use_binary_from_path": %s.', use_binary_from_path)
 
     if use_binary_from_path == "if_found_in_ci":
         # With if_found_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days)

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -62,7 +62,9 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
         from shutil import which
 
         if which("bicep") is None:
-            raise ValidationError('Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".')
+            raise ValidationError(
+                'Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".'  # pylint: disable=line-too-long
+            )
 
         bicep_version_message = _run_command("bicep", ["--version"])
 
@@ -194,6 +196,7 @@ def supports_bicep_publish():
 def _bicep_installed_in_ci():
     if "GITHUB_ACTIONS" in os.environ or "TF_BUILD" in os.environ:
         from shutil import which
+
         return which("bicep") is not None
     return False
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -64,7 +64,7 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
         if which("bicep") is None:
             raise ValidationError('Could not find the "bicep" executable on PATH. To install Bicep via Azure CLI, set the "bicep.use_binary_from_path" configuration to False and run "az bicep install".')
 
-        bicep_version_message = _run_command("bicep", "--version")
+        bicep_version_message = _run_command("bicep", ["--version"])
 
         _logger.debug("Using Bicep CLI from PATH. %s", bicep_version_message)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -73,7 +73,10 @@ def run_bicep_command(cli_ctx, args, auto_install=True):
         return _run_command("bicep", args)
 
     installation_path = _get_bicep_installation_path(platform.system())
+    _logger.debug("Bicep CLI installation path: %s", installation_path)
+
     installed = os.path.isfile(installation_path)
+    _logger.debug("Bicep CLI installed: %s.", installed)
 
     check_version = cli_ctx.config.getboolean("bicep", "check_version", True)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -203,7 +203,7 @@ def _use_binary_from_path(cli_ctx):
         return False
 
     _logger.warning(
-        'The configuration value of bicep.use_binary_from_path is invalid: "%s". Possible values include "if_running_in_ci" and booleans.',  # pylint: disable=line-too-long
+        'The configuration value of bicep.use_binary_from_path is invalid: "%s". Possible values include "if_running_in_ci" and Booleans.',  # pylint: disable=line-too-long
         use_binary_from_path,
     )
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2694,11 +2694,13 @@ helps['bicep'] = """
 type: group
 short-summary: Bicep CLI command group.
 long-summary: |
-  Bicep CLI command group. There are two configurations that can be set for the command group, including bicep.check_version and bicep.use_binary_from_path.
+  Bicep CLI command group. There are two configurations that can be set for the command group, including bicep.check_version and bicep.use_binary_from_path:
 
-  bicep.check_version accepts Boolean values and defaults to True. If set to False, version checks for Bicep CLI installed via Azure CLI will be disabled.
+  [1] az config set bicep.version_check=True/False
+      Turn on/off Bicep CLI version check when executing az bicep commands.
 
-  The possible values of bicep.use_binary_from_path are if_found_in_ci and Booleans. The default value is if_found_in_ci.
+  [2] az config set bicep.use_binary_from_path=True/False/if_found_in_ci
+      Specify whether to use Bicep CLI from PATH or not. The default value is if_found_in_ci.
 """
 
 helps['bicep install'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2699,9 +2699,9 @@ long-summary: |
 
   bicep.check_version accepts Boolean values and defaults to True. If set to False, version checks for Bicep CLI installed via Azure CLI will be disabled.
 
-  The possible values of bicep.use_binary_from_path are if_running_in_ci and Booleans. The default value is if_running_in_ci.
+  The possible values of bicep.use_binary_from_path are if_found_in_ci and Booleans. The default value is if_found_in_ci.
 
-  With if_running_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days) in getting the latest version of Bicep CLI, since the az bicep commands will use the pre-installed Bicep CLI on the build agents, but the build agents has a different release cycle. The benefit is that the az bicep commands will not download the Bicep CLI on each pipeline run.
+  With if_found_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days) in getting the latest version of Bicep CLI, since the az bicep commands will use the pre-installed Bicep CLI on the build agents, but the build agents has a different release cycle. The benefit is that the az bicep commands will not download the Bicep CLI on each pipeline run.
 
   Setting bicep.use_binary_from_path to True forces the az bicep commands to use the Bicep executable added to PATH (if it exists), which indicates that the user is intended to manage the Bicep CLI, and version checks will be disabled.
 """

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2694,16 +2694,11 @@ helps['bicep'] = """
 type: group
 short-summary: Bicep CLI command group.
 long-summary: |
-  Bicep CLI command group. There are two configurations that can be set for the command group,
-  including bicep.check_version and bicep.use_binary_from_path.
+  Bicep CLI command group. There are two configurations that can be set for the command group, including bicep.check_version and bicep.use_binary_from_path.
 
   bicep.check_version accepts Boolean values and defaults to True. If set to False, version checks for Bicep CLI installed via Azure CLI will be disabled.
 
   The possible values of bicep.use_binary_from_path are if_found_in_ci and Booleans. The default value is if_found_in_ci.
-
-  With if_found_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days) in getting the latest version of Bicep CLI, since the az bicep commands will use the pre-installed Bicep CLI on the build agents, but the build agents has a different release cycle. The benefit is that the az bicep commands will not download the Bicep CLI on each pipeline run.
-
-  Setting bicep.use_binary_from_path to True forces the az bicep commands to use the Bicep executable added to PATH (if it exists), which indicates that the user is intended to manage the Bicep CLI, and version checks will be disabled.
 """
 
 helps['bicep install'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2698,11 +2698,11 @@ long-summary: |
   including bicep.check_version and bicep.use_binary_from_path.
 
   bicep.check_version accepts Boolean values and defaults to True. If set to False, version checks for Bicep CLI installed via Azure CLI will be disabled.
-  
+
   The possible values of bicep.use_binary_from_path are if_running_in_ci and Booleans. The default value is if_running_in_ci.
-  
+
   With if_running_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days) in getting the latest version of Bicep CLI, since the az bicep commands will use the pre-installed Bicep CLI on the build agents, but the build agents has a different release cycle. The benefit is that the az bicep commands will not download the Bicep CLI on each pipeline run.
-  
+
   Setting bicep.use_binary_from_path to True forces the az bicep commands to use the Bicep executable added to PATH (if it exists), which indicates that the user is intended to manage the Bicep CLI, and version checks will be disabled.
 """
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2693,6 +2693,17 @@ examples:
 helps['bicep'] = """
 type: group
 short-summary: Bicep CLI command group.
+long-summary: |
+  Bicep CLI command group. There are two configurations that can be set for the command group,
+  including bicep.check_version and bicep.use_binary_from_path.
+
+  bicep.check_version accepts Boolean values and defaults to True. If set to False, version checks for Bicep CLI installed via Azure CLI will be disabled.
+  
+  The possible values of bicep.use_binary_from_path are if_running_in_ci and Booleans. The default value is if_running_in_ci.
+  
+  With if_running_in_ci, GitHub Actions and Azure Pipeline users may expect some delay (usually a few days) in getting the latest version of Bicep CLI, since the az bicep commands will use the pre-installed Bicep CLI on the build agents, but the build agents has a different release cycle. The benefit is that the az bicep commands will not download the Bicep CLI on each pipeline run.
+  
+  Setting bicep.use_binary_from_path to True forces the az bicep commands to use the Bicep executable added to PATH (if it exists), which indicates that the user is intended to manage the Bicep CLI, and version checks will be disabled.
 """
 
 helps['bicep install'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -321,7 +321,7 @@ def _deploy_arm_template_core_unmodified(cmd, resource_group_name, template_file
         template_obj = _remove_comments_from_json(_urlretrieve(template_uri).decode('utf-8'), file_path=template_uri)
     else:
         template_content = (
-            run_bicep_command(["build", "--stdout", template_file])
+            run_bicep_command(cmd.cli_ctx, ["build", "--stdout", template_file])
             if is_bicep_file(template_file)
             else read_file_content(template_file)
         )
@@ -958,7 +958,7 @@ def _prepare_deployment_properties_unmodified(cmd, deployment_scope, template_fi
         template_obj = show_resource(cmd=cmd, resource_ids=[template_spec], api_version=api_version).properties['mainTemplate']
     else:
         template_content = (
-            run_bicep_command(["build", "--stdout", template_file])
+            run_bicep_command(cmd.cli_ctx, ["build", "--stdout", template_file])
             if is_bicep_file(template_file)
             else read_file_content(template_file)
         )
@@ -1920,7 +1920,7 @@ def create_template_spec(cmd, resource_group_name, name, template_file=None, loc
         if template_file:
             from azure.cli.command_modules.resource._packing_engine import (pack)
             if is_bicep_file(template_file):
-                template_content = run_bicep_command(["build", "--stdout", template_file])
+                template_content = run_bicep_command(cmd.cli_ctx, ["build", "--stdout", template_file])
                 input_content = _remove_comments_from_json(template_content, file_path=template_file)
                 input_template = json.loads(json.dumps(input_content))
                 artifacts = []
@@ -1970,7 +1970,7 @@ def update_template_spec(cmd, resource_group_name=None, name=None, template_spec
     if template_file:
         from azure.cli.command_modules.resource._packing_engine import (pack)
         if is_bicep_file(template_file):
-            template_content = run_bicep_command(["build", "--stdout", template_file])
+            template_content = run_bicep_command(cmd.cli_ctx, ["build", "--stdout", template_file])
             input_content = _remove_comments_from_json(template_content, file_path=template_file)
             input_template = json.loads(json.dumps(input_content))
             artifacts = []
@@ -3668,7 +3668,7 @@ def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, no_resto
     if stdout:
         args += ["--stdout"]
 
-    output = run_bicep_command(args)
+    output = run_bicep_command(cmd.cli_ctx, args)
 
     if stdout:
         print(output)
@@ -3679,7 +3679,7 @@ def publish_bicep_file(cmd, file, target):
 
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
-        run_bicep_command(["publish", file, "--target", target])
+        run_bicep_command(cmd.cli_ctx, ["publish", file, "--target", target])
     else:
         logger.error("az bicep publish could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 
@@ -3692,7 +3692,7 @@ def restore_bicep_file(cmd, file, force=None):
         args = ["restore", file]
         if force:
             args += ["--force"]
-        run_bicep_command(args)
+        run_bicep_command(cmd.cli_ctx, args)
     else:
         logger.error("az bicep restore could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 
@@ -3701,11 +3701,11 @@ def decompile_bicep_file(cmd, file, force=None):
     args = ["decompile", file]
     if force:
         args += ["--force"]
-    run_bicep_command(args)
+    run_bicep_command(cmd.cli_ctx, args)
 
 
 def show_bicep_cli_version(cmd):
-    print(run_bicep_command(["--version"], auto_install=False))
+    print(run_bicep_command(cmd.cli_ctx, ["--version"], auto_install=False))
 
 
 def list_bicep_cli_versions(cmd):
@@ -3727,7 +3727,7 @@ def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, 
         if stdout:
             args += ["--stdout"]
 
-        output = run_bicep_command(args)
+        output = run_bicep_command(cmd.cli_ctx, args)
 
         if stdout:
             print(output)

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -19,6 +19,7 @@ from azure.cli.core.azclierror import InvalidTemplateError
 from azure.cli.core.mock import DummyCli
 
 cli_ctx = DummyCli()
+cli_ctx.config.set_value("bicep", "use_binary_from_path", "false")
 
 
 class TestBicep(unittest.TestCase):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -16,6 +16,9 @@ from azure.cli.command_modules.resource._bicep import (
     _bicep_version_check_file_path,
 )
 from azure.cli.core.azclierror import InvalidTemplateError
+from azure.cli.core.mock import DummyCli
+
+cli_ctx = DummyCli()
 
 
 class TestBicep(unittest.TestCase):
@@ -24,7 +27,7 @@ class TestBicep(unittest.TestCase):
         isfile_stub.return_value = False
 
         with self.assertRaisesRegex(CLIError, 'Bicep CLI not found. Install it now by running "az bicep install".'):
-            run_bicep_command(["--version"], auto_install=False)
+            run_bicep_command(cli_ctx, ["--version"], auto_install=False)
 
     @mock.patch("azure.cli.command_modules.resource._bicep._logger.warning")
     @mock.patch("azure.cli.command_modules.resource._bicep._run_command")
@@ -45,11 +48,10 @@ class TestBicep(unittest.TestCase):
         _get_bicep_installed_version_stub.return_value = "1.0.0"
         get_bicep_latest_release_tag_stub.return_value = "v2.0.0"
 
-        run_bicep_command(["--version"], check_version=True)
+        run_bicep_command(cli_ctx, ["--version"])
 
         warning_mock.assert_called_once_with(
-            'A new Bicep release is available: %s. Upgrade now by running "az bicep upgrade".',
-            "v2.0.0",
+            'A new Bicep release is available: %s. Upgrade now by running "az bicep upgrade".', "v2.0.0",
         )
 
     @mock.patch("azure.cli.command_modules.resource._bicep._logger.warning")
@@ -74,7 +76,7 @@ class TestBicep(unittest.TestCase):
             _get_bicep_installed_version_stub.return_value = "1.0.0"
             get_bicep_latest_release_tag_stub.return_value = "v2.0.0"
 
-            run_bicep_command(["--version"], check_version=True)
+            run_bicep_command(cli_ctx, ["--version"])
 
             self.assertTrue(os.path.isfile(_bicep_version_check_file_path))
         finally:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az bicep *`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
The `az bicep` commands download Bicep CLI automatically if it does not exist on `$AZURE_CONFIG_DIR/bin`. This is causing an [GitHub API throttling issue](https://github.com/Azure/bicep/issues/3689) if users uses the Azure CLI ADO task, as each task run creates an empty azure config directory. The PR adds two configurations `bicep.use_binary_from_path` and `bicep.check_version` to allow users to reuse the pre-installed Bicep CLI on the CLI runners and to disable version checks for each `az bicep` command run.

Closes https://github.com/Azure/bicep/issues/9452.

**Testing Guide**
Set `bicep.use_binary_from_path` and `bicep.check_version` and run any `az bicep` commands.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ARM] `az bicep`: Add configuration `bicep.use_binary_from_path`. Possible values include `if_running_in_ci` (default) and Booleans
[ARM] `az bicep`: Add configuration `bicep.check_version` that accepts Boolean values. If set to `False`, version checks for Bicep CLI will be disabled

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
