### PR TITLE
[ACR] `acr manifest list-referrers`: Support OCI reference types and remove ORAS artifact reference types

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_constants.py
@@ -32,7 +32,8 @@ ACR_AUDIENCE_RESOURCE_NAME = "containerregistry"
 ALLOWED_TASK_FILE_TYPES = ('.yaml', '.yml', '.toml', '.json', '.sh', '.bash', '.zsh', '.ps1',
                            '.ps', '.cmd', '.bat', '.ts', '.js', '.php', '.py', '.rb', '.lua')
 
-REF_KEY = "referrers"
+# https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+REF_KEY = "manifests"
 
 
 def get_classic_sku(cmd):

--- a/src/azure-cli/azure/cli/command_modules/acr/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_help.py
@@ -592,7 +592,7 @@ examples:
 
 helps['acr manifest list-referrers'] = """
 type: command
-short-summary: List the ORAS referrers to a manifest in an Azure Container Registry.
+short-summary: List the referrers to a manifest in an Azure Container Registry.
 examples:
   - name: List the referrers to the manifest of the artifact 'hello-world:latest'.
     text: az acr manifest list-referrers -r MyRegistry -n hello-world:latest

--- a/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/tests/latest/test_acr_commands_mock.py
@@ -606,10 +606,9 @@ class AcrMockCommandsTests(unittest.TestCase):
                                     manifest_spec='testrepository:testtag')
         mock_requests_get.assert_called_with(
             method='get',
-            url='https://testregistry.azurecr.io/v2/testrepository/_oras/artifacts/referrers',
+            url='https://testregistry.azurecr.io/v2/testrepository/referrers/sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
             headers=get_authorization_header('username', 'password'),
             params={
-                'digest': 'sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
                 'artifactType': None
             },
             json=None,
@@ -622,10 +621,9 @@ class AcrMockCommandsTests(unittest.TestCase):
                                     manifest_spec='testrepository@sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7')
         mock_requests_get.assert_called_with(
             method='get',
-            url='https://testregistry.azurecr.io/v2/testrepository/_oras/artifacts/referrers',
+            url='https://testregistry.azurecr.io/v2/testrepository/referrers/sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
             headers=get_authorization_header('username', 'password'),
             params={
-                'digest': 'sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
                 'artifactType': None
             },
             json=None,
@@ -638,10 +636,9 @@ class AcrMockCommandsTests(unittest.TestCase):
                                     artifact_type='sbom/example')
         mock_requests_get.assert_called_with(
             method='get',
-            url='https://testregistry.azurecr.io/v2/testrepository/_oras/artifacts/referrers',
+            url='https://testregistry.azurecr.io/v2/testrepository/referrers/sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
             headers=get_authorization_header('username', 'password'),
             params={
-                'digest': 'sha256:c5515758d4c5e1e838e9cd307f6c6a0d620b5e07e6f927b07d05f6d12a1ac8d7',
                 'artifactType': 'sbom/example'
             },
             json=None,


### PR DESCRIPTION
**Related command**
az acr manifest list-referrers -r myregistry -n myrepo:mytag

**Description**<!--Mandatory-->
- ACR has started to support [OCI Specifications 1.1](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/azure-container-registry-the-first-cloud-registry-to-support-the/ba-p/3708998). [OCI reference types](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) will supersede [ORAS artifact reference types](https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md). The change switches `acr manifest list-referrers` from `ORAS artifact reference types` to `OCI reference types`

**Testing Guide**
- Use [ORAS CLI](https://oras.land/cli/) to attach an OCI artifact to an image, see the [example](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-oras-artifacts#attach-a-signature-to-the-registry-as-a-reference-to-the-container-image)
- az acr manifest list-referrers -r myregistry -n myrepo:mytag

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[ACR] BREAKING CHANGE: `acr manifest list-referrers`: Support OCI reference types and remove ORAS artifact reference types

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
