### PR TITLE
[AKS] raise InvalidArgumentValueError for azure cni + pod_cidr without overlay

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2030,7 +2030,6 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         # read the original value passed by the command
         network_plugin = self.raw_param.get("network_plugin")
-        network_plugin_mode = self.raw_param.get("network_plugin_mode")
         # try to read the property value corresponding to the parameter from the `mc` object
         if (
             self.mc and
@@ -2038,13 +2037,6 @@ class AKSManagedClusterContext(BaseAKSContext):
             self.mc.network_profile.network_plugin is not None
         ):
             network_plugin = self.mc.network_profile.network_plugin
-
-        if (
-            self.mc and
-            self.mc.network_profile and
-            self.mc.network_profile.network_plugin_mode is not None
-        ):
-            network_plugin_mode = self.mc.network_profile.network_plugin_mode
 
         # this parameter does not need dynamic completion
         # validation
@@ -2059,11 +2051,10 @@ class AKSManagedClusterContext(BaseAKSContext):
                 enable_validation=False
             )
             if network_plugin:
-                if network_plugin == "azure" and pod_cidr and network_plugin_mode != "overlay":
+                if network_plugin == "azure" and pod_cidr:
                     raise InvalidArgumentValueError(
-                        "Please specify network plugin mode `overlay` when using pod_cidr or " +
-                        "use network plugin `kubenet`. For more information about Azure CNI " +
-                        "Overlay please see https://aka.ms/aksoverlay"
+                        "Please use kubenet as the network plugin type when pod_cidr is specified or use "+
+                        "the preview feature Azure CNI Overlay. More information at https://aka.ms/aksoverlay"
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2030,6 +2030,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         # read the original value passed by the command
         network_plugin = self.raw_param.get("network_plugin")
+        network_plugin_mode = self.raw_param.get("network_plugin_mode")
         # try to read the property value corresponding to the parameter from the `mc` object
         if (
             self.mc and
@@ -2037,6 +2038,13 @@ class AKSManagedClusterContext(BaseAKSContext):
             self.mc.network_profile.network_plugin is not None
         ):
             network_plugin = self.mc.network_profile.network_plugin
+
+        if (
+            self.mc and
+            self.mc.network_profile and
+            self.mc.network_profile.network_plugin_mode is not None
+        ):
+            network_plugin_mode = self.mc.network_profile.network_plugin_mode
 
         # this parameter does not need dynamic completion
         # validation
@@ -2051,11 +2059,11 @@ class AKSManagedClusterContext(BaseAKSContext):
                 enable_validation=False
             )
             if network_plugin:
-                if network_plugin == "azure" and pod_cidr:
-                    logger.warning(
-                        'When using `--network-plugin azure` without the preview feature '
-                        '`--network-plugin-mode overlay` the provided pod CIDR "%s" will be '
-                        'overwritten with the subnet CIDR.', pod_cidr
+                if network_plugin == "azure" and pod_cidr and network_plugin_mode != "overlay":
+                    raise InvalidArgumentValueError(
+                        "Please specify network plugin mode `overlay` when using pod_cidr or " +
+                        "use network plugin `kubenet`. For more information about Azure CNI " +
+                        "Overlay please see https://aka.ms/aksoverlay"
                     )
             else:
                 if (


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks create -n mycluster -g myrg --network-plugin azure --pod-cidr 10.244.0.0/16` - will now raise a client error and specify an error message to either use Kubenet or Azure CNI Overlay

`az aks create -n mycluster -g myrg --network-plugin azure --network-plugin-mode overlay --pod-cidr 10.244.0.0/16` - will not have a warning about the pod_cidr being wiped.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Remove unneeded warning message when using Azure CNI Overlay and block user from specifying pod_cidr using azure cni without overlay.

**Testing Guide**
<!--Example commands with explanations.-->

Built az cli locally and tested the InvalidArgumentValueError was raised when trying to use azure cni without overlay and specifying pod_cidr. Also that the warning message did not exist when creating an azure cni overlay cluster.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] `az aks create -n mycluster -g myrg --network-plugin azure --pod-cidr 10.244.0.0/16`: will now raise a client error and specify an error message to either use Kubenet or Azure CNI Overlay
[AKS] `az aks create -n mycluster -g myrg --network-plugin azure --network-plugin-mode overlay --pod-cidr 10.244.0.0/16`: will not have a warning about the pod_cidr being wiped.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
