### PR TITLE
{AKS} az aks nodepool: Add doc line on how to delete node taints

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -993,7 +993,7 @@ parameters:
     short-summary: "Describe how VMs are added to or removed from nodepools."
   - name: --node-taints
     type: string
-    short-summary: The node taints for the node pool.
+    short-summary: The node taints for the node pool. Pass the empty string `""` to remove all taints.
   - name: --labels
     type: string
     short-summary: The node labels for the node pool. See https://aka.ms/node-labels for syntax of labels.
@@ -1120,7 +1120,7 @@ parameters:
     short-summary: Extra nodes used to speed upgrade. When specified, it represents the number or percent used, eg. 5 or 33%
   - name: --node-taints
     type: string
-    short-summary: The node taints for the node pool. You can update the existing node taint of a nodepool or create a new node taint for a nodepool.
+    short-summary: The node taints for the node pool. You can update the existing node taint of a nodepool or create a new node taint for a nodepool. Pass the empty string `""` to remove all taints.
   - name: --labels
     type: string
     short-summary: The node labels for the node pool. See https://aka.ms/node-labels for syntax of labels.

--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -993,7 +993,7 @@ parameters:
     short-summary: "Describe how VMs are added to or removed from nodepools."
   - name: --node-taints
     type: string
-    short-summary: The node taints for the node pool. Pass the empty string `""` to remove all taints.
+    short-summary: The node taints for the node pool.
   - name: --labels
     type: string
     short-summary: The node labels for the node pool. See https://aka.ms/node-labels for syntax of labels.


### PR DESCRIPTION
**Related command**
az aks nodepool update

**Description**
I added a note to the `--node-taints` option in your docs. 

It is not immediately obvious how to delete node taints. [Kubernetes reference](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) tells you to add a hyphen at the end, which does not work on the Azure CLI. This behavior is also different from the `labels` argument.

**Testing Guide**
Unneeded, this is a docs change.

**History Notes**


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
