### PR TITLE
[Packaging] Remove openssl1.1-compat and use openssl-dev in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,8 @@ LABEL maintainer="Microsoft" \
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
 
 # We don't use openssl (3.0) for now. We only install it so that users can use it.
-# Once cryptography is bumped to the latest version, openssl1.1-compat should be removed and openssl1.1-compat-dev
-# should be replaced by openssl-dev.
 RUN apk add --no-cache bash openssh ca-certificates jq curl openssl perl git zip \
- && apk add --no-cache --virtual .build-deps gcc make libffi-dev musl-dev linux-headers \
+ && apk add --no-cache --virtual .build-deps gcc make openssl-dev libffi-dev musl-dev linux-headers \
  && apk add --no-cache libintl icu-libs libc6-compat \
  && apk add --no-cache bash-completion \
  && update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ LABEL maintainer="Microsoft" \
 # We don't use openssl (3.0) for now. We only install it so that users can use it.
 # Once cryptography is bumped to the latest version, openssl1.1-compat should be removed and openssl1.1-compat-dev
 # should be replaced by openssl-dev.
-RUN apk add --no-cache bash openssh ca-certificates jq curl openssl openssl1.1-compat perl git zip \
- && apk add --no-cache --virtual .build-deps gcc make openssl1.1-compat-dev libffi-dev musl-dev linux-headers \
+RUN apk add --no-cache bash openssh ca-certificates jq curl openssl perl git zip \
+ && apk add --no-cache --virtual .build-deps gcc make libffi-dev musl-dev linux-headers \
  && apk add --no-cache libintl icu-libs libc6-compat \
  && apk add --no-cache bash-completion \
  && update-ca-certificates


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Revert #24768, as #24793 is merged and cryptography and pyOpenSSL support openssl3.

Although `openssl1.1-compat` is only available from 2.43.0, it's worth to mention this in changelog.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
