### PR TITLE
{CI} Fix home path `~` in regression test pipeline

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -29,7 +29,7 @@ serial_modules = sys.argv[4].split() if len(sys.argv) >= 5 else []
 fix_failure_tests = sys.argv[5].lower() == 'true' if len(sys.argv) >= 6 else False
 target = sys.argv[6].lower() if len(sys.argv) >= 7 else 'cli'
 working_directory = os.getenv('BUILD_SOURCESDIRECTORY') if target == 'cli' else f"{os.getenv('BUILD_SOURCESDIRECTORY')}/azure-cli-extensions"
-azdev_test_result_dir = f"~/.azdev/env_config/mnt/vss/_work/1/s/env"
+azdev_test_result_dir = os.path.expanduser("~/.azdev/env_config/mnt/vss/_work/1/s/env")
 cli_jobs = {
             'acr': 45,
             'acs': 62,

--- a/scripts/regression_test/extension_regression_test.yml
+++ b/scripts/regression_test/extension_regression_test.yml
@@ -113,13 +113,13 @@ jobs:
     displayName: "Rerun tests"
   - bash: |
       publishErrorModules='false'
-      if [[ -f '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_error_modules_$(Instance_idx).txt' ]]; then
+      if [[ -f '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_error_modules_$(Instance_idx).txt' ]]; then
         publishErrorModules='true'
       fi
       echo "##vso[task.setvariable variable=publishErrorModules]$publishErrorModules"
 
       publishFailureTests='false'
-      if [[ -f '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_failure_tests_$(Instance_idx).txt' ]]; then
+      if [[ -f '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_failure_tests_$(Instance_idx).txt' ]]; then
         publishFailureTests='true'
       fi
       echo "##vso[task.setvariable variable=publishFailureTests]$publishFailureTests"
@@ -128,18 +128,18 @@ jobs:
   - task: PublishTestResults@2
     condition: succeededOrFailed()
     inputs:
-      testResultsFiles: '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_*.xml'
+      testResultsFiles: '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_*.xml'
       testRunTitle: 'CLI Regression test results of instance $(Instance_idx)'
   - task: PublishBuildArtifacts@1
     condition: and(succeededOrFailed(), eq(variables.publishErrorModules, 'true'))
     inputs:
-      PathtoPublish: '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_error_modules_$(Instance_idx).txt'
+      PathtoPublish: '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_error_modules_$(Instance_idx).txt'
       ArtifactName: 'error_modules'
       publishLocation: 'Container'
   - task: PublishBuildArtifacts@1
     condition: and(succeededOrFailed(), eq(variables.publishFailureTests, 'true'))
     inputs:
-      PathtoPublish: '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_failure_tests_$(Instance_idx).txt'
+      PathtoPublish: '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_failure_tests_$(Instance_idx).txt'
       ArtifactName: 'failure_tests'
       publishLocation: 'Container'
 

--- a/scripts/regression_test/regression_test.yml
+++ b/scripts/regression_test/regression_test.yml
@@ -127,7 +127,7 @@ jobs:
       displayName: "Rerun tests"
     - task: PublishTestResults@2
       inputs:
-        testResultsFiles: '~/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_*.xml'
+        testResultsFiles: '/$(HOME)/.azdev/env_config/mnt/vss/_work/1/s/env/test_results_*.xml'
         testRunTitle: 'CLI Regression test results of instance $(Instance_idx)'
 
 - job: CreatePR


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Using `~` directly in ADO pipeline will cause failure, this PR aims to fix the failure. See my comments for detailed explanation



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
