### PR TITLE
[Network] Fix #25130: `az network list-usages`: `-o table` cannot be used

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/network/_format.py
@@ -206,15 +206,6 @@ def transform_waf_rule_sets_table_output(result):
     return transformed
 
 
-def transform_network_usage_list(result):
-    result = list(result)
-    for item in result:
-        item.current_value = str(item.current_value)
-        item.limit = str(item.limit)
-        item.local_name = item.name.localized_value
-    return result
-
-
 def transform_network_usage_table(result):
     transformed = []
     for item in result:

--- a/src/azure-cli/azure/cli/command_modules/network/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/network/commands.py
@@ -36,7 +36,7 @@ from azure.cli.command_modules.network._format import (
     transform_vpn_connection, transform_vpn_connection_list,
     transform_geographic_hierachy_table_output,
     transform_service_community_table_output, transform_waf_rule_sets_table_output,
-    transform_network_usage_list, transform_network_usage_table, transform_nsg_rule_table_output,
+    transform_network_usage_table, transform_nsg_rule_table_output,
     transform_vnet_table_output, transform_effective_route_table, transform_effective_nsg,
     transform_vnet_gateway_routes_table, transform_vnet_gateway_bgp_peer_table)
 from azure.cli.command_modules.network._validators import (
@@ -209,8 +209,9 @@ def load_command_table(self, _):
 
     # region NetworkRoot
     with self.command_group('network'):
-        from azure.cli.command_modules.network.aaz.latest.network import ListUsages
-        self.command_table['network list-usages'] = ListUsages(loader=self, transform=transform_network_usage_list, table_transformer=transform_network_usage_table)
+        from azure.cli.command_modules.network.custom import UsagesList
+        self.command_table['network list-usages'] = UsagesList(loader=self,
+                                                               table_transformer=transform_network_usage_table)
     # endregion
 
     # region ApplicationGateways

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -26,6 +26,7 @@ from azure.cli.command_modules.network._client_factory import network_client_fac
 from azure.cli.command_modules.network.zone_file.parse_zone_file import parse_zone_file
 from azure.cli.command_modules.network.zone_file.make_zone_file import make_zone_file
 
+from .aaz.latest.network import ListUsages as _UsagesList
 from .aaz.latest.network.application_gateway import Update as _ApplicationGatewayUpdate
 from .aaz.latest.network.application_gateway.url_path_map import Create as _URLPathMapCreate, \
     Update as _URLPathMapUpdate
@@ -8158,4 +8159,18 @@ def update_shared_key(cmd, instance, value):
     with cmd.update_context(instance) as c:
         c.set_param('value', value)
     return instance
+# endregion
+
+
+# region usages
+class UsagesList(_UsagesList):
+    def _output(self, *args, **kwargs):
+        result = self.deserialize_output(self.ctx.vars.instance.value, client_flatten=True)
+        next_link = self.deserialize_output(self.ctx.vars.instance.next_link)
+        result = list(result)
+        for item in result:
+            item['currentValue'] = str(item['currentValue'])
+            item['limit'] = str(item['limit'])
+            item['localName'] = item['name']['localizedValue']
+        return result, next_link
 # endregion

--- a/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_usage_list.yaml
+++ b/src/azure-cli/azure/cli/command_modules/network/tests/latest/recordings/test_network_usage_list.yaml
@@ -13,25 +13,25 @@ interactions:
       ParameterSetName:
       - --location
       User-Agent:
-      - AZURECLI/2.42.0 (AAZ) azsdk-python-core/1.24.0 Python/3.8.1 (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.44.1 (AAZ) azsdk-python-core/1.24.0 Python/3.9.5 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages?api-version=2022-01-01
   response:
     body:
-      string: "{\r\n  \"value\": [\r\n    {\r\n      \"currentValue\": 5,\r\n      \"id\":
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"currentValue\": 9,\r\n      \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/VirtualNetworks\",\r\n
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Virtual Networks\",\r\n        \"value\": \"VirtualNetworks\"\r\n      },\r\n
         \     \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n    },\r\n    {\r\n
-        \     \"currentValue\": 1,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/StaticPublicIPAddresses\",\r\n
+        \     \"currentValue\": 3,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/StaticPublicIPAddresses\",\r\n
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Static Public IP Addresses\",\r\n        \"value\": \"StaticPublicIPAddresses\"\r\n
         \     },\r\n      \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n
-        \   },\r\n    {\r\n      \"currentValue\": 161,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/NetworkSecurityGroups\",\r\n
+        \   },\r\n    {\r\n      \"currentValue\": 280,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/NetworkSecurityGroups\",\r\n
         \     \"limit\": 5000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Network Security Groups\",\r\n        \"value\": \"NetworkSecurityGroups\"\r\n
         \     },\r\n      \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n
-        \   },\r\n    {\r\n      \"currentValue\": 3,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/PublicIPAddresses\",\r\n
+        \   },\r\n    {\r\n      \"currentValue\": 8,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/PublicIPAddresses\",\r\n
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Public IP Addresses\",\r\n        \"value\": \"PublicIPAddresses\"\r\n      },\r\n
         \     \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n    },\r\n    {\r\n
@@ -47,7 +47,7 @@ interactions:
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Nat Gateways\",\r\n        \"value\": \"NatGateways\"\r\n      },\r\n      \"unit\":
         \"Count\",\r\n      \"isAdjustable\": true\r\n    },\r\n    {\r\n      \"currentValue\":
-        1,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/NetworkInterfaces\",\r\n
+        -12,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/NetworkInterfaces\",\r\n
         \     \"limit\": 65536,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Network Interfaces\",\r\n        \"value\": \"NetworkInterfaces\"\r\n      },\r\n
         \     \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n    },\r\n    {\r\n
@@ -111,7 +111,7 @@ interactions:
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Standard Sku Load Balancers\",\r\n        \"value\": \"StandardSkuLoadBalancers\"\r\n
         \     },\r\n      \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n
-        \   },\r\n    {\r\n      \"currentValue\": 1,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/StandardSkuPublicIpAddresses\",\r\n
+        \   },\r\n    {\r\n      \"currentValue\": 3,\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/usages/StandardSkuPublicIpAddresses\",\r\n
         \     \"limit\": 1000,\r\n      \"name\": {\r\n        \"localizedValue\":
         \"Public IP Addresses - Standard\",\r\n        \"value\": \"StandardSkuPublicIpAddresses\"\r\n
         \     },\r\n      \"unit\": \"Count\",\r\n      \"isAdjustable\": true\r\n
@@ -207,11 +207,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '17766'
+      - '17768'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 07 Nov 2022 01:25:08 GMT
+      - Mon, 16 Jan 2023 03:07:42 GMT
       expires:
       - '-1'
       pragma:
@@ -221,10 +221,14 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
       x-ms-arm-service-request-id:
-      - 09f1efd1-5215-448e-b6df-a0566a53176c
+      - 23fc4f67-13a1-408a-9227-9201b4098187
     status:
       code: 200
       message: OK


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
fixed: #25130 
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
