### PR TITLE
{Core} Disable aladdin recommendation in autocomplete mode

### DIFF
--- a/src/azure-cli-core/azure/cli/core/command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/command_recommender.py
@@ -345,7 +345,6 @@ class CommandRecommender():  # pylint: disable=too-few-public-methods
         """
 
         from azure.cli.core.cloud import CLOUDS_FORBIDDING_ALADDIN_REQUEST
-        from azure.cli.core.util import is_autocomplete
 
         # CLI is not started well
         if not self.cli_ctx or not self.cli_ctx.cloud:
@@ -359,7 +358,7 @@ class CommandRecommender():  # pylint: disable=too-few-public-methods
         if self.cli_ctx.__class__.__name__ == 'DummyCli':
             return True
 
-        if is_autocomplete():
+        if self.cli_ctx.data['completer_active']:
             return True
 
         return False

--- a/src/azure-cli-core/azure/cli/core/command_recommender.py
+++ b/src/azure-cli-core/azure/cli/core/command_recommender.py
@@ -338,12 +338,14 @@ class CommandRecommender():  # pylint: disable=too-few-public-methods
             1. CLI context is missing
             2. In air-gapped clouds
             3. In testing environments
+            4. In autocomplete mode
 
         :return: whether Aladdin service need to be disabled or not
         :type: bool
         """
 
         from azure.cli.core.cloud import CLOUDS_FORBIDDING_ALADDIN_REQUEST
+        from azure.cli.core.util import is_autocomplete
 
         # CLI is not started well
         if not self.cli_ctx or not self.cli_ctx.cloud:
@@ -355,6 +357,9 @@ class CommandRecommender():  # pylint: disable=too-few-public-methods
 
         # for testing environments
         if self.cli_ctx.__class__.__name__ == 'DummyCli':
+            return True
+
+        if is_autocomplete():
             return True
 
         return False

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1360,9 +1360,3 @@ def should_encrypt_token_cache(cli_ctx):
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 
     return encrypt
-
-
-def is_autocomplete():
-    """Detect if the command is running in autocomplete mode"""
-    from knack.completion import ARGCOMPLETE_ENV_NAME
-    return os.environ.get(ARGCOMPLETE_ENV_NAME) is not None

--- a/src/azure-cli-core/azure/cli/core/util.py
+++ b/src/azure-cli-core/azure/cli/core/util.py
@@ -1360,3 +1360,9 @@ def should_encrypt_token_cache(cli_ctx):
     encrypt = cli_ctx.config.getboolean('core', 'encrypt_token_cache', fallback=fallback)
 
     return encrypt
+
+
+def is_autocomplete():
+    """Detect if the command is running in autocomplete mode"""
+    from knack.completion import ARGCOMPLETE_ENV_NAME
+    return os.environ.get(ARGCOMPLETE_ENV_NAME) is not None


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
If the command is not complete, you will get recommendation.
For example, type `az account` you get
```                                                                                                                                                ─╯
the following arguments are required: _subcommand

Examples from AI knowledge base:
az account list
Get a list of subscriptions for the logged in account. (autogenerated)

az account show
Get the details of a subscription. (autogenerated)

az account set --subscription mysubscription
Set a subscription to be the current active subscription. (autogenerated)

https://docs.microsoft.com/en-US/cli/azure/account#az_account_list
Read more about the command in reference docs
```
In autocomplete mode, it's common that the command is not complete. The recommendation is useless and time-consuming.
So I disable it in autocomplete mode.

**Testing Guide**
<!--Example commands with explanations.-->
`time IFS=$'\013' _ARC_DEBUG=1 COMP_LINE='az account' COMP_POINT=11 COMP_TYPE="" _ARGCOMPLETE=1 _ARGCOMPLETE_SUPPRESS_SPACE=0 az 8>&1 1>&1 2>&1 9>&1 ` takes 0.4s.
After apply this pr, it only takes 0.2s.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
