### PR TITLE
[ARM] `az deployment what-if`: Fix an issue where formatting nested array changes throws an exception

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_formatters.py
@@ -266,7 +266,7 @@ def _format_property_change(builder, property_change, max_path_length, indent_le
         _format_property_modify(builder, before, after, children, indent_level + 1)
     elif property_change_type == PropertyChangeType.array:
         _format_property_change_path(builder, property_change, "children", max_path_length, indent_level)
-        _format_property_array_change(builder, children, indent_level + 1)
+        _format_property_array_change(builder, property_change, children, indent_level + 1)
     elif property_change_type == PropertyChangeType.no_effect:
         _format_property_change_path(builder, property_change, "after", max_path_length, indent_level)
         _format_property_no_effect(builder, after, indent_level + 1)
@@ -275,6 +275,9 @@ def _format_property_change(builder, property_change, max_path_length, indent_le
 
 
 def _format_property_change_path(builder, property_change, value_name, max_path_length, indent_level):
+    if not property_change.path:
+        return
+
     path, property_change_type = property_change.path, property_change.property_change_type
     value = getattr(property_change, value_name)
 
@@ -350,7 +353,14 @@ def _format_property_modify(builder, before, after, children, indent_level):
             builder.append_line()
 
 
-def _format_property_array_change(builder, property_changes, indent_level):
+def _format_property_array_change(builder, parent_property_change, property_changes, indent_level):
+    if not parent_property_change.path:
+        # The parent change doesn't have a path, which means the current
+        # array change is a nested change. We need to decrease indent_level
+        # and print indentation before printing "[".
+        indent_level -= 1
+        _format_indent(builder, indent_level)
+
     if not property_changes:
         builder.append_line("[]")
         return

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_formatters.py
@@ -357,17 +357,11 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
                     WhatIfPropertyChange(
                         path="path.a.to.change2",
                         property_change_type=PropertyChangeType.modify,
-                        before={
-                            "tag1": "value"
-                        },
-                        after={
-                            "tag2": "value"
-                        },
+                        before={"tag1": "value"},
+                        after={"tag2": "value"},
                     ),
                     WhatIfPropertyChange(
-                        path="path.a.to.change3",
-                        property_change_type=PropertyChangeType.no_effect,
-                        after=12345,
+                        path="path.a.to.change3", property_change_type=PropertyChangeType.no_effect, after=12345,
                     ),
                     WhatIfPropertyChange(
                         path="path.b.to.nested.change",
@@ -497,6 +491,81 @@ Scope: /subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg1
     + long.path: []
     ~ long.nested.path: [
       - 5: 12345
+      ]
+"""
+
+        result = format_what_if_operation_result(WhatIfOperationResult(changes=changes), False)
+
+        self.assertIn(expected, result)
+
+    def test_nested_array_changes(self):
+        changes = [
+            WhatIfChange(
+                resource_id="/subscriptions/00000000-0000-0000-0000-000000000004/resourceGroups/rg4/providers/Microsoft.DocumentDB/databaseAccounts/myaccount/sqlDatabases/accesscontrol/containers/workflows",
+                change_type=ChangeType.modify,
+                delta=[
+                    WhatIfPropertyChange(
+                        path="properties.resource.indexingPolicy.compositeIndexes",
+                        property_change_type=PropertyChangeType.array,
+                        children=[
+                            WhatIfPropertyChange(
+                                path="0",
+                                property_change_type=PropertyChangeType.modify,
+                                children=[
+                                    WhatIfPropertyChange(
+                                        path=None,
+                                        property_change_type=PropertyChangeType.array,
+                                        children=[
+                                            WhatIfPropertyChange(
+                                                path="0",
+                                                property_change_type=PropertyChangeType.modify,
+                                                children=[
+                                                    WhatIfPropertyChange(
+                                                        path="order",
+                                                        property_change_type=PropertyChangeType.delete,
+                                                        before="ascending"
+                                                    )
+                                                ]
+                                            ),
+                                            WhatIfPropertyChange(
+                                                path="1",
+                                                property_change_type=PropertyChangeType.modify,
+                                                children=[
+                                                    WhatIfPropertyChange(
+                                                        path="order",
+                                                        property_change_type=PropertyChangeType.delete,
+                                                        before="ascending"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ]
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ]
+
+        expected = """
+Scope: /subscriptions/00000000-0000-0000-0000-000000000004/resourceGroups/rg4
+
+  ~ Microsoft.DocumentDB/databaseAccounts/myaccount/sqlDatabases/accesscontrol/containers/workflows
+    ~ properties.resource.indexingPolicy.compositeIndexes: [
+      ~ 0:
+
+        [
+        ~ 0:
+
+          - order: "ascending"
+
+        ~ 1:
+
+          - order: "ascending"
+
+        ]
+
       ]
 """
 


### PR DESCRIPTION
**Related command**
`az deployment what-if`

**Description**<!--Mandatory-->
A customer reported an issue where the what-if command throws an exception when formatting nested array changes. The PR fixes the bug.

**Testing Guide**
`az deployment what-if ...`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
