### PR TITLE
[Network] Fix #25124: `az network vnet-gateway create`: Active-Active gateway fails with insufficient IP configurations

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -7282,7 +7282,7 @@ def create_vnet_gateway(cmd, resource_group_name, virtual_network_gateway_name,
                 private_ip_allocation_method='Dynamic',
                 name='vnetGatewayConfig{}'.format(i)
             )
-        vnet_gateway.ip_configurations.append(ip_configuration)
+            vnet_gateway.ip_configurations.append(ip_configuration)
     else:
         vnet_gateway.vpn_type = None
         vnet_gateway.sku = None


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-cli/issues/25124

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. ---> az network vnet-gateway create

**Description**<!--Mandatory--> Fix the bug that create network gateway command can only take 1 public ip from arguments while 2 are required
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
