### PR TITLE
{Packaging} Fix #25149: Updated deb_install.sh to use /etc/apt/keyrings

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -38,6 +38,11 @@ global_consent=0 # Artificially giving global consent after review-feedback. Rem
 
 setup() {
 
+    if [[ $(/usr/bin/whoami) != "root" ]]; then
+        echo "Script $(basename $0) must be run as root."
+        exit 1
+    fi
+
     assert_consent "Add packages necessary to modify your apt-package sources?" ${global_consent}
     set -v
     export DEBIAN_FRONTEND=noninteractive
@@ -45,9 +50,15 @@ setup() {
     apt-get install -y apt-transport-https lsb-release gnupg curl
     set +v
 
+    if [[ ! -d /etc/apt/keyrings ]]; then
+        assert_consent "Create the /etc/apt/keyrings directory?" ${global_consent}
+        mkdir -pm 755 /etc/apt/keyrings
+    fi
+
     assert_consent "Add Microsoft as a trusted package signer?" ${global_consent}
     set -v
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg
+    chmod go+r /etc/apt/keyrings/microsoft.gpg
     set +v
 
     assert_consent "Add the Azure CLI Repository to your apt sources?" ${global_consent}
@@ -81,7 +92,7 @@ setup() {
             exit 1
         fi
     fi
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ ${CLI_REPO} main" \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli ${CLI_REPO} main" \
         > /etc/apt/sources.list.d/azure-cli.list
     apt-get update
     set +v


### PR DESCRIPTION
Fixes #25149. Updated deb_install.sh script to match the [manual commands](https://learn.microsoft.com/cli/azure/install-azure-cli-linux?pivots=apt).

* The key is now placed in `/etc/apt/keyrings`
* The /etc/apt/sources.list.d/azure-cli.list file now has the signed-by form, e.g.

    ```text
    deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ jammy main
    ```

* Also added a check to ensure the script is run as root

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).
- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
