### PR TITLE
{AD} `az ad`: Update `--filter` argument's help message

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -234,7 +234,9 @@ def load_arguments(self, _):
         c.argument('identifier_uri', help='graph application identifier, must be in uri format')
         c.argument('spn', help='service principal name')
         c.argument('upn', help='user principal name, e.g. john.doe@contoso.com')
-        c.argument('query_filter', options_list=['--filter'], help='OData filter, e.g. --filter "displayname eq \'test\' and servicePrincipalType eq \'Application\'"')
+        c.argument('query_filter', options_list=['--filter'],
+                   help='The $filter OData query parameter to retrieve a subset of a collection. '
+                        'For more information, see https://learn.microsoft.com/graph/filter-query-parameter')
 
     with self.argument_context('ad user') as c:
         c.argument('mail_nickname', help='mail alias. Defaults to user principal name')


### PR DESCRIPTION
**Related command**
`az ad`

**Description**<!--Mandatory-->
`--filter` is defined on the whole `az ad` scope, so whenever a command under `az ad` supports `--filter`, the help message shows the same example:

https://github.com/Azure/azure-cli/blob/ce4469321e66be2ef75b2c2721be7e289ab20a84/src/azure-cli/azure/cli/command_modules/role/_params.py#L232

https://github.com/Azure/azure-cli/blob/ce4469321e66be2ef75b2c2721be7e289ab20a84/src/azure-cli/azure/cli/command_modules/role/_params.py#L237

The current example `--filter "displayname eq 'test' and servicePrincipalType eq 'Application'"` only works for `az ad sp list`, but doesn't work for

- `az ad app list`
- `az ad app permission list-grants`
- `az ad user list`
- `az ad group list`

This PR updates the help message of `--filter` to a generic one that suits all commands that supports `--filter`.