### PR TITLE
Trailing slash on issuer URL causes issues

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/role/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_help.py
@@ -350,7 +350,7 @@ examples:
     ("credential.json" contains the following content)
     {
         "name": "Testing",
-        "issuer": "https://token.actions.githubusercontent.com/",
+        "issuer": "https://token.actions.githubusercontent.com",
         "subject": "repo:octo-org/octo-repo:environment:Production",
         "description": "Testing",
         "audiences": [


### PR DESCRIPTION
The trailing slash on the issuer URL in the code sample will cause the federated credential to not work when leveraging the azure/login action in a pipeline. The error it throws is "AADSTS70021: No matching federated identity record found for presented assertion".

Removing the trailing slash fixes it and works as expected.

**Description**
Documentation update when using `az ad app federated-credential create` to create a federated credential.

The official GitHub documents also call this out as not having a trailing slash https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#:~:text=(Issuer)%20The%20issuer%20of%20the%20OIDC%20token%3A%20https%3A//token.actions.githubusercontent.com

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
