### PR TITLE
{CI} Fix azure cli live test send email

### DIFF
--- a/scripts/live_test/CLITest.yml
+++ b/scripts/live_test/CLITest.yml
@@ -464,7 +464,7 @@ jobs:
         ls $(System.ArtifactsDirectory)
         pwd
         commit_id=`git ls-remote https://github.com/Azure/azure-cli.git HEAD`
-        pip install sendgrid
+        pip install azure-communication-email
         pip install mysql-connector-python
         pip install requests
         # pip install certifi


### PR DESCRIPTION
Abandoning `Twilio SendGrid` for several reasons:
1. `Twilio SendGrid` is not a Microsoft product
2. The `Twilio SendGrid` we created before sends email and returns 202, but the actual sending is not successful, it may be blocked by `Twilio SendGrid`
3. Creating a new `Twilio SendGrid` needs to add a credit card, so it cannot be created successfully
![image](https://user-images.githubusercontent.com/18628534/213604935-4fa1ef2e-a2ca-4ae7-87e5-7f026023ff3e.png)

After many attempts, I decided to use the azure service `Azure Communication Email` instead of `Twilio SendGrid`
Test screenshot:
![image](https://user-images.githubusercontent.com/18628534/213604198-a4016328-6fa4-41ea-a464-71131c7811c1.png)

TODO:
How can we stop Outlook from recognizing this type of mail as external?