### PR TITLE
[RDBMS] `az postgres flexible-server migration`: Change behavior of cancel/cutover and added Offline Flag for FMS based migrations

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -354,7 +354,9 @@ helps['postgres flexible-server migration create'] = """
 type: command
 short-summary: Create a new migration workflow for a flexible server.
 examples:
-  - name: Start a migration workflow on the target server identified by the parameters. The configurations of the migration should be specified in the migrationConfig.json file.
+  - name: Start a migration workflow on the target server identified by the parameters. The configurations of the migration should be specified in the migrationConfig.json file. Use --migration-mode online for Online(with CDC) migration
+    text: az postgres flexible-server migration create --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --properties "migrationConfig.json" --migration-mode online
+  - name: Start a migration workflow on the target server identified by the parameters. The configurations of the migration should be specified in the migrationConfig.json file. Use --migration-mode offline or no --migration-mode flag for Offline Migration.
     text: az postgres flexible-server migration create --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --properties "migrationConfig.json"
 """
 
@@ -386,10 +388,10 @@ examples:
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --db-names db1 db2
   - name: Allow the migration workflow to overwrite the DB on the target.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --overwrite-dbs
-  - name: Cut-over the data migration for either all databases or few selected ones. After this is complete, subsequent updates to the selected databases will not be migrated to the target.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover db1 db2 db3
-  - name: Cancel the data migration for either all databases or few selected ones.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover db1 db2 db3
+  - name: Cut-over the data migration for all the databases involved in the migration.After this is complete, subsequent updates to all databases in the migration will not be migrated to the target.
+    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover
+  - name: Cancels the data migration for all the databases involved in the migration.
+    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cancel
 """
 
 helps['postgres flexible-server migration check-name-availability'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -388,7 +388,7 @@ examples:
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --db-names db1 db2
   - name: Allow the migration workflow to overwrite the DB on the target.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --overwrite-dbs
-  - name: Cut-over the data migration for all the databases involved in the migration.After this is complete, subsequent updates to all databases in the migration will not be migrated to the target.
+  - name: Cut-over the data migration for all the databases involved in the migration. After this is complete, subsequent updates to all databases in the migration will not be migrated to the target.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover
   - name: Cancels the data migration for all the databases involved in the migration.
     text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cancel

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -770,10 +770,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                                help='Space-separated list of DBs to migrate. Note that each additional DB affects the performance of the source server.')
                     c.argument('overwrite_dbs', options_list=['--overwrite-dbs'], action='store_true', required=False,
                                help='Allow the migration workflow to overwrite the DB on the target.')
-                    c.argument('cutover', nargs='+', options_list=['--cutover'], required=False,
-                               help='Cut-over the data migration for either all databases or few selected ones. After this is complete, subsequent updates to the selected databases will not be migrated to the target.')
-                    c.argument('cancel', nargs='+', options_list=['--cancel'], required=False,
-                               help='Cancel the data migration for either all databases or few selected ones.')
+                    c.argument('cutover', options_list=['--cutover'], required=False, action='store_true',
+                               help='Cut-over the data migration for all the databases in the migration. After this is complete, subsequent updates to all databases will not be migrated to the target.')
+                    c.argument('cancel', options_list=['--cancel'], required=False, action='store_true',
+                               help='Cancel the data migration for all the databases.')
                 elif scope == "check-name-availability":
                     c.argument('migration_name', arg_type=migration_id_arg_type, options_list=['--migration-name'],
                                help='Name of the migration.')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -123,16 +123,17 @@ def migration_update_func(cmd, client, resource_group_name, server_name, migrati
         if operationSpecified is True:
             raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
         operationSpecified = True
-        r = migration_show_func(cmd, client, resource_group_name, server_name, migration_name, "Default")
+        r = migration_show_func(cmd, client, resource_group_name, server_name, migration_name)
         if r.get("properties").get("migrationMode") == "Offline":
             raise BadRequestError("Cutover is not possible for migration {} if the migration_mode set to offline. The migration will cutover automatically".format(migration_name))
-        properties = json.dumps({"properties": {"triggerCutover": "true", "DBsToTriggerCutoverMigrationOn": cutover}})
+        properties = json.dumps({"properties": {"triggerCutover": "true", "DBsToTriggerCutoverMigrationOn": r.get("properties").get("dBsToMigrate")}})
 
     if cancel is not None:
         if operationSpecified is True:
             raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
         operationSpecified = True
-        properties = json.dumps({"properties": {"Cancel": "true", "DBsToCancelMigrationOn": cancel}})
+        r = migration_show_func(cmd, client, resource_group_name, server_name, migration_name)
+        properties = json.dumps({"properties": {"Cancel": "true", "DBsToCancelMigrationOn": r.get("properties").get("dBsToMigrate")}})
 
     if operationSpecified is False:
         raise RequiredArgumentMissingError("Incorrect Usage: At least one update operation needs to be specified.")

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -62,6 +62,9 @@ def migration_create_func(cmd, client, resource_group_name, server_name, propert
             request_payload = json.load(f)
             if migration_mode == "online":
                 request_payload.get("properties")['MigrationMode'] = "Online"
+            else:
+                request_payload.get("properties")['MigrationMode'] = "Offline"
+
             json_data = json.dumps(request_payload)
         except ValueError as err:
             logger.error(err)


### PR DESCRIPTION
**Related command**
Added --offline and --online flags to az postgres flexible-server migration create
Changed `az postgres flexible-server migration update `--cutover` db1 db2 db3` to `az postgres flexible-server migration update` `--cutover`

Changed `az postgres flexible-server migration update `--cancel` db1 db2 db3` to `az postgres flexible-server migration update` `--cancel`

**Description**
This PR is a breaking change for FMS based Migrations from Sterling to Meru Platforms in Postgres.
Fixed offline mode for migration creation. The supplied flag was never being passed to the JSON request.
Changed Cancel and cutover functionality to ONLY ALL databases involved in the migration.
**The PR does not break any functionality for the existing customers.**

**Testing Guide**
Did manually testing.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
