### PR TITLE
[NetAppFiles] Fix volume patch dataprotection props

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -338,7 +338,7 @@ def patch_volume(instance, usage_threshold=None, service_level=None, tags=None, 
     if any(x is not None for x in [vault_id, backup_policy_id, backup_enabled, policy_enforced]):
         backup = VolumeBackupProperties(vault_id=vault_id, backup_enabled=backup_enabled,
                                         backup_policy_id=backup_policy_id, policy_enforced=policy_enforced)
-        logger.debug("ANF Log: backup set")                                        
+        logger.debug("ANF Log: backup set")
 
     if any(x is not None for x in [backup, snapshot]):
         snapshot = VolumeSnapshotProperties(snapshot_policy_id=snapshot_policy_id)

--- a/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/netappfiles/custom.py
@@ -327,8 +327,8 @@ def create_volume(cmd, client, account_name, pool_name, volume_name, resource_gr
 
 
 # -- volume update
-def patch_volume(instance, usage_threshold=None, service_level=None, tags=None, vault_id=None, backup_enabled=False,
-                 backup_policy_id=None, policy_enforced=False, throughput_mibps=None, snapshot_policy_id=None,
+def patch_volume(instance, usage_threshold=None, service_level=None, tags=None, vault_id=None, backup_enabled=None,
+                 backup_policy_id=None, policy_enforced=None, throughput_mibps=None, snapshot_policy_id=None,
                  is_def_quota_enabled=None, default_user_quota=None, default_group_quota=None, unix_permissions=None,
                  cool_access=None, coolness_period=None):
     data_protection = None
@@ -338,8 +338,11 @@ def patch_volume(instance, usage_threshold=None, service_level=None, tags=None, 
     if any(x is not None for x in [vault_id, backup_policy_id, backup_enabled, policy_enforced]):
         backup = VolumeBackupProperties(vault_id=vault_id, backup_enabled=backup_enabled,
                                         backup_policy_id=backup_policy_id, policy_enforced=policy_enforced)
-    if snapshot_policy_id is not None:
+        logger.debug("ANF Log: backup set")                                        
+
+    if any(x is not None for x in [backup, snapshot]):
         snapshot = VolumeSnapshotProperties(snapshot_policy_id=snapshot_policy_id)
+        logger.debug("ANF Log: DataProtection props set")
 
     if backup is not None or snapshot is not None:
         data_protection = VolumePatchPropertiesDataProtection(backup=backup, snapshot=snapshot)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az netappfiles volume update 


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix an issue where Volumes `DataProtectionProperties`  properties where getting updated (with default values)  in PATCH opertion even when not set on command line for update command.

**Testing Guide**
<!--Example commands with explanations.-->
az netappfiles volume update -g test_rg -a testAccount -p testPool -v test-volume1 --usage-threshold 1000
Just setting `usage-threshold`  should not update `DataProtection `properties

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
