### PR TITLE
[Network] `az network dns zone export`: Fix the export to emit all ALIAS records for a particular record set name

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/custom.py
@@ -2534,7 +2534,8 @@ def export_zone(cmd, resource_group_name, zone_name, file_name=None):  # pylint:
                 target_resource_id = record_set.target_resource.id
                 record_obj.update({'target-resource-id': record_type.upper() + " " + target_resource_id})
                 record_type = 'alias'
-                zone_obj[record_set_name][record_type] = []
+                if record_type not in zone_obj[record_set_name]:
+                    zone_obj[record_set_name][record_type] = []
             elif record_type == 'aaaa' or record_type == 'a':
                 record_obj.update({'ip': ''})
             elif record_type == 'cname':

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2603,7 +2603,8 @@ def export_zone(cmd, resource_group_name, zone_name, file_name=None):  # pylint:
                 target_resource_id = record_set.target_resource.id
                 record_obj.update({'target-resource-id': record_type.upper() + " " + target_resource_id})
                 record_type = 'alias'
-                zone_obj[record_set_name][record_type] = []
+                if record_type not in zone_obj[record_set_name]:
+                    zone_obj[record_set_name][record_type] = []
             elif record_type == 'aaaa' or record_type == 'a':
                 record_obj.update({'ip': ''})
             elif record_type == 'cname':


### PR DESCRIPTION
**Related command**
`az network dns zone export`

**Description**<!--Mandatory-->
Let's say there are two ALIAS records for the same record set name:

    www 3600 AZURE ALIAS A    /subscriptions/...
    www 3600 AZURE ALIAS AAAA /subscriptions/...

Before this change, export would only emit the last record for any record set name, in this case the AAAA record, because when it processed the second record it would incorrectly clear the array containing the first record.

With this change, the array is only initialized when the first record is processed.

**Testing Guide**
I had this problem with my DNS Zone, so I made the change in my local `azure-cli` installation and verified the export is now correct.

I did not find any checked-in tests for `export_zone`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
