### PR TITLE
{CI} Fix regression test git push branch

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -288,7 +288,7 @@ def git_push(message, modules=[]):
             module_name = '_'.join(modules)
             branch_name = f"regression_test_{build_id}_{module_name}"
             run_command(["git", "checkout", "-b", branch_name])
-            run_command(["git", "push", "azclibot", branch_name], check_return_code=True)
+            run_command(["git", "push", "--set-upstream", "azclibot", branch_name], check_return_code=True)
         run_command(["git", "add", "src/*"], check_return_code=True)
         run_command(["git", "commit", "-m", message], check_return_code=True)
     except RuntimeError as ex:

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -283,12 +283,12 @@ def git_push(message, modules=[]):
     if "nothing to commit, working tree clean" in str(stdout):
         return
     try:
-        build_id = os.getenv("BUILD_BUILDID")
-        branch_name = f"regression_test_{build_id}"
         if modules:
+            build_id = os.getenv("BUILD_BUILDID")
             module_name = '_'.join(modules)
             branch_name = f"regression_test_{build_id}_{module_name}"
             run_command(["git", "checkout", "-b", branch_name])
+            run_command(["git", "push", "azclibot", branch_name], check_return_code=True)
         run_command(["git", "add", "src/*"], check_return_code=True)
         run_command(["git", "commit", "-m", message], check_return_code=True)
     except RuntimeError as ex:
@@ -298,7 +298,7 @@ def git_push(message, modules=[]):
         try:
             run_command(["git", "fetch"], check_return_code=True)
             run_command(["git", "pull", "--rebase"], check_return_code=True)
-            run_command(["git", "push", "azclibot", branch_name], check_return_code=True)
+            run_command(["git", "push"], check_return_code=True)
 
             logger.info("git push all recording files")
             break

--- a/scripts/regression_test/regression_test.yml
+++ b/scripts/regression_test/regression_test.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global user.name "Azure CLI Team"
           git remote add azclibot https://azclibot:${GITHUB_TOKEN}@github.com/azclibot/azure-cli.git
 
-          git checkout -b bump_version_$(Build.BuildId)
+          git checkout -b regression_test_$(Build.BuildId)
 
           echo package: $(PACKAGE) $(TARGET_PACKAGE_VERSION)
           echo resource_type: $(RESOURCE_TYPE) $(TARGET_API_VERSION)
@@ -57,7 +57,7 @@ jobs:
 
           git add .
           git commit -m "update version"
-          git push --set-upstream azclibot bump_version_$(Build.BuildId)
+          git push --set-upstream azclibot regression_test_$(Build.BuildId)
 
 - job: RerunTests
   displayName: CLI Regression tests
@@ -104,7 +104,7 @@ jobs:
             GITHUB_TOKEN=$(CUSTOM_GITHUB_TOKEN)
           else
             GITHUB_REPO="azclibot"
-            GITHUB_BRANCH="bump_version_$(Build.BuildId)"
+            GITHUB_BRANCH="regression_test_$(Build.BuildId)"
             GITHUB_TOKEN=$(az keyvault secret show --vault-name kv-azuresdk --name azclibot-pat --query value -otsv)
           fi
           git config --global user.email "AzPyCLI@microsoft.com"


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When implementing Extension Regression Test Pipeline, we push all changes to `azclibot` repo
But in CLI Regression Test Pipeline, we support customized repo & branch

Here's a fix to specify `azclibot` repo only for Extension Regression Test Pipeline

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
