### PR TITLE
[SLQ] `az sql db threat-policy`: Change expiration version for cmd group to 2.49.0

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -386,7 +386,7 @@ def load_command_table(self, _):
     with self.command_group('sql db threat-policy',
                             database_threat_detection_policies_operations,
                             client_factory=get_sql_database_threat_detection_policies_operations,
-                            deprecate_info=self.deprecate(redirect='sql db advanced-threat-protection-setting', hide=True, expiration='2.45.0')) as g:
+                            deprecate_info=self.deprecate(redirect='sql db advanced-threat-protection-setting', hide=True, expiration='2.49.0')) as g:
 
         g.custom_show_command('show', 'db_threat_detection_policy_get')
         g.generic_update_command('update',


### PR DESCRIPTION
**Related command**
`az sql db threat-policy show`
`az sql db threat-policy show update`

**Description**<!--Mandatory-->
Microsoft.Sql - Change expiration version for `az sql db threat-policy` cmds group to version 2.49.0 (instead of 2.45.0)
The following will replace this cmd group:
`az sql db advanced-threat-protection-setting show -g <resource_group> -s <sql_server_name> -n <db_name>`
Displays the current advancedThreatProtectionSettings state for the SQL Database (Enabled or Disabled)
`az sql db advanced-threat-protection-setting update -g <resource_group> -s <sql_server_name> -n <db_name> --state <Disabled/Enabled>`
Updates the current advancedThreatProtectionSettings state for the SQL Database (Enabled or Disabled)

**Testing Guide**
`az sql db threat-policy show -g <resource_group> -s <sql_server_name> -n <db_name>`
Displays the current policy configuration for the SQL Database
`az sql db threat-policy update -g <resource_group> -s <sql_server_name> -n <db_name> --state <Disabled/Enabled>`
Updates the current policy configuration state for the SQL Database (Enabled or Disabled)

**History Notes**
[SLQ] `az sql db threat-policy`: Change expiration version for cmd group to 2.49.0

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
