### PR TITLE
{Core} Add linux distribution info in telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -143,6 +143,8 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.OS.Type': platform.system().lower(),  # eg. darwin, windows
             'Context.Default.VS.Core.OS.Version': platform.version().lower(),  # eg. 10.0.14942
             'Context.Default.VS.Core.OS.Platform': platform.platform().lower(),  # eg. windows-10-10.0.19041-sp0
+            'Context.Default.VS.Core.Distro.Name': _get_distro_name(),
+            'Context.Default.VS.Core.Distro.Version': _get_distro_version(),
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
             'Context.Default.VS.Core.User.IsOptedIn': 'True',
@@ -554,6 +556,24 @@ def _get_hash_mac_address():
 def _get_hash_machine_id():
     # Definition: Take first 128bit of the SHA256 hashed MAC address and convert them into a GUID
     return str(uuid.UUID(_get_hash_mac_address()[0:32]))
+
+
+@decorators.suppress_all_exceptions(fallback_return='')
+def _get_distro_name():
+    try:
+        import distro
+        return distro.name(pretty=True)
+    except ImportError:
+        return ''
+
+
+@decorators.suppress_all_exceptions(fallback_return='')
+def _get_distro_version():
+    try:
+        import distro
+        return distro.version(pretty=True)
+    except ImportError:
+        return ''
 
 
 @decorators.suppress_all_exceptions(fallback_return='')

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -143,8 +143,9 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.OS.Type': platform.system().lower(),  # eg. darwin, windows
             'Context.Default.VS.Core.OS.Version': platform.version().lower(),  # eg. 10.0.14942
             'Context.Default.VS.Core.OS.Platform': platform.platform().lower(),  # eg. windows-10-10.0.19041-sp0
-            'Context.Default.VS.Core.Distro.Name': _get_distro_name(),
-            'Context.Default.VS.Core.Distro.Version': _get_distro_version(),
+            # the distro info is complement of platform info for linux
+            'Context.Default.VS.Core.Distro.Name': _get_distro_name(),  # eg. 'CentOS Linux 8'
+            'Context.Default.VS.Core.Distro.Version': _get_distro_version(),  # eg. '8.4.2105'
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
             'Context.Default.VS.Core.User.IsOptedIn': 'True',

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -145,6 +145,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
             'Context.Default.VS.Core.OS.Platform': platform.platform().lower(),  # eg. windows-10-10.0.19041-sp0
             # the distro info is complement of platform info for linux
             'Context.Default.VS.Core.Distro.Name': _get_distro_name(),  # eg. 'CentOS Linux 8'
+            'Context.Default.VS.Core.Distro.Id': _get_distro_id(),  # eg. 'centos'
             'Context.Default.VS.Core.Distro.Version': _get_distro_version(),  # eg. '8.4.2105'
             'Context.Default.VS.Core.User.Id': _get_installation_id(),
             'Context.Default.VS.Core.User.IsMicrosoftInternal': 'False',
@@ -569,10 +570,19 @@ def _get_distro_name():
 
 
 @decorators.suppress_all_exceptions(fallback_return='')
+def _get_distro_id():
+    try:
+        import distro
+        return distro.id()
+    except ImportError:
+        return ''
+
+
+@decorators.suppress_all_exceptions(fallback_return='')
 def _get_distro_version():
     try:
         import distro
-        return distro.version(pretty=True)
+        return distro.version()
     except ImportError:
         return ''
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -47,6 +47,8 @@ DEPENDENCIES = [
     'azure-cli-telemetry==1.0.8.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
+    # On Linux, the distribution (Ubuntu, Debian, etc) and version are logged in telemetry
+    'distro; sys_platform == "linux"',
     'humanfriendly~=10.0',
     'jmespath',
     'knack~=0.10.1',


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #24783 

Currently we use `platform.system()`, `platform.version()` and `platform.platform()` to log OS info in telemetry https://github.com/Azure/azure-cli/blob/060b414d8ac5e4d8f4fc17cc2e23c2154c762226/src/azure-cli-core/azure/cli/core/telemetry.py#L143-L145

But it's not clear in some scenarios for linux distribution like @jiasli mentioned in the linked issue.
In this PR, we import `distro` lib for linux and log detailed info. Another two fields will be added to `Properties` in telemetry:
- `Context.Default.VS.Core.Distro.Name`
- `Context.Default.VS.Core.Distro.Version`



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
