### PR TITLE
[Core] `aaz`: Support singular options of `AAZListArg` in shorthand syntax partial value expression

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -16,7 +16,7 @@ from azure.cli.core import azclierror
 from ._base import AAZUndefined, AAZBlankArgValue
 from ._help import AAZShowHelp
 from ._utils import AAZShortHandSyntaxParser
-from .exceptions import AAZInvalidShorthandSyntaxError, AAZInvalidValueError
+from .exceptions import AAZInvalidShorthandSyntaxError, AAZInvalidValueError, AAZUnknownFieldError
 
 logger = get_logger(__name__)
 
@@ -64,13 +64,14 @@ class AAZArgAction(Action):
             setattr(namespace, self.dest, AAZArgActionOperations())
         dest_ops = getattr(namespace, self.dest)
         try:
-            self.setup_operations(dest_ops, values)
+            try:
+                self.setup_operations(dest_ops, values)
+            except AAZShowHelp as aaz_help:
+                # show help message
+                aaz_help.keys = (option_string, *aaz_help.keys)
+                self.show_aaz_help(parser, aaz_help) # may raise AAZUnknownFieldError
         except (ValueError, KeyError) as ex:
             raise azclierror.InvalidArgumentValueError(f"Failed to parse '{option_string}' argument: {ex}") from ex
-        except AAZShowHelp as aaz_help:
-            # show help message
-            aaz_help.keys = (option_string, *aaz_help.keys)
-            self.show_aaz_help(parser, aaz_help)
 
     @classmethod
     def setup_operations(cls, dest_ops, values, prefix_keys=None):
@@ -165,50 +166,78 @@ class AAZCompoundTypeArgAction(AAZArgAction):  # pylint: disable=abstract-method
     def decode_values(cls, values):
         for v in values:
             key, key_parts, v = cls._str_parser.split_partial_value(v)
-            v = cls._decode_value(key, key_parts, v)
+            key_parts, schema = cls.get_schema_by_key_items(key_parts, cls._schema)
+
+            try:
+                v = cls._decode_value(schema, v)
+            except AAZShowHelp as aaz_help:
+                aaz_help.schema = cls._schema
+                aaz_help.keys = (*key_parts, *aaz_help.keys)
+                raise aaz_help
+
             yield key, key_parts, v
 
+    @staticmethod
+    def get_schema_by_key_items(key_items, schema):
+        if not key_items:
+            return key_items, schema
+
+        valid_key_items = []
+        for item in key_items:
+            try:
+                schema = schema[item]
+                valid_key_items.append(item)
+            except AAZUnknownFieldError as err:
+                from ._arg import AAZObjectArg, AAZListArg
+                if not isinstance(schema, AAZObjectArg):
+                    raise err
+                is_singular = False
+                for field_name, field in schema._fields.items():
+                    if not isinstance(field, AAZListArg):
+                        continue
+                    if field.singular_options and item in field.singular_options:
+                        valid_key_items.append(field_name)
+                        schema = field.Element
+                        valid_key_items.append(_ELEMENT_APPEND_KEY)
+                        is_singular = True
+                        break
+                if not is_singular:
+                    raise err
+        return valid_key_items, schema
+
     @classmethod
-    def _decode_value(cls, key, key_items, value):  # pylint: disable=unused-argument
+    def _decode_value(cls, schema, value):  # pylint: disable=unused-argument
         from ._arg import AAZSimpleTypeArg
         from azure.cli.core.util import get_file_json, shell_safe_json_parse, get_file_yaml
-
-        schema = cls._schema
-        for item in key_items:
-            schema = schema[item]  # pylint: disable=unsubscriptable-object
 
         if len(value) == 0:
             # the express "a=" will return the blank value of schema 'a'
             return AAZBlankArgValue
 
-        try:
-            if isinstance(schema, AAZSimpleTypeArg):
-                # simple type
-                v = cls._str_parser(value, is_simple=True)
-            else:
-                # compound type
-                # read from file
-                path = os.path.expanduser(value)
-                if os.path.exists(path):
-                    if path.endswith('.yml') or path.endswith('.yaml'):
-                        # read from yaml file
-                        v = get_file_yaml(path)
-                    else:
-                        # read from json file
-                        v = get_file_json(path, preserve_order=True)
+        if isinstance(schema, AAZSimpleTypeArg):
+            # simple type
+            v = cls._str_parser(value, is_simple=True)
+        else:
+            # compound type
+            # read from file
+            path = os.path.expanduser(value)
+            if os.path.exists(path):
+                if path.endswith('.yml') or path.endswith('.yaml'):
+                    # read from yaml file
+                    v = get_file_yaml(path)
                 else:
+                    # read from json file
+                    v = get_file_json(path, preserve_order=True)
+            else:
+                try:
+                    v = cls._str_parser(value)
+                except AAZInvalidShorthandSyntaxError as shorthand_ex:
                     try:
-                        v = cls._str_parser(value)
-                    except AAZInvalidShorthandSyntaxError as shorthand_ex:
-                        try:
-                            v = shell_safe_json_parse(value, True)
-                        except Exception as ex:
-                            logger.debug(ex)  # log parse json failed expression
-                            raise shorthand_ex  # raise shorthand syntax exception
-        except AAZShowHelp as aaz_help:
-            aaz_help.schema = cls._schema
-            aaz_help.keys = (*key_items, *aaz_help.keys)
-            raise aaz_help
+                        v = shell_safe_json_parse(value, True)
+                    except Exception as ex:
+                        logger.debug(ex)  # log parse json failed expression
+                        raise shorthand_ex  # raise shorthand syntax exception
+
         return v
 
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -69,7 +69,7 @@ class AAZArgAction(Action):
             except AAZShowHelp as aaz_help:
                 # show help message
                 aaz_help.keys = (option_string, *aaz_help.keys)
-                self.show_aaz_help(parser, aaz_help) # may raise AAZUnknownFieldError
+                self.show_aaz_help(parser, aaz_help)  # may raise AAZUnknownFieldError
         except (ValueError, KeyError) as ex:
             raise azclierror.InvalidArgumentValueError(f"Failed to parse '{option_string}' argument: {ex}") from ex
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -203,7 +203,7 @@ class AAZCompoundTypeArgAction(AAZArgAction):  # pylint: disable=abstract-method
                         break
                 if not is_singular:
                     raise err
-        return valid_key_items, schema
+        return tuple(valid_key_items), schema
 
     @classmethod
     def _decode_value(cls, schema, value):  # pylint: disable=unused-argument

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_arg.py
@@ -1139,6 +1139,7 @@ class TestAAZArg(unittest.TestCase):
         )
         schema.properties.vnets = AAZListArg(
             options=["vnets"],
+            singular_options=["vnet"],
             nullable=True
         )
         schema.properties.vnets.Element = AAZObjectArg()
@@ -1183,8 +1184,25 @@ class TestAAZArg(unittest.TestCase):
             "pt": 12.123
         })
 
+        action.setup_operations(dest_ops, ["vnet.id=223", "vnet={id:456}"])
+        self.assertEqual(len(dest_ops._ops), 3)
+        dest_ops.apply(v, "properties")
+        self.assertEqual(v.properties.to_serialized_data(), {
+            "enable": False,
+            "tags": {
+                "a": 1,
+                "3": 2,
+            },
+            "vnets": [
+                {"id": "/123"},
+                {"id": "223"},
+                {"id": "456"}
+            ],
+            "pt": 12.123
+        })
+
         action.setup_operations(dest_ops, ["pt=", "enable=null", "vnets=[]"])
-        self.assertEqual(len(dest_ops._ops), 4)
+        self.assertEqual(len(dest_ops._ops), 6)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, {
             "enable": None,
@@ -1197,7 +1215,7 @@ class TestAAZArg(unittest.TestCase):
         })
 
         action.setup_operations(dest_ops, ["{enable:false,pt,tags:{a:1,3:2,c},vnets:[{id}],identities:{a:{},'http://b/c/d/e'}}"])
-        self.assertEqual(len(dest_ops._ops), 5)
+        self.assertEqual(len(dest_ops._ops), 7)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, {
             "enable": False,
@@ -1217,7 +1235,7 @@ class TestAAZArg(unittest.TestCase):
         })
 
         action.setup_operations(dest_ops, ["identities.'http://b.p['/]/c'=", "identities.a=null"])
-        self.assertEqual(len(dest_ops._ops), 7)
+        self.assertEqual(len(dest_ops._ops), 9)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, {
             "enable": False,
@@ -1238,17 +1256,17 @@ class TestAAZArg(unittest.TestCase):
         })
 
         action.setup_operations(dest_ops, ["{}"])
-        self.assertEqual(len(dest_ops._ops), 8)
+        self.assertEqual(len(dest_ops._ops), 10)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, {})
 
         action.setup_operations(dest_ops, ["null"])
-        self.assertEqual(len(dest_ops._ops), 9)
+        self.assertEqual(len(dest_ops._ops), 11)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, None)
 
         action.setup_operations(dest_ops, ["{enable:True,tags:null,vnets:null,pt:12.123,newIPv6:'00:00:00'}"])
-        self.assertEqual(len(dest_ops._ops), 10)
+        self.assertEqual(len(dest_ops._ops), 12)
         dest_ops.apply(v, "properties")
         self.assertEqual(v.properties, {
             "enable": True,


### PR DESCRIPTION
Closed https://github.com/Azure/aaz-dev-tools/issues/188

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
