### PR TITLE
{AzureServiceBus} fixes Azure/azure-cli#25161 fix for migration abort issue

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicebus/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/commands.py
@@ -177,7 +177,7 @@ def load_command_table(self, _):
         g.custom_command('start', 'cli_migration_start')
         g.custom_show_command('show', 'cli_migration_show')
         g.custom_command('complete', 'cli_migration_complete')
-        g.command('abort', 'revert')
+        g.custom_command('abort', 'revert')
 
 # NetwrokRuleSet Region
     with self.command_group('servicebus namespace network-rule', sb_namespace_util, client_factory=namespaces_mgmt_client_factory, resource_type=ResourceType.MGMT_SERVICEBUS) as g:

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -628,6 +628,10 @@ def cli_migration_complete(client, resource_group_name, namespace_name, config_n
     return client.complete_migration(resource_group_name, namespace_name, config_name)
 
 
+def revert(client, resource_group_name, namespace_name, config_name="$default"):
+    return client.revert(resource_group_name, namespace_name, config_name)
+
+
 iso8601pattern = re.compile("^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+.)?(\\d+S)?)?$")
 timedeltapattern = re.compile("^\\d+:\\d+:\\d+$")
 


### PR DESCRIPTION
fixes Azure/azure-cli#25161 fix for migration abort issue

Azure CLI command `az servicebus migration abort` fails with the below error:
```
  File "/opt/az/lib/python3.10/site-packages/azure/mgmt/servicebus/v2022_01_01_preview/operations/_migration_configs_operations.py", line 766, in revert
    request = build_revert_request(
  File "/opt/az/lib/python3.10/site-packages/azure/mgmt/servicebus/v2022_01_01_preview/operations/_migration_configs_operations.py", line 251, in build_revert_request
    "configName": _SERIALIZER.url("config_name", config_name, 'str'),
  File "/opt/az/lib/python3.10/site-packages/msrest/serialization.py", line 652, in url
    output = self.serialize_data(data, data_type, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/msrest/serialization.py", line 760, in serialize_data
    raise ValueError("No value for given attribute")
ValueError: No value for given attribute
```

This is because the config-name parameter with ($defualt) value isn't passed to the below function:

https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-mgmt-servicebus/azure/mgmt/servicebus/v2022_01_01_preview/operations/_migration_configs_operations.py#L733

This PR fixes the above error by passing the config_name parameter to the revert function while performing migration abort operation.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
