### PR TITLE
{ServiceBus} Change expiration version to next breaking change window

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 /src/azure-cli/azure/cli/command_modules/resource/ @zhoxing-ms @jsntcy @yanzhudd
 /src/azure-cli/azure/cli/command_modules/role/ @jiasli @evelyn-ys @calvinhzy
 /src/azure-cli/azure/cli/command_modules/search/ @huangbolun @kairu-ms
-/src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @zhoxing-ms @jsntcy
+/src/azure-cli/azure/cli/command_modules/servicebus/ @v-ajnava @zhoxing-ms @jsntcy @evelyn-ys
 /src/azure-cli/azure/cli/command_modules/serviceconnector/ @yungezz @houk-ms @xfz11 @yanzhudd @kairu-ms
 /src/azure-cli/azure/cli/command_modules/servicefabric/ @QingChenmsft @zhoxing-ms @jsntcy @yanzhudd
 /src/azure-cli/azure/cli/command_modules/sql/ @jaredmoo @evelyn-ys @calvinhzy

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -105,11 +105,11 @@ def load_arguments_sb(self, _):
 
     with self.argument_context('servicebus queue update') as c:
         c.argument('enable_partitioning', arg_type=get_three_state_flag(),
-                   help='A boolean value that indicates whether the queue is to be partitioned across multiple message brokers.', deprecate_info=c.deprecate(hide=True, expiration='2.45.0'))
-        c.argument('requires_session', options_list=['--enable-session'], arg_type=get_three_state_flag(), help='A boolean value indicating whether the queue supports the concept of sessions.', deprecate_info=c.deprecate(hide=True, expiration='2.45.0'))
+                   help='A boolean value that indicates whether the queue is to be partitioned across multiple message brokers.', deprecate_info=c.deprecate(hide=True, expiration='2.49.0'))
+        c.argument('requires_session', options_list=['--enable-session'], arg_type=get_three_state_flag(), help='A boolean value indicating whether the queue supports the concept of sessions.', deprecate_info=c.deprecate(hide=True, expiration='2.49.0'))
         c.argument('requires_duplicate_detection', options_list=['--enable-duplicate-detection'],
                    arg_type=get_three_state_flag(),
-                   help='A boolean value indicating if this queue requires duplicate detection.', deprecate_info=c.deprecate(hide=True, expiration='2.45.0'))
+                   help='A boolean value indicating if this queue requires duplicate detection.', deprecate_info=c.deprecate(hide=True, expiration='2.49.0'))
 
     with self.argument_context('servicebus queue list') as c:
         c.argument('namespace_name', id_part=None, options_list=['--namespace-name'], help='Name of Namespace')

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -10,7 +10,10 @@
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-return-statements
 import re
+from knack.log import get_logger
 from azure.cli.core.profiles import ResourceType
+
+logger = get_logger(__name__)
 
 
 # Namespace Region
@@ -638,7 +641,6 @@ def return_valid_duration(update_value, current_value=None):
     from isodate import Duration
     from azure.cli.core.azclierror import InvalidArgumentValueError
     from azure.cli.command_modules.servicebus.constants import DURATION_SECS, DURATION_MIN, DURATION_DAYS
-    from argcomplete import warn
     if update_value is not None:
         value_toreturn = update_value
     else:
@@ -662,7 +664,7 @@ def return_valid_duration(update_value, current_value=None):
         return value_toreturn
 
     if timedeltapattern.match(value_toreturn):
-        warn('Please use ISO8601 duration for timespan inputs. Timespan inputs of format (days:min:seconds) would be deprecated from version 2.45.0.')
+        logger.warning('Please use ISO8601 duration for timespan inputs. Timespan inputs of format (days:min:seconds) would be deprecated from version 2.49.0.')
         day, minute, seconds = value_toreturn.split(":")
         if timedelta(days=int(day), minutes=int(minute), seconds=int(seconds)) <= timedelta(days=DURATION_DAYS,
                                                                                             minutes=DURATION_MIN,
@@ -678,7 +680,6 @@ def return_valid_duration_create(update_value):
     from datetime import timedelta
     from isodate import parse_duration
     from knack.util import CLIError
-    import warnings
     from azure.cli.command_modules.servicebus.constants import DURATION_SECS, DURATION_MIN, DURATION_DAYS
     if update_value is not None:
         if iso8601pattern.match(update_value):
@@ -687,7 +688,7 @@ def return_valid_duration_create(update_value):
                     'duration value should be less than (days:min:secs) 10675199:10085:477581')
 
         if timedeltapattern.match(update_value):
-            warnings.warn('Please use ISO8601 duration for timespan inputs. Timespan inputs of format (days:min:seconds) would be deprecated from version 2.45.0.')
+            logger.warning('Please use ISO8601 duration for timespan inputs. Timespan inputs of format (days:min:seconds) would be deprecated from version 2.49.0.')
             day, minute, seconds = update_value.split(":")
             if timedelta(days=int(day), minutes=int(minute), seconds=int(seconds)) <= timedelta(days=DURATION_DAYS, minutes=DURATION_MIN, seconds=DURATION_SECS):
                 update_value = timedelta(days=int(day), minutes=int(minute), seconds=int(seconds))


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
CLI 2.45.0 release failed with
```
-  FAIL - HIGH severity: expired_parameter
    Parameter: servicebus queue update, `enable_partitioning` - Deprecated parameter is expired and should be removed.
    Parameter: servicebus queue update, `requires_duplicate_detection` - Deprecated parameter is expired and should be removed.
    Parameter: servicebus queue update, `requires_session` - Deprecated parameter is expired and should be removed.
```

Since `2.45.0` doesn't allow breaking changes, so change the deprecation info to next breaking change window which would be `2.49.0` then

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
