### PR TITLE
{RDBMS} `az mysql flexible-server create/update`: Change auto_scale_iops parameter validation logic

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -82,7 +82,9 @@ def flexible_server_create(cmd, client,
                               byok_identity=byok_identity,
                               backup_byok_identity=backup_byok_identity,
                               byok_key=byok_key,
-                              backup_byok_key=backup_byok_key)
+                              backup_byok_key=backup_byok_key,
+                              auto_io_scaling=auto_scale_iops,
+                              iops=iops)
     list_skus_info = get_mysql_list_skus_info(db_context.cmd, location)
     iops_info = list_skus_info['iops_info']
 
@@ -369,7 +371,9 @@ def flexible_server_update_custom_func(cmd, client, instance,
                               backup_byok_identity=backup_byok_identity,
                               byok_key=byok_key,
                               backup_byok_key=backup_byok_key,
-                              disable_data_encryption=disable_data_encryption)
+                              disable_data_encryption=disable_data_encryption,
+                              auto_io_scaling=auto_scale_iops,
+                              iops=iops)
 
     list_skus_info = get_mysql_list_skus_info(db_context.cmd, location, server_name=instance.name if instance else None)
     iops_info = list_skus_info['iops_info']


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az mysql flexible-server create
az mysql flexible-server update

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This pr change the validation function. When customers input both --iops and --auto_scale_iops and the --auto_scale_iops is enabled, we should tell the customer that only one parameter take effect.

**Testing Guide**
It has been covered in test_mysql_flexible_server_paid_iops_mgmt

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
