### PR TITLE
[ACR] `az acr manifest`: Support oci image index

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -531,7 +531,10 @@ def get_manifest_authorization_header(username, password):
     return {'Authorization': auth,
             'Accept': '*/*, application/vnd.oci.artifact.manifest.v1+json'
             ', application/vnd.cncf.oras.artifact.manifest.v1+json'
-            ', application/vnd.oci.image.manifest.v1+json'}
+            ', application/vnd.oci.image.manifest.v1+json'
+            ', application/vnd.oci.image.index.v1+json'
+            ', application/vnd.docker.distribution.manifest.v2+json'
+            ', application/vnd.docker.distribution.manifest.list.v2+json'}
 
 
 # pylint: disable=too-many-statements


### PR DESCRIPTION
**Related command**
az acr manifest list myregistry.azurecr.io/myrepo
az acr manifest show myregistry.azurecr.io/myrepo:oci-multi-arch

**Description**<!--Mandatory-->
Add [OCI image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md) media-type (`application/vnd.oci.image.index.v1+json`) to registry http request accept header.

For the backward compatibility, the change also adds Docker image `manifest` and `manifest list` media type in the accept header.

Fix #25280 

**Testing Guide**
```
az login
az acr login -n myregistry

# build a multi-arch image using latest buildkit driver, it generates the manifest of oci image index media-type
docker buildx create --name container --driver=docker-container --bootstrap

echo "FROM hello-world" | docker buildx build --builder=container --progress plain --platform linux/amd64,linux/arm64 -t myregistry.azurecr.io/hello-world:multi-arch-oci --push -

az acr manifest show myregistry.azurecr.io/hello-world:multi-arch-oci
```

**History Notes**
[ACR] `az acr manifest`: Support oci image index

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
