### PR TITLE
{Storage} Fix #25125: `az storage account`: Update help for `--access-tier`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/__init__.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/__init__.py
@@ -149,9 +149,10 @@ class StorageArgumentContext(AzArgumentContext):
                       help='Generate and assign a new Storage Account Identity for this storage account for use '
                            'with key management services like Azure KeyVault.')
         self.argument('access_tier', arg_type=get_enum_type(t_access_tier),
-                      help='The access tier used for billing StandardBlob accounts. Cannot be set for StandardLRS, '
-                           'StandardGRS, StandardRAGRS, or PremiumLRS account types. It is required for '
-                           'StandardBlob accounts during creation')
+                      help='Required for storage accounts where kind = BlobStorage. '
+                           'The access tier is used for billing. The "Premium" access tier is the default value for '
+                           'premium block blobs storage account type and it cannot be changed for '
+                           'the premium block blobs storage account type.')
 
         if t_encryption_services:
             encryption_choices = list(


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account create`
`az storage account update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Closed [#25125](https://github.com/Azure/azure-cli/issues/25125)
The inline help for the argument `--access-tier` is out of date. This PR updates help for `--access-tier` to sync what's in the SDK.


**Testing Guide**
<!--Example commands with explanations.-->
`az storage account create -h` or  `az storage account update -h` 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
