### PR TITLE
{Compute} Fix #25088: Fix a paging bug in VM

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -5125,7 +5125,7 @@ def list_generator(pages, num_results=50):
 
         # handle num results
         if num_results is not None:
-            if num_results >= len(result):
+            if num_results <= len(result):
                 break
 
         page = list(next(pages))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az sig image-definition list-shared`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Closed #25088
The PR fixes a paging bug in VM to solve the problem that the break will be ignored when `num_results` is not divisible by page number.  Since `num_results` is used to handle the maximum value returned in `result`, here should be `<=`. 


**Testing Guide**
<!--Example commands with explanations.-->


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
