### PR TITLE
{ACR} Fix: `az acr login` Add missing command text to log output

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/custom.py
@@ -301,7 +301,7 @@ def acr_login(cmd,
                        'docker commands, to avoid authentication errors, use all lowercase.')
 
     from subprocess import PIPE, Popen
-    logger.debug("Invoking '%s --username %s --password <redacted> %s'",
+    logger.debug("Invoking '%s login --username %s --password <redacted> %s'",
                  docker_command, username, login_server)
     p = Popen([docker_command, "login",
                "--username", username,


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az acr login`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Running `az acr login` with `--debug` outputs the following

```
cli.azure.cli.command_modules.acr.custom: Invoking 'docker --username 00000000-0000-0000-0000-000000000000 --password <redacted> myacr.azurecr.io'
```

The actual command run is `docker login --username ...`, but the `login` portion is missing. This PR adds it

**Testing Guide**
<!--Example commands with explanations.-->

Run `az acr login` with the `--debug` flag and validate that the output includes `Invoking 'docker login --username '`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
