### PR TITLE
{CI} Fix live test: Lock pytest-rerunfailures to 11.0 

### DIFF
--- a/scripts/live_test/CLITest.yml
+++ b/scripts/live_test/CLITest.yml
@@ -361,7 +361,7 @@ jobs:
         # pip install -e azure-cli-dev-tools
         pip install pytest-json-report
         pip install pytest-html
-        pip install pytest-rerunfailures
+        pip install pytest-rerunfailures==11.0
 
         azdev setup -c azure-cli -r azure-cli-extensions
 


### PR DESCRIPTION
pytest-rerunfailures released a new version 11.1 on 2023-02-09 and added a new function called pytest_runtest_teardown.
That will cause all live test failed.
Error log:
![image](https://user-images.githubusercontent.com/18628534/218025938-ba6efdcd-ef32-4f6b-b1ba-b9eb277a890e.png)

Email:
![image](https://user-images.githubusercontent.com/18628534/218025683-b30312d6-184c-4982-ab74-3db84ed9a043.png)

After I locked pytest-rerunfailures to 11.0, the tests came back to work.

![image](https://user-images.githubusercontent.com/18628534/218025761-4edf9037-8829-4101-be8e-3d3cb6d1c20f.png)
