### PR TITLE
[RDBMS] `az postgres flexible-server migration`: Remove DMS Based commands for PG migrations that do not apply to FMS

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_helptext_pg.py
@@ -382,16 +382,10 @@ helps['postgres flexible-server migration update'] = """
 type: command
 short-summary: Update a specific migration.
 examples:
-  - name: Allow the migration workflow to setup logical replication on the source. Note that this command will restart the source server.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --setup-replication
-  - name: Space-separated list of DBs to migrate. A minimum of 1 and a maximum of 8 DBs can be specified. You can migrate more DBs concurrently using additional migrations. Note that each additional DB affects the performance of the source server.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --db-names db1 db2
-  - name: Allow the migration workflow to overwrite the DB on the target.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --overwrite-dbs
-  - name: Cut-over the data migration for all the databases involved in the migration. After this is complete, subsequent updates to all databases in the migration will not be migrated to the target.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover
-  - name: Cancels the data migration for all the databases involved in the migration.
-    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cancel
+  - name: Cut-over the data migration for either all databases or few selected ones. After this is complete, subsequent updates to the selected databases will not be migrated to the target.
+    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover db1 db2 db3
+  - name: Cancel the data migration for either all databases or few selected ones.
+    text: az postgres flexible-server migration update --subscription xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx --resource-group testGroup --name testserver --migration-name testmigration --cutover db1 db2 db3
 """
 
 helps['postgres flexible-server migration check-name-availability'] = """

--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -774,16 +774,10 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
                 elif scope == "update":
                     c.argument('migration_name', arg_type=migration_id_arg_type, options_list=['--migration-name'],
                                help='Name of the migration.')
-                    c.argument('setup_logical_replication', options_list=['--setup-replication'], action='store_true', required=False,
-                               help='Allow the migration workflow to setup logical replication on the source. Note that this command will restart the source server.')
-                    c.argument('db_names', nargs='+', options_list=['--db-names', '--dbs'], required=False,
-                               help='Space-separated list of DBs to migrate. Note that each additional DB affects the performance of the source server.')
-                    c.argument('overwrite_dbs', options_list=['--overwrite-dbs'], action='store_true', required=False,
-                               help='Allow the migration workflow to overwrite the DB on the target.')
-                    c.argument('cutover', options_list=['--cutover'], required=False, action='store_true',
-                               help='Cut-over the data migration for all the databases in the migration. After this is complete, subsequent updates to all databases will not be migrated to the target.')
-                    c.argument('cancel', options_list=['--cancel'], required=False, action='store_true',
-                               help='Cancel the data migration for all the databases.')
+                    c.argument('cutover', nargs='+', options_list=['--cutover'], required=False,
+                               help='Cut-over the data migration for either all databases or few selected ones. After this is complete, subsequent updates to the selected databases will not be migrated to the target.')
+                    c.argument('cancel', nargs='+', options_list=['--cancel'], required=False,
+                               help='Cancel the data migration for either all databases or few selected ones.')
                 elif scope == "check-name-availability":
                     c.argument('migration_name', arg_type=migration_id_arg_type, options_list=['--migration-name'],
                                help='Name of the migration.')

--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_common.py
@@ -95,29 +95,11 @@ def migration_list_func(cmd, client, resource_group_name, server_name, migration
     return r.json()
 
 
-def migration_update_func(cmd, client, resource_group_name, server_name, migration_name, setup_logical_replication=None, db_names=None, overwrite_dbs=None, cutover=None, cancel=None):
+def migration_update_func(cmd, client, resource_group_name, server_name, migration_name, cutover=None, cancel=None):
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
 
     operationSpecified = False
-    if setup_logical_replication is True:
-        operationSpecified = True
-        properties = "{\"properties\": {\"setupLogicalReplicationOnSourceDBIfNeeded\": \"true\"} }"
-
-    if db_names is not None:
-        if operationSpecified is True:
-            raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
-        operationSpecified = True
-        prefix = "{ \"properties\": { \"dBsToMigrate\": ["
-        db_names_str = "\"" + "\", \"".join(db_names) + "\""
-        suffix = "] } }"
-        properties = prefix + db_names_str + suffix
-
-    if overwrite_dbs is True:
-        if operationSpecified is True:
-            raise MutuallyExclusiveArgumentError("Incorrect Usage: Can only specify one update operation.")
-        operationSpecified = True
-        properties = "{\"properties\": {\"overwriteDBsInTarget\": \"true\"} }"
 
     if cutover is not None:
         if operationSpecified is True:


### PR DESCRIPTION
**Related command**
Removed `az postgres flexible-server migration update --setup-replication`
Removed `az postgres flexible-server migration update --overwrite-dbs`
Removed `az postgres flexible-server migration update --db-names db1 db2`

All the above commands were part of DMS based PG migrations which is now on path to be deprecated. Hence, we are removing them to avoid confusion for our customers.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
