### PR TITLE
[Sqlvm] `az sql vm update`: Update no longer requires the mode to be sent as full

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sqlvm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/_params.py
@@ -215,7 +215,6 @@ def load_arguments(self, _):
         c.argument('sql_management_mode',
                    help='SQL Server management type. Updates from LightWeight to Full.',
                    options_list=['--sql-mgmt-type'],
-                   arg_type=get_enum_type(['Full']),
                    deprecate_info=c.deprecate())
         c.argument('prompt',
                    options_list=['--yes', '-y'],


### PR DESCRIPTION
**Related command**
az sql vm update --sql-mgmt-type LightWeight/Full/NoAgent

**Description**<!--Mandatory-->
The argument --sql-mgmt-type no longer requires to mode to be sent as just full. We have made changes in our feature and thus it can now accept other modes too like LightWeight/ Full / NoAgent.

**Testing Guide**
az sql vm update --sql-mgmt-type LightWeight/Full/NoAgent

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Sqlvm] `az sql vm update`: Update no longer requires the mode to be sent as full

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
