### PR TITLE
[ARM] `az bicep publish`: Update command to support new optional parameter `--documentationUri`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2762,6 +2762,8 @@ short-summary: Publish a bicep file to a remote module registry.
 examples:
   - name: Publish a bicep file.
     text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}"
+  - name: Publish a bicep file with documentation uri.
+    text: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri}
 """
 
 helps['bicep restore'] = """

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -674,7 +674,7 @@ def load_arguments(self, _):
         c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'],
                                                       help="The target location where the Bicep module will be published."))
         c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
-                                                      help="The documentation uri of the Bicep module."))      
+                                                                help="The documentation uri of the Bicep module."))
 
     with self.argument_context('bicep install') as c:
         c.argument('version', options_list=['--version', '-v'], help='The version of Bicep CLI to be installed. Default to the latest if not specified.')

--- a/src/azure-cli/azure/cli/command_modules/resource/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_params.py
@@ -673,6 +673,8 @@ def load_arguments(self, _):
         c.argument('file', arg_type=bicep_file_type, help="The path to the Bicep module file to publish in the file system.")
         c.argument('target', arg_type=CLIArgumentType(options_list=['--target', '-t'],
                                                       help="The target location where the Bicep module will be published."))
+        c.argument('documentationUri', arg_type=CLIArgumentType(options_list=['--documentationUri', '-d'],
+                                                      help="The documentation uri of the Bicep module."))      
 
     with self.argument_context('bicep install') as c:
         c.argument('version', options_list=['--version', '-v'], help='The version of Bicep CLI to be installed. Default to the latest if not specified.')

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3680,7 +3680,8 @@ def publish_bicep_file(cmd, file, target, documentationUri=None):
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["publish", file, "--target", target]
-        if documentationUri:
+        minimum_supported_version_for_documentationUri_parameter = "0.14.46"
+        if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter) and documentationUri:
             args += ["--documentationUri", documentationUri]
         run_bicep_command(cmd.cli_ctx, args)
     else:

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3685,7 +3685,7 @@ def publish_bicep_file(cmd, file, target, documentationUri=None):
             if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter):
                 args += ["--documentationUri", documentationUri]
             else:
-                logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)   
+                logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)
         run_bicep_command(cmd.cli_ctx, args)
     else:
         logger.error("az bicep publish could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3674,12 +3674,15 @@ def build_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, no_resto
         print(output)
 
 
-def publish_bicep_file(cmd, file, target):
+def publish_bicep_file(cmd, file, target, documentationUri=None):
     ensure_bicep_installation()
 
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
-        run_bicep_command(cmd.cli_ctx, ["publish", file, "--target", target])
+        args = ["publish", file, "--target", target]
+        if documentationUri:
+            args += ["--documentationUri", documentationUri]
+        run_bicep_command(cmd.cli_ctx, args)
     else:
         logger.error("az bicep publish could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)
 

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3680,9 +3680,12 @@ def publish_bicep_file(cmd, file, target, documentationUri=None):
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["publish", file, "--target", target]
-        minimum_supported_version_for_documentationUri_parameter = "0.14.46"
-        if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter) and documentationUri:
-            args += ["--documentationUri", documentationUri]
+        if documentationUri:
+            minimum_supported_version_for_documentationUri_parameter = "0.14.46"
+            if bicep_version_greater_than_or_equal_to(minimum_supported_version_for_documentationUri_parameter):
+                args += ["--documentationUri", documentationUri]
+            else:
+                logger.error("az bicep publish with --documentationUri/-d parameter could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version_for_documentationUri_parameter)   
         run_bicep_command(cmd.cli_ctx, args)
     else:
         logger.error("az bicep publish could not be executed with the current version of Bicep CLI. Please upgrade Bicep CLI to v%s or later.", minimum_supported_version)


### PR DESCRIPTION
**Related command**
az bicep publish

**Description**<!--Mandatory-->
Fixes https://github.com/Azure/bicep/issues/9775. We added a new optional parameter in bicep publish command. As a part of this PR, updating az bicep publish command to support the same.

**Testing Guide**
```az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}"```
```az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentationUri {documentationUri}```

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
