### PR TITLE
{Storage} `az storage account failover`: Remove prompt for planned failover

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -308,6 +308,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage account failover') as c:
         c.argument('failover_type', options_list=['--failover-type', '--type'], is_preview=True, default=None,
                    help="The parameter is set to 'Planned' to indicate whether a Planned failover is requested")
+        c.argument('yes', options_list=['--yes', '-y'], action='store_true')
 
     with self.argument_context('storage account delete') as c:
         c.argument('account_name', acct_name_type, options_list=['--name', '-n'], local_context_attribute=None)

--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -308,7 +308,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
     with self.argument_context('storage account failover') as c:
         c.argument('failover_type', options_list=['--failover-type', '--type'], is_preview=True, default=None,
                    help="The parameter is set to 'Planned' to indicate whether a Planned failover is requested")
-        c.argument('yes', options_list=['--yes', '-y'], action='store_true')
+        c.argument('yes', options_list=['--yes', '-y'], help='Do not prompt for confirmation.', action='store_true')
 
     with self.argument_context('storage account delete') as c:
         c.argument('account_name', acct_name_type, options_list=['--name', '-n'], local_context_attribute=None)

--- a/src/azure-cli/azure/cli/command_modules/storage/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/commands.py
@@ -116,14 +116,7 @@ def load_command_table(self, _):  # pylint: disable=too-many-locals, too-many-st
                          'show_storage_account_connection_string')
         g.generic_update_command('update', getter_name='get_properties', setter_name='update',
                                  custom_func_name='update_storage_account', min_api='2016-12-01')
-        failover_confirmation = """
-        The secondary cluster will become the primary cluster after failover. Please understand the following impact to your storage account before you initiate the failover:
-            1. Please check the Last Sync Time using `az storage account show` with `--expand geoReplicationStats` and check the "geoReplicationStats" property. This is the data you may lose if you initiate the failover.
-            2. After the failover, your storage account type will be converted to locally redundant storage (LRS). You can convert your account to use geo-redundant storage (GRS).
-            3. Once you re-enable GRS/GZRS for your storage account, Microsoft will replicate data to your new secondary region. Replication time is dependent on the amount of data to replicate. Please note that there are bandwidth charges for the bootstrap. Please refer to doc: https://azure.microsoft.com/pricing/details/bandwidth/
-        """
-        g.command('failover', 'begin_failover', supports_no_wait=True, is_preview=True, min_api='2018-07-01',
-                  confirmation=failover_confirmation)
+        g.custom_command('failover', 'begin_failover', supports_no_wait=True, is_preview=True, min_api='2018-07-01')
         g.command('hns-migration start', 'begin_hierarchical_namespace_migration',
                   supports_no_wait=True, min_api='2021-06-01')
         g.command('hns-migration stop', 'begin_abort_hierarchical_namespace_migration',

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -1091,7 +1091,7 @@ def update_local_user(cmd, client, resource_group_name, account_name, username, 
 
 
 def begin_failover(client, resource_group_name, account_name, failover_type=None, yes=None, **kwargs):
-    if failover_type.lower() != "planned":
+    if not failover_type or failover_type.lower() != "planned":
         message = """
         The secondary cluster will become the primary cluster after failover. Please understand the following impact to your storage account before you initiate the failover:
             1. Please check the Last Sync Time using `az storage account show` with `--expand geoReplicationStats` and check the "geoReplicationStats" property. This is the data you may lose if you initiate the failover.

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -7,7 +7,7 @@
 
 import os
 from azure.cli.command_modules.storage._client_factory import storage_client_factory, cf_sa_for_keys
-from azure.cli.core.util import get_file_json, shell_safe_json_parse, find_child_item
+from azure.cli.core.util import get_file_json, shell_safe_json_parse, find_child_item, user_confirmation
 from azure.cli.core.profiles import ResourceType, get_sdk
 from knack.log import get_logger
 from knack.util import CLIError
@@ -1091,14 +1091,12 @@ def update_local_user(cmd, client, resource_group_name, account_name, username, 
 
 
 def begin_failover(client, resource_group_name, account_name, failover_type=None, yes=None, **kwargs):
-    if not yes and failover_type and failover_type.lower() != "planned":
-        from knack.prompting import prompt_y_n
+    if failover_type.lower() != "planned":
         message = """
         The secondary cluster will become the primary cluster after failover. Please understand the following impact to your storage account before you initiate the failover:
             1. Please check the Last Sync Time using `az storage account show` with `--expand geoReplicationStats` and check the "geoReplicationStats" property. This is the data you may lose if you initiate the failover.
             2. After the failover, your storage account type will be converted to locally redundant storage (LRS). You can convert your account to use geo-redundant storage (GRS).
             3. Once you re-enable GRS/GZRS for your storage account, Microsoft will replicate data to your new secondary region. Replication time is dependent on the amount of data to replicate. Please note that there are bandwidth charges for the bootstrap. Please refer to doc: https://azure.microsoft.com/pricing/details/bandwidth/
         """
-        if not prompt_y_n(message):
-            return None
+        user_confirmation(message, yes)
     return client.begin_failover(resource_group_name=resource_group_name, account_name=account_name, failover_type=failover_type, **kwargs)

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/account.py
@@ -1090,8 +1090,8 @@ def update_local_user(cmd, client, resource_group_name, account_name, username, 
                                    username=username, properties=local_user)
 
 
-def begin_failover(client, resource_group_name, account_name, failover_type=None, **kwargs):
-    if failover_type and failover_type.lower() != "planned":
+def begin_failover(client, resource_group_name, account_name, failover_type=None, yes=None, **kwargs):
+    if not yes and failover_type and failover_type.lower() != "planned":
         from knack.prompting import prompt_y_n
         message = """
         The secondary cluster will become the primary cluster after failover. Please understand the following impact to your storage account before you initiate the failover:
@@ -1101,4 +1101,4 @@ def begin_failover(client, resource_group_name, account_name, failover_type=None
         """
         if not prompt_y_n(message):
             return None
-    return client.begin_failover(resource_group_name = resource_group_name, account_name = account_name, failover_type = failover_type, **kwargs)
+    return client.begin_failover(resource_group_name=resource_group_name, account_name=account_name, failover_type=failover_type, **kwargs)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage account failover`


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Keep the prompt for unplanned failover but remove for planned failover.


**Testing Guide**
<!--Example commands with explanations.-->


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
