### PR TITLE
[App Service] `az webapp ...`: Fix #25406

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -114,7 +114,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.0
-paramiko==2.10.1
+paramiko==2.11.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -115,7 +115,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.0
-paramiko==2.10.1
+paramiko==2.11.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -114,7 +114,7 @@ msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2
 packaging==23.0
-paramiko==2.10.1
+paramiko==2.11.0
 pbr==5.3.1
 pkginfo==1.8.2
 portalocker==2.3.2


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
Seems to impact all web app commands (and possibly all app service commands).

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fixes #25406. [One of our dependencies (I believe for an ssh command), paramiko, was using a deprecated library, blowfish](https://github.com/paramiko/paramiko/issues/2038). Whenever a user runs a webapp command, it outputs a message about blowfish being deprecated. Fortunately, this [was fixed](https://www.paramiko.org/changelog.html) in pamiko version 2.11.0.

**Testing Guide**
<!--Example commands with explanations.-->
`az webapp list --query "[].name"`  
This command should no longer output a deprecation warning for blowfish

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
