### PR TITLE
{Misc} Fix name 'xxx' is not defined error in __main__.py

### DIFF
--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -62,15 +62,12 @@ except SystemExit as ex:  # some code directly call sys.exit, this is to make su
     raise ex
 
 finally:
-    try:
-        # Log the invoke finish time
-        invoke_finish_time = timeit.default_timer()
-        logger.info("Command ran in %.3f seconds (init: %.3f, invoke: %.3f)",
-                    invoke_finish_time - start_time,
-                    init_finish_time - start_time,
-                    invoke_finish_time - init_finish_time)
-    except NameError:
-        pass
+    # Log the invoke finish time
+    invoke_finish_time = timeit.default_timer()
+    logger.info("Command ran in %.3f seconds (init: %.3f, invoke: %.3f)",
+                invoke_finish_time - start_time,
+                init_finish_time - start_time,
+                invoke_finish_time - init_finish_time)
 
     try:
         # check for new version auto-upgrade
@@ -92,6 +89,8 @@ finally:
                     update_all = az_cli.config.getboolean('auto-upgrade', 'all', True)
                     prompt = az_cli.config.getboolean('auto-upgrade', 'prompt', True)
                     cmd = ['az', 'upgrade', '--all', str(update_all)]
+                    az_upgrade_run = False
+                    upgrade_exit_code = None
                     if prompt:
                         from knack.prompting import verify_is_a_tty, NoTTYException  # pylint: disable=ungrouped-imports
                         az_upgrade_run = True

--- a/src/azure-cli/azure/cli/__main__.py
+++ b/src/azure-cli/azure/cli/__main__.py
@@ -42,6 +42,7 @@ telemetry.set_application(az_cli, ARGCOMPLETE_ENV_NAME)
 
 # Log the init finish time
 init_finish_time = timeit.default_timer()
+exit_code = None
 
 try:
     telemetry.start()


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In [these issues](https://github.com/Azure/azure-cli/issues?q=is%3Aissue+is%3Aopen+%22name+%27exit_code%27+is+not+defined%22), the error message `Auto upgrade failed. name 'exit_code' is not defined` is useless.

I think `handle_exception` should be able to handle all exceptions, but sometimes it fails (In the above issues, most of them are result from import error). And `knack` raise error in [invoke()](https://github.com/microsoft/knack/blob/11f2454b8e4d977797057231d0850e7935b26fa6/knack/cli.py#L245), and `exit_code` is not defined.
https://github.com/Azure/azure-cli/blob/359a85d804eeac3b7a06407594150faf122977d8/src/azure-cli-core/azure/cli/core/util.py#L56

So I set `exit_code` to None, which makes the logic robust and removes `Name 'exit_code' can be undefined` in Python linter.

I also fix the same error for `az_upgrade_run`, `upgrade_exit_code` and `invoke_finish_time`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
