### PR TITLE
[ARO] `az aro`: Rename install-version argument to version

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/aro/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_help.py
@@ -18,7 +18,7 @@ helps['aro create'] = """
   - name: Create a cluster.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet
   - name: Create a cluster with a supported OpenShift version.
-    text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --install-version X.Y.Z
+    text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --version X.Y.Z
   - name: Create a cluster with 5 compute nodes and Red Hat pull secret.
     text: az aro create --resource-group MyResourceGroup --name MyCluster --vnet MyVnet --master-subnet MyMasterSubnet --worker-subnet MyWorkerSubnet --worker-count 5 --pull-secret @pullsecret.txt
   - name: Create a private cluster.

--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -56,6 +56,7 @@ def load_arguments(self, _):
                    validator=validate_client_secret(isCreate=True))
 
         c.argument('version',
+                   options_list=['--version', c.deprecate(target='--install-version', redirect='--version', hide=True)],
                    help='OpenShift version to use for cluster creation.',
                    validator=validate_version_format)
 

--- a/src/azure-cli/azure/cli/command_modules/aro/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_params.py
@@ -17,7 +17,7 @@ from azure.cli.command_modules.aro._validators import validate_vnet_resource_gro
 from azure.cli.command_modules.aro._validators import validate_worker_count
 from azure.cli.command_modules.aro._validators import validate_worker_vm_disk_size_gb
 from azure.cli.command_modules.aro._validators import validate_refresh_cluster_credentials
-from azure.cli.command_modules.aro._validators import validate_install_version_format
+from azure.cli.command_modules.aro._validators import validate_version_format
 from azure.cli.core.commands.parameters import name_type
 from azure.cli.core.commands.parameters import get_enum_type, get_three_state_flag
 from azure.cli.core.commands.parameters import resource_group_name_type
@@ -55,9 +55,9 @@ def load_arguments(self, _):
                    help='Client secret of cluster service principal.',
                    validator=validate_client_secret(isCreate=True))
 
-        c.argument('install_version',
+        c.argument('version',
                    help='OpenShift version to use for cluster creation.',
-                   validator=validate_install_version_format)
+                   validator=validate_version_format)
 
         c.argument('pod_cidr',
                    help='CIDR of pod network. Must be a minimum of /18 or larger.',

--- a/src/azure-cli/azure/cli/command_modules/aro/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/_validators.py
@@ -252,8 +252,6 @@ def validate_refresh_cluster_credentials(namespace):
         raise RequiredArgumentMissingError('--client-id and --client-secret must be not set with --refresh-credentials.')  # pylint: disable=line-too-long
 
 
-def validate_install_version_format(namespace):
-    if namespace.install_version is not None and not re.match(r'^' +
-                                                              r'[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}' +
-                                                              r'$', namespace.install_version):
-        raise InvalidArgumentValueError('--install-version is invalid')
+def validate_version_format(namespace):
+    if namespace.version is not None and not re.match(r'^[4-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$', namespace.version):
+        raise InvalidArgumentValueError('--version is invalid')

--- a/src/azure-cli/azure/cli/command_modules/aro/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/aro/custom.py
@@ -57,7 +57,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
                apiserver_visibility=None,
                ingress_visibility=None,
                tags=None,
-               install_version=None,
+               version=None,
                no_wait=False):
 
     resource_client = get_mgmt_service_client(
@@ -102,7 +102,7 @@ def aro_create(cmd,  # pylint: disable=too-many-locals
             resource_group_id=(f"/subscriptions/{subscription_id}"
                                f"/resourceGroups/{cluster_resource_group or 'aro-' + random_id}"),
             fips_validated_modules='Enabled' if fips_validated_modules else 'Disabled',
-            version=install_version or '',
+            version=version or '',
         ),
         service_principal_profile=openshiftcluster.ServicePrincipalProfile(
             client_id=client_id,


### PR DESCRIPTION
**Related command**

`az aro`

**Description**

A name change of the new `az aro create` parameter, introduced in this previous PR: https://github.com/Azure/azure-cli/pull/25211, from `install-version` to simply `version`, before we publish documentation and the multi-version feature goes GA.

**Testing Guide**

Run:
```bash
az aro create --resource-group cluster-rg --name test-cluster --vnet test-vnet --master-subnet test-master-subnet --worker-subnet test-worker-subnet --version 4.10.40
```
The command will not give an error on the `version` argument.

**History Notes**

[aro] `az aro create`: Rename the create `install-version` parameter to `version`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
