### PR TITLE
[ACR] Fix #24886: `az acr`: Improve the 429 error handling for CONNECTIVITY_REFRESH_TOKEN_ERROR

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -33,6 +33,7 @@ from ._constants import ACR_AUDIENCE_RESOURCE_NAME
 from ._utils import get_registry_by_name, ResourceNotFound
 from .policy import acr_config_authentication_as_arm_show
 from ._format import add_timestamp
+from ._errors import CONNECTIVITY_TOOMANYREQUESTS_ERROR
 
 
 logger = get_logger(__name__)
@@ -164,7 +165,6 @@ def _get_aad_token_after_challenge(cli_ctx,
                              verify=(not should_disable_connection_verify()))
 
     if response.status_code == 429:
-        from ._errors import CONNECTIVITY_TOOMANYREQUESTS_ERROR
         if is_diagnostics_context:
             return CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
         raise CLIError(CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
@@ -445,7 +445,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
 
 
 def raise_toomanyrequests_error(error):
-    if 'Too many requests' in error:
+    if CONNECTIVITY_TOOMANYREQUESTS_ERROR.error_title in error:
         raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, error))
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -411,8 +411,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                                                             permission,
                                                             use_acr_audience=use_acr_audience)
         except CLIError as e:
-            if '429' in str(e):
-                raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, str(e)))
+            raise_tomanyrequests_error(str(e))
             logger.warning("%s: %s", AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
 
     # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
@@ -443,6 +442,11 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
             'Please specify both username and password in non-interactive mode.')
 
     return login_server, None, None
+
+
+def raise_tomanyrequests_error(error):
+    if '429' in error:
+        raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, error))
 
 
 def get_login_credentials(cmd,

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -169,7 +169,7 @@ def _get_aad_token_after_challenge(cli_ctx,
             return CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
         raise CLIError(CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
                        .get_error_message())
-    elif response.status_code not in [200]:
+    if response.status_code not in [200]:
         from ._errors import CONNECTIVITY_REFRESH_TOKEN_ERROR
         if is_diagnostics_context:
             return CONNECTIVITY_REFRESH_TOKEN_ERROR.format_error_message(login_server, response.status_code)
@@ -412,7 +412,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                                                             use_acr_audience=use_acr_audience)
         except CLIError as e:
             logger.warning("%s: %s CLI will attempt to get the admin credentials (if enabled).",
-                AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
+                           AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
 
     # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
     if registry:
@@ -423,13 +423,13 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                 return login_server, cred.username, cred.passwords[0].value
             except CLIError as e:
                 logger.warning("%s: %s CLI will attempt to get credentials with username and password.",
-                    ADMIN_USER_BASE_ERROR_MESSAGE, str(e))
+                               ADMIN_USER_BASE_ERROR_MESSAGE, str(e))
         else:
             logger.warning("%s: %s CLI will attempt to get credentials with username and password.",
-                ADMIN_USER_BASE_ERROR_MESSAGE, "Admin user is disabled.")
+                           ADMIN_USER_BASE_ERROR_MESSAGE, "Admin user is disabled.")
     else:
         logger.warning("%s: %s  CLI will attempt to get credentials with username and password.",
-            ADMIN_USER_BASE_ERROR_MESSAGE, resource_not_found)
+                       ADMIN_USER_BASE_ERROR_MESSAGE, resource_not_found)
 
     # 4. if we still don't have credentials, prompt the user
     try:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -169,7 +169,7 @@ def _get_aad_token_after_challenge(cli_ctx,
         if is_diagnostics_context:
             return CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
         raise AzureResponseError(CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
-                       .get_error_message())
+                                 .get_error_message())
     if response.status_code not in [200]:
         from ._errors import CONNECTIVITY_REFRESH_TOKEN_ERROR
         if is_diagnostics_context:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -164,10 +164,10 @@ def _get_aad_token_after_challenge(cli_ctx,
                              verify=(not should_disable_connection_verify()))
 
     if response.status_code == 429:
-        from ._errors import CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR
+        from ._errors import CONNECTIVITY_TOOMANYREQUESTS_ERROR
         if is_diagnostics_context:
-            return CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
-        raise CLIError(CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
+            return CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
+        raise CLIError(CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
                        .get_error_message())
     if response.status_code not in [200]:
         from ._errors import CONNECTIVITY_REFRESH_TOKEN_ERROR
@@ -411,8 +411,10 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                                                             permission,
                                                             use_acr_audience=use_acr_audience)
         except CLIError as e:
-            logger.warning("%s: %s CLI will attempt to get the admin credentials (if enabled).",
-                           AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
+            if '429' in str(e):
+                raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, str(e)))
+            else:
+                logger.warning("%s: %s", AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
 
     # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
     if registry:
@@ -422,14 +424,11 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                 cred = cf_acr_registries(cli_ctx).list_credentials(resource_group_name, registry_name)
                 return login_server, cred.username, cred.passwords[0].value
             except CLIError as e:
-                logger.warning("%s: %s CLI will attempt to get credentials with username and password.",
-                               ADMIN_USER_BASE_ERROR_MESSAGE, str(e))
+                logger.warning("%s: %s", ADMIN_USER_BASE_ERROR_MESSAGE, str(e))
         else:
-            logger.warning("%s: %s CLI will attempt to get credentials with username and password.",
-                           ADMIN_USER_BASE_ERROR_MESSAGE, "Admin user is disabled.")
+            logger.warning("%s: %s", ADMIN_USER_BASE_ERROR_MESSAGE, "Admin user is disabled.")
     else:
-        logger.warning("%s: %s  CLI will attempt to get credentials with username and password.",
-                       ADMIN_USER_BASE_ERROR_MESSAGE, resource_not_found)
+        logger.warning("%s: %s", ADMIN_USER_BASE_ERROR_MESSAGE, resource_not_found)
 
     # 4. if we still don't have credentials, prompt the user
     try:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -26,6 +26,7 @@ from azure.cli.core.util import should_disable_connection_verify
 from azure.cli.core.cloud import CloudSuffixNotSetException
 from azure.cli.core._profile import _AZ_LOGIN_MESSAGE
 from azure.cli.core.commands.client_factory import get_subscription_id
+from azure.cli.core.azclierror import AzureResponseError
 
 from ._client_factory import cf_acr_registries
 from ._constants import get_managed_sku
@@ -167,7 +168,7 @@ def _get_aad_token_after_challenge(cli_ctx,
     if response.status_code == 429:
         if is_diagnostics_context:
             return CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
-        raise CLIError(CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
+        raise AzureResponseError(CONNECTIVITY_TOOMANYREQUESTS_ERROR.format_error_message(login_server)
                        .get_error_message())
     if response.status_code not in [200]:
         from ._errors import CONNECTIVITY_REFRESH_TOKEN_ERROR
@@ -446,7 +447,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
 
 def raise_toomanyrequests_error(error):
     if CONNECTIVITY_TOOMANYREQUESTS_ERROR.error_title in error:
-        raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, error))
+        raise AzureResponseError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, error))
 
 
 def get_login_credentials(cmd,

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -413,8 +413,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
         except CLIError as e:
             if '429' in str(e):
                 raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, str(e)))
-            else:
-                logger.warning("%s: %s", AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
+            logger.warning("%s: %s", AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
 
     # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
     if registry:

--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -411,7 +411,7 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
                                                             permission,
                                                             use_acr_audience=use_acr_audience)
         except CLIError as e:
-            raise_tomanyrequests_error(str(e))
+            raise_toomanyrequests_error(str(e))
             logger.warning("%s: %s", AAD_TOKEN_BASE_ERROR_MESSAGE, str(e))
 
     # 3. if we still don't have credentials, attempt to get the admin credentials (if enabled)
@@ -444,8 +444,8 @@ def _get_credentials(cmd,  # pylint: disable=too-many-statements
     return login_server, None, None
 
 
-def raise_tomanyrequests_error(error):
-    if '429' in error:
+def raise_toomanyrequests_error(error):
+    if 'Too many requests' in error:
         raise CLIError("{}: {}".format(AAD_TOKEN_BASE_ERROR_MESSAGE, error))
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -117,8 +117,8 @@ CONNECTIVITY_REFRESH_TOKEN_ERROR = ErrorClass(
     "Access to registry '{}' was denied. Response code: {}. Please try running 'az login' again to refresh permissions."
 )
 
-CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR = ErrorClass(
-    "CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR",
+CONNECTIVITY_TOOMANYREQUESTS_ERROR = ErrorClass(
+    "CONNECTIVITY_TOOMANYREQUESTS_ERROR",
     "Too many requests, access to registry '{}' was denied. Response code: 429. Please wait a moment before trying again."
 )
 

--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -117,6 +117,11 @@ CONNECTIVITY_REFRESH_TOKEN_ERROR = ErrorClass(
     "Access to registry '{}' was denied. Response code: {}. Please try running 'az login' again to refresh permissions."
 )
 
+CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR = ErrorClass(
+    "CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR",
+    "Too many requests, access to registry '{}' was denied. Response code: 429. Please wait a moment before trying again."
+)
+
 
 CONNECTIVITY_ACCESS_TOKEN_ERROR = ErrorClass(
     "CONNECTIVITY_ACCESS_TOKEN_ERROR",

--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -117,6 +117,7 @@ CONNECTIVITY_REFRESH_TOKEN_ERROR = ErrorClass(
     "Access to registry '{}' was denied. Response code: {}. Please try running 'az login' again to refresh permissions."
 )
 
+
 CONNECTIVITY_TOOMANYREQUESTS_ERROR = ErrorClass(
     "CONNECTIVITY_TOOMANYREQUESTS_ERROR",
     "Too many requests, access to registry '{}' was denied. Please wait a moment before trying again."

--- a/src/azure-cli/azure/cli/command_modules/acr/_errors.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_errors.py
@@ -119,7 +119,7 @@ CONNECTIVITY_REFRESH_TOKEN_ERROR = ErrorClass(
 
 CONNECTIVITY_TOOMANYREQUESTS_ERROR = ErrorClass(
     "CONNECTIVITY_TOOMANYREQUESTS_ERROR",
-    "Too many requests, access to registry '{}' was denied. Response code: 429. Please wait a moment before trying again."
+    "Too many requests, access to registry '{}' was denied. Please wait a moment before trying again."
 )
 
 

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -251,7 +251,8 @@ def _get_registry_status(login_server, registry_name, ignore_errors):
 
 def _get_endpoint_and_token_status(cmd, login_server, ignore_errors):
     from ._errors import CONNECTIVITY_CHALLENGE_ERROR, CONNECTIVITY_AAD_LOGIN_ERROR, \
-        CONNECTIVITY_REFRESH_TOKEN_ERROR, CONNECTIVITY_ACCESS_TOKEN_ERROR
+        CONNECTIVITY_REFRESH_TOKEN_ERROR, CONNECTIVITY_ACCESS_TOKEN_ERROR, \
+        CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR
 
     # Check access to login endpoint
     url = 'https://' + login_server + '/v2/'
@@ -269,6 +270,10 @@ def _get_endpoint_and_token_status(cmd, login_server, ignore_errors):
             return
 
         if result_from_token.error_title == CONNECTIVITY_REFRESH_TOKEN_ERROR.error_title:
+            _handle_error(result_from_token, ignore_errors)
+            return
+        
+        if result_from_token.error_title == CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.error_title:
             _handle_error(result_from_token, ignore_errors)
             return
 

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -252,7 +252,7 @@ def _get_registry_status(login_server, registry_name, ignore_errors):
 def _get_endpoint_and_token_status(cmd, login_server, ignore_errors):
     from ._errors import CONNECTIVITY_CHALLENGE_ERROR, CONNECTIVITY_AAD_LOGIN_ERROR, \
         CONNECTIVITY_REFRESH_TOKEN_ERROR, CONNECTIVITY_ACCESS_TOKEN_ERROR, \
-        CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR
+        CONNECTIVITY_TOOMANYREQUESTS_ERROR
 
     # Check access to login endpoint
     url = 'https://' + login_server + '/v2/'
@@ -273,7 +273,7 @@ def _get_endpoint_and_token_status(cmd, login_server, ignore_errors):
             _handle_error(result_from_token, ignore_errors)
             return
 
-        if result_from_token.error_title == CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.error_title:
+        if result_from_token.error_title == CONNECTIVITY_TOOMANYREQUESTS_ERROR.error_title:
             _handle_error(result_from_token, ignore_errors)
             return
 

--- a/src/azure-cli/azure/cli/command_modules/acr/check_health.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/check_health.py
@@ -272,7 +272,7 @@ def _get_endpoint_and_token_status(cmd, login_server, ignore_errors):
         if result_from_token.error_title == CONNECTIVITY_REFRESH_TOKEN_ERROR.error_title:
             _handle_error(result_from_token, ignore_errors)
             return
-        
+
         if result_from_token.error_title == CONNECTIVITY_REFRESH_TOKEN_TOOMANYREQUESTS_ERROR.error_title:
             _handle_error(result_from_token, ignore_errors)
             return


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az acr`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR updates the error message that appears when "CONNECTIVITY_REFRESH_TOKEN_ERROR, Response code: 429" occurs. The original message "Please try running 'az login' again to refresh permissions" is misleading and is now replaced with a more accurate message to ask the user to retry.

Fix #24886 

**Testing Guide**
<!--Example commands with explanations.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
