### PR TITLE
{IoT} Fix test_certificate_lifecycle

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2019_03_01/test_iot_certificate_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2019_03_01/test_iot_certificate_commands.py
@@ -24,7 +24,7 @@ class IotHubCertificateTest(ScenarioTest):
         _create_test_cert(CERT_FILE, KEY_FILE, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, MAX_INT))
 
     def tearDown(self):
-        _delete_test_cert([CERT_FILE, KEY_FILE, VERIFICATION_FILE])
+        _delete_test_cert(CERT_FILE, KEY_FILE, VERIFICATION_FILE)
         super(IotHubCertificateTest, self).tearDown()
 
     @ResourceGroupPreparer()

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2019_03_01/test_iot_certificate_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2019_03_01/test_iot_certificate_commands.py
@@ -23,8 +23,9 @@ class IotHubCertificateTest(ScenarioTest):
         self.hub_name = 'iot-hub-for-cert-test'
         _create_test_cert(CERT_FILE, KEY_FILE, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, MAX_INT))
 
-    def __del__(self):
-        _delete_test_cert(CERT_FILE, KEY_FILE, VERIFICATION_FILE)
+    def tearDown(self):
+        _delete_test_cert([CERT_FILE, KEY_FILE, VERIFICATION_FILE])
+        super(IotHubCertificateTest, self).tearDown()
 
     @ResourceGroupPreparer()
     def test_certificate_lifecycle(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_certificate_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/hybrid_2020_09_01/test_iot_certificate_commands.py
@@ -24,8 +24,9 @@ class IotHubCertificateTest(ScenarioTest):
         self.hub_name = 'iot-hub-for-cert-test'
         _create_test_cert(CERT_FILE, KEY_FILE, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, MAX_INT))
 
-    def __del__(self):
-        _delete_test_cert(CERT_FILE, KEY_FILE, VERIFICATION_FILE)
+    def tearDown(self):
+        _delete_test_cert([CERT_FILE, KEY_FILE, VERIFICATION_FILE])
+        super(IotHubCertificateTest, self).tearDown()
 
     @ResourceGroupPreparer()
     def test_certificate_lifecycle(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_certificate_commands.py
@@ -25,8 +25,9 @@ class IotHubCertificateTest(ScenarioTest):
         _create_test_cert(CERT_FILE, KEY_FILE, self.create_random_name(prefix='TESTCERT', length=24), 3, random.randint(0, MAX_INT))
         _create_fake_chain_cert(CERT_FILE, CHAIN_FILE)
 
-    def __del__(self):
+    def tearDown(self):
         _delete_test_cert([CERT_FILE, KEY_FILE, VERIFICATION_FILE, CHAIN_FILE])
+        super(IotHubCertificateTest, self).tearDown()
 
     @ResourceGroupPreparer()
     def test_certificate_lifecycle(self, resource_group):


### PR DESCRIPTION
**Related command**
Change the certificate deletion to a teardown in certificate lifecycle tests. This will force the teardown to run and delete the certificates.

**Description**<!--Mandatory-->
Change to test regarding:
https://github.com/Azure/azure-cli/issues/25481

**Testing Guide**
Use `azdev test test_certificate_lifecycle` 

**History Notes**
No customer facing changes. Internal changes only.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
