### PR TITLE
[Storage] Fix #25305: `az storage blob copy start-batch`: Add `--destination-blob-type` and `--tier`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1318,19 +1318,23 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
         c.extra('tags', tags_type)
         c.extra('destination_blob_type', arg_type=get_enum_type(['Detect', 'BlockBlob', 'PageBlob', 'AppendBlob']),
                 help='Defines the type of blob at the destination. '
-                     'Value of "Detect" determines the type basd on source blob type.')
+                     'Value of "Detect" determines the type based on source blob type.')
 
-    with self.argument_context('storage blob copy start-batch', arg_group='Copy Source') as c:
+    with self.argument_context('storage blob copy start-batch', arg_group='Copy Source',
+                               resource_type=ResourceType.DATA_STORAGE_BLOB) as c:
         from azure.cli.command_modules.storage._validators import get_source_file_or_blob_service_client_track2
-
         c.argument('source_client', ignore_type, validator=get_source_file_or_blob_service_client_track2)
-
         c.extra('source_account_name')
         c.extra('source_account_key')
         c.extra('source_uri')
         c.argument('source_sas')
         c.argument('source_container')
         c.argument('source_share')
+
+        c.extra('tier', tier_type)
+        c.extra('destination_blob_type', arg_type=get_enum_type(['Detect', 'BlockBlob', 'PageBlob', 'AppendBlob']),
+                help='Defines the type of blob at the destination. '
+                     'Value of "Detect" determines the type based on source blob type.')
 
     with self.argument_context('storage blob incremental-copy start') as c:
         from azure.cli.command_modules.storage._validators import process_blob_source_uri

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -361,7 +361,7 @@ def set_service_properties_track2(client, parameters, delete_retention=None, del
 
 def storage_blob_copy_batch(cmd, client, source_client, container_name=None, destination_path=None,
                             source_container=None, source_share=None, source_sas=None, pattern=None, dryrun=False,
-                            source_account_name=None, source_account_key=None):
+                            source_account_name=None, source_account_key=None, **kwargs):
     """Copy a group of blob or files to a blob container."""
     if dryrun:
         logger.warning('copy files or blobs to blob container')
@@ -384,7 +384,8 @@ def storage_blob_copy_batch(cmd, client, source_client, container_name=None, des
                                                     destination_path=destination_path,
                                                     source_container=source_container,
                                                     source_blob_name=blob_name,
-                                                    source_sas=source_sas)
+                                                    source_sas=source_sas,
+                                                    **kwargs)
         return list(filter_none(action_blob_copy(blob) for blob in collect_blobs(source_client,
                                                                                  source_container,
                                                                                  pattern)))
@@ -889,7 +890,7 @@ def create_blob_url(client, container_name, blob_name, snapshot, protocol='https
 
 
 def _copy_blob_to_blob_container(cmd, blob_service, source_blob_service, destination_container, destination_path,
-                                 source_container, source_blob_name, source_sas):
+                                 source_container, source_blob_name, source_sas, **kwargs):
     t_blob_client = cmd.get_models('_blob_client#BlobClient')
     source_client = t_blob_client(account_url=source_blob_service.url, container_name=source_container,
                                   blob_name=source_blob_name, credential=source_sas)
@@ -898,7 +899,8 @@ def _copy_blob_to_blob_container(cmd, blob_service, source_blob_service, destina
     destination_blob_name = normalize_blob_file_path(destination_path, source_blob_name)
     try:
         blob_client = blob_service.get_blob_client(container=destination_container, blob=destination_blob_name)
-        blob_client.start_copy_from_url(source_url=source_blob_url, incremental_copy=False)
+        copy_blob(cmd, blob_client, source_blob_url, source_client=source_client, metadata=None, requires_sync=False,
+                  **kwargs)
         return blob_client.url
     except HttpResponseError as ex:
         if 'One of the request inputs is not valid' in str(ex):
@@ -997,9 +999,11 @@ def copy_blob(cmd, client, source_url, metadata=None, **kwargs):
     if not kwargs['requires_sync']:
         kwargs.pop('requires_sync')
     blob_type = kwargs.pop('destination_blob_type', None)
-    src_client = client.from_blob_url(source_url)
-    if src_client.account_name == client.account_name:
-        src_client = client.from_blob_url(source_url, credential=client.credential)
+    src_client = kwargs.pop('source_client', None)
+    if src_client is None:
+        src_client = client.from_blob_url(source_url)
+        if src_client.account_name == client.account_name:
+            src_client = client.from_blob_url(source_url, credential=client.credential)
     StandardBlobTier = cmd.get_models('_models#StandardBlobTier')
     if blob_type is not None and blob_type != 'Detect':
         blob_service_client = src_client._get_container_client()._get_blob_service_client()

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_copy_scenarios.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_blob_copy_scenarios.py
@@ -180,7 +180,7 @@ class StorageBlobCopyTests(StorageScenarioMixin, LiveScenarioTest):
         source_container = self.create_container(account1_info)
         target_container = self.create_container(account1_info)
         target_container_different_account = self.create_container(account2_info)
-        target_container_premium =  self.create_container(accountpremium_info)
+        target_container_premium = self.create_container(accountpremium_info)
 
         self.storage_cmd('storage blob upload -c {} -f "{}" -n srcBlockBlob', account1_info,
                          source_container, source_file)
@@ -334,7 +334,6 @@ class StorageBlobCopyTests(StorageScenarioMixin, LiveScenarioTest):
             self.storage_cmd('storage blob show -c {} -n {}', accountpremium_info, target_container_premium,
                              'dstpremiumtier' + tier).assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
 
-
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='account1', kind='StorageV2', hns=True)
     @StorageAccountPreparer(parameter_name='account2', kind='StorageV2')
@@ -380,3 +379,116 @@ class StorageBlobCopyTests(StorageScenarioMixin, LiveScenarioTest):
                              dst_account_info, dst_container, src_share, src_account_info[0],
                              src_account_info[1]).assert_with_checks(
                 JMESPathCheck('length(@)', 2))
+
+    @ResourceGroupPreparer()
+    @StorageAccountPreparer(parameter_name='account1', kind='StorageV2')
+    @StorageAccountPreparer(parameter_name='account2', kind='StorageV2')
+    @StorageAccountPreparer(parameter_name='accountpremium', sku='Premium_LRS', kind='StorageV2')
+    def test_storage_blob_copy_batch_destination_blob_type(self, resource_group, account1, account2, accountpremium):
+        source_file = self.create_temp_file(16, full_random=False)
+        account1_info = self.get_account_info(resource_group, account1)
+        account2_info = self.get_account_info(resource_group, account2)
+        accountpremium_info = self.get_account_info(resource_group, accountpremium)
+
+        src_container = self.create_container(account1_info)
+        src_container_premium = self.create_container(accountpremium_info)
+        src_container_block = self.create_container(account1_info)
+        src_container_page = self.create_container(account1_info)
+
+        self.storage_cmd('storage blob upload -c {} -f "{}" -n srcBlockBlob -t block', account1_info,
+                         src_container, source_file)
+        self.storage_cmd('storage blob upload -c {} -f "{}" -n srcAppendBlob -t append', account1_info,
+                         src_container, source_file)
+        self.storage_cmd('storage blob upload -c {} -f "{}" -n srcPageBlob -t page', account1_info,
+                         src_container, source_file)
+        self.storage_cmd('storage blob upload -c {} -f "{}" -n srcPrePageBlob -t page', account1_info,
+                         src_container_page, source_file)
+        self.storage_cmd('storage blob upload -c {} -f "{}" -n srcPrePageBlob -t page', accountpremium_info,
+                         src_container_premium, source_file)
+
+        # same account
+        dst_types = ['', 'Detect', 'BlockBlob', 'AppendBlob', 'PageBlob']
+        src_types = ['BlockBlob', 'AppendBlob', 'PageBlob']
+        for dst_type in dst_types:
+            if dst_type == 'BlockBlob':
+                dst_container = src_container_block
+            else:
+                dst_container = self.create_container(account1_info)
+            dst_container_different_account = self.create_container(account2_info)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --source-account-key {} '
+                             '{}',
+                             account1_info, dst_container, src_container,
+                             account1_info[0], account1_info[1],
+                             '--destination-blob-type ' + dst_type if dst_type != '' else '')
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --source-account-key {} '
+                             '{}',
+                             account2_info, dst_container_different_account, src_container,
+                             account1_info[0], account1_info[1],
+                             '--destination-blob-type ' + dst_type if dst_type != '' else '')
+            for src_type in src_types:
+                blob_name = 'src' + src_type
+                self.storage_cmd('storage blob show -c {} -n {}', account1_info, dst_container, blob_name). \
+                    assert_with_checks([JMESPathCheck('properties.blobType',
+                                                      dst_type if (dst_type != '' and dst_type != 'Detect')
+                                                      else src_type)])
+                self.storage_cmd('storage blob show -c {} -n {}', account2_info, dst_container_different_account,
+                                 blob_name). \
+                    assert_with_checks([JMESPathCheck('properties.blobType',
+                                                      dst_type if (dst_type != '' and dst_type != 'Detect')
+                                                      else src_type)])
+
+        # tier
+        # specify dst-blob-type BlockBlob
+        tiers = ['Cool', 'Hot', 'Archive']
+        blob_names = ['srcBlockBlob', 'srcAppendBlob', 'srcPageBlob']
+        for tier in tiers:
+            dst_container = self.create_container(account1_info)
+            dst_container_different_account = self.create_container(account2_info)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --destination-blob-type BlockBlob --tier {}',
+                             account1_info, dst_container, src_container_block, account1, tier)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --source-account-key {} --destination-blob-type BlockBlob'
+                             ' --tier {}',
+                             account2_info, dst_container_different_account, src_container_block,
+                             account1_info[0], account1_info[1], tier)
+            for blob_name in blob_names:
+                self.storage_cmd('storage blob show -c {} -n {}', account1_info, dst_container, blob_name). \
+                    assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+                self.storage_cmd('storage blob show -c {} -n {}', account2_info, dst_container_different_account,
+                                 blob_name). assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+
+        # does not specify dst-blob-type BlockBlob
+        for tier in tiers:
+            dst_container = self.create_container(account1_info)
+            dst_container_different_account = self.create_container(account2_info)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --tier {}',
+                             account1_info, dst_container, src_container_block, account1, tier)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --source-account-key {} --tier {}',
+                             account2_info, dst_container_different_account, src_container_block,
+                             account1_info[0], account1_info[1], tier)
+            for blob_name in blob_names:
+                self.storage_cmd('storage blob show -c {} -n {}', account1_info, dst_container, blob_name). \
+                    assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+                self.storage_cmd('storage blob show -c {} -n {}', account2_info, dst_container_different_account,
+                                 blob_name).assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+
+        # does not specify dst-blob-type PageBlob Premium
+        tiers = ['P10', 'P20', 'P30', 'P40', 'P50', 'P60', 'P4', 'P6']
+        for tier in tiers:
+            dst_container = self.create_container(accountpremium_info)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --tier {}',
+                             accountpremium_info, dst_container, src_container_premium, accountpremium, tier)
+            self.storage_cmd('storage blob copy start-batch --destination-container {} --source-container {} '
+                             '--source-account-name {} --source-account-key {} --tier {}',
+                             accountpremium_info, dst_container, src_container_page,
+                             account1_info[0], account1_info[1], tier)
+            self.storage_cmd('storage blob show -c {} -n srcPrePageBlob', accountpremium_info, dst_container). \
+                assert_with_checks([JMESPathCheck('properties.blobTier', tier)])
+            self.storage_cmd('storage blob show -c {} -n srcPrePageBlob', accountpremium_info, dst_container). \
+                assert_with_checks([JMESPathCheck('properties.blobTier', tier)])


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob copy start-batch`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix [#25305](https://github.com/Azure/azure-cli/issues/25305)
Support `--destination-blob-type` and `--tier` for blob type and tier conversion when copying batched blobs.

**Testing Guide**
<!--Example commands with explanations.-->
`storage blob copy start-batch --account-name {} --account-key {} --destination-container {} --source-container {} --source-account-name {} --source-account-key {} --destination-blob-type {} --tier {}`


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] `az storage blob copy start-batch`: Add `--destination-blob-type` and `--tier`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
