### PR TITLE
{AzureFrontdoor} fixes Azure/azure-cli#25553 fix the DomainNameLabelScope property value

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cdn/custom/custom_afdx.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/custom/custom_afdx.py
@@ -156,7 +156,7 @@ def create_afd_endpoint(client: AFDEndpointsOperations, resource_group_name, pro
     # Force location to global
     endpoint = AFDEndpoint(location="global",
                            enabled_state=enabled_state,
-                           auto_generated_domain_name_label_scope=auto_generated_domain_name_label_scope,
+                           auto_generated_domain_name_label_scope=auto_generated_domain_name_label_scope.upper(),
                            tags=tags)
 
     return sdk_no_wait(no_wait, client.begin_create, resource_group_name, profile_name, endpoint_name, endpoint)


### PR DESCRIPTION
fixes Azure/azure-cli#25553 

fix the DomainNameLabelScope property value

This PR fixes the below error:

```
(BadRequest) Property 'AfdEndpoint.AutoGeneratedDomainNameLabelScope' cannot be set to 'TenantReuse'. Acceptable values are: UNSECURE, TENANTREUSE, SUBSCRIPTIONREUSE, RESOURCEGROUPREUSE, NOREUSE
Code: BadRequest
Message: Property 'AfdEndpoint.AutoGeneratedDomainNameLabelScope' cannot be set to 'TenantReuse'. Acceptable values are: UNSECURE, TENANTREUSE, SUBSCRIPTIONREUSE, RESOURCEGROUPREUSE, NOREUSE
```

While invoking [this REST API](https://learn.microsoft.com/en-us/rest/api/frontdoorservice/azurefrontdoorstandardpremium/afd-endpoints/create) the Service expects the value to be in upper case.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
