### PR TITLE
[App Service] `az functionapp config`: block for managed env deployments

### DIFF
--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -158,6 +158,9 @@ class InvalidArgumentValueError(UserFault):
     """ Argument value is not valid. """
     pass
 
+class UnsupportOperationError(UserFault):
+    """ Operation is not supported"""
+    pass
 
 class ArgumentUsageError(UserFault):
     """ Fallback of the argument usage related errors.

--- a/src/azure-cli-core/azure/cli/core/azclierror.py
+++ b/src/azure-cli-core/azure/cli/core/azclierror.py
@@ -158,9 +158,6 @@ class InvalidArgumentValueError(UserFault):
     """ Argument value is not valid. """
     pass
 
-class UnsupportOperationError(UserFault):
-    """ Operation is not supported"""
-    pass
 
 class ArgumentUsageError(UserFault):
     """ Fallback of the argument usage related errors.

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -7,7 +7,8 @@ import ipaddress
 
 
 from azure.cli.core.azclierror import (InvalidArgumentValueError, ArgumentUsageError, RequiredArgumentMissingError,
-                                       ResourceNotFoundError, ValidationError, MutuallyExclusiveArgumentError)
+                                       ResourceNotFoundError, ValidationError, MutuallyExclusiveArgumentError,
+                                       UnsupportOperationError)
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.validators import validate_tags
@@ -118,6 +119,17 @@ def validate_functionapp_asp_create(namespace):
     if namespace.max_burst is not None:
         if tier.lower() != "elasticpremium":
             raise ArgumentUsageError("--max-burst is only supported for Elastic Premium (EP) plans")
+
+
+def validate_functionapp_on_containerapp_site_config(cmd, namespace):
+    resource_group_name = namespace.resource_group_name
+    name = namespace.name
+    slot = namespace.slot
+    function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if function_app.managed_environment_id is not None:
+        raise UnsupportOperationError(
+            "This command is not supported for function apps deployed in managed environments.",
+            "Please view or update your function app's site configuration in the container app environment.")
 
 
 def validate_app_exists(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -7,8 +7,7 @@ import ipaddress
 
 
 from azure.cli.core.azclierror import (InvalidArgumentValueError, ArgumentUsageError, RequiredArgumentMissingError,
-                                       ResourceNotFoundError, ValidationError, MutuallyExclusiveArgumentError,
-                                       UnsupportOperationError)
+                                       ResourceNotFoundError, ValidationError, MutuallyExclusiveArgumentError)
 from azure.cli.core.commands.client_factory import get_mgmt_service_client, get_subscription_id
 from azure.cli.core.profiles import ResourceType
 from azure.cli.core.commands.validators import validate_tags
@@ -121,15 +120,26 @@ def validate_functionapp_asp_create(namespace):
             raise ArgumentUsageError("--max-burst is only supported for Elastic Premium (EP) plans")
 
 
-def validate_functionapp_on_containerapp_site_config(cmd, namespace):
+def validate_functionapp_on_containerapp_site_config_set(cmd, namespace):
     resource_group_name = namespace.resource_group_name
     name = namespace.name
     slot = namespace.slot
     function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
     if function_app.managed_environment_id is not None:
-        raise UnsupportOperationError(
-            "This command is not supported for function apps deployed in managed environments.",
-            "Please view or update your function app's site configuration in the container app environment.")
+        raise ValidationError(
+            "Invalid command. This is not supported for Azure Functions on Azure Container app environments.",
+            "Please use the following command instead: az functionapp config container set")
+
+
+def validate_functionapp_on_containerapp_site_config_show(cmd, namespace):
+    resource_group_name = namespace.resource_group_name
+    name = namespace.name
+    slot = namespace.slot
+    function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if function_app.managed_environment_id is not None:
+        raise ValidationError(
+            "Invalid command. This is not supported for Azure Functions on Azure Container app environments.",
+            "Please use the following command instead: az functionapp config container show")
 
 
 def validate_app_exists(cmd, namespace):

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -12,7 +12,8 @@ from ._validators import (validate_onedeploy_params, validate_staticsite_link_fu
                           validate_vnet_integration, validate_asp_create, validate_functionapp_asp_create,
                           validate_webapp_up, validate_app_exists, validate_add_vnet, validate_app_is_functionapp,
                           validate_app_is_webapp,
-                          validate_functionapp_on_containerapp_site_config)
+                          validate_functionapp_on_containerapp_site_config_set,
+                          validate_functionapp_on_containerapp_site_config_show)
 
 
 def output_slots_in_table(slots):
@@ -332,8 +333,8 @@ def load_command_table(self, _):
                                  custom_func_name='update_functionapp', getter_type=appservice_custom, setter_type=appservice_custom, command_type=webapp_sdk)
 
     with self.command_group('functionapp config') as g:
-        g.custom_command('set', 'update_site_configs', validator=validate_functionapp_on_containerapp_site_config, exception_handler=ex_handler_factory())
-        g.custom_show_command('show', 'get_site_configs', validator=validate_functionapp_on_containerapp_site_config, exception_handler=ex_handler_factory())
+        g.custom_command('set', 'update_site_configs', validator=validate_functionapp_on_containerapp_site_config_set, exception_handler=ex_handler_factory())
+        g.custom_show_command('show', 'get_site_configs', validator=validate_functionapp_on_containerapp_site_config_show, exception_handler=ex_handler_factory())
 
     with self.command_group('functionapp config appsettings') as g:
         g.custom_command('list', 'get_app_settings', exception_handler=empty_on_404)

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -11,7 +11,8 @@ from ._client_factory import cf_web_client, cf_plans, cf_webapps
 from ._validators import (validate_onedeploy_params, validate_staticsite_link_function, validate_staticsite_sku,
                           validate_vnet_integration, validate_asp_create, validate_functionapp_asp_create,
                           validate_webapp_up, validate_app_exists, validate_add_vnet, validate_app_is_functionapp,
-                          validate_app_is_webapp)
+                          validate_app_is_webapp,
+                          validate_functionapp_on_containerapp_site_config)
 
 
 def output_slots_in_table(slots):
@@ -331,8 +332,8 @@ def load_command_table(self, _):
                                  custom_func_name='update_functionapp', getter_type=appservice_custom, setter_type=appservice_custom, command_type=webapp_sdk)
 
     with self.command_group('functionapp config') as g:
-        g.custom_command('set', 'update_site_configs')
-        g.custom_show_command('show', 'get_site_configs')
+        g.custom_command('set', 'update_site_configs', validator=validate_functionapp_on_containerapp_site_config, exception_handler=ex_handler_factory())
+        g.custom_show_command('show', 'get_site_configs', validator=validate_functionapp_on_containerapp_site_config, exception_handler=ex_handler_factory())
 
     with self.command_group('functionapp config appsettings') as g:
         g.custom_command('list', 'get_app_settings', exception_handler=empty_on_404)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -15,7 +15,7 @@ from azure.cli.testsdk.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
                                StorageAccountPreparer, JMESPathCheck, live_only)
 from azure.cli.testsdk.checkers import JMESPathCheckNotExists, JMESPathPatternCheck
-from azure.cli.core.azclierror import ResourceNotFoundError
+from azure.cli.core.azclierror import ResourceNotFoundError, UnsupportOperationError
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -1982,6 +1982,60 @@ class FunctionAppConfigTest(ScenarioTest):
                      JMESPathCheck('powerShellVersion', '7.0')])
         self.cmd(
             'functionapp delete -g {} -n {}'.format(resource_group, functionapp_name))
+
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_config_set_with_appcontainer_managed_environment_error(self, resource_group, storage_account):
+
+        functionapp_name = self.create_random_name('functionapp', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+
+
+        with self.assertRaises(UnsupportOperationError):
+            self.cmd('functionapp config set -g {} -n {}'
+            .format(resource_group, functionapp_name))
+    
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer()
+    def test_functionapp_config_show_with_appcontainer_managed_environment_error(self, resource_group, storage_account):
+
+        functionapp_name = self.create_random_name('functionapp', 40)
+        managed_environment_name = self.create_random_name('containerappmanagedenvironment', 40)
+        plan_name = self.create_random_name('functionappplan', 40)
+
+        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
+        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
+                     JMESPathCheck('name', managed_environment_name),
+                     JMESPathCheck('resourceGroup', resource_group),
+                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
+        self.cmd(
+            'appservice plan create -g {} -n {} --sku P1V2'.format(resource_group, plan_name))
+        self.cmd(
+            'functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
+            .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
+                     JMESPathCheck('state', 'Running'),
+                     JMESPathCheck('name', functionapp_name),
+                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
+
+
+        with self.assertRaises(UnsupportOperationError):
+            self.cmd('functionapp config show -g {} -n {}'
+            .format(resource_group, functionapp_name))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -15,7 +15,7 @@ from azure.cli.testsdk.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
                                StorageAccountPreparer, JMESPathCheck, live_only)
 from azure.cli.testsdk.checkers import JMESPathCheckNotExists, JMESPathPatternCheck
-from azure.cli.core.azclierror import ResourceNotFoundError, UnsupportOperationError
+from azure.cli.core.azclierror import ResourceNotFoundError, ValidationError
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -2006,7 +2006,7 @@ class FunctionAppConfigTest(ScenarioTest):
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
 
 
-        with self.assertRaises(UnsupportOperationError):
+        with self.assertRaises(ValidationError):
             self.cmd('functionapp config set -g {} -n {}'
             .format(resource_group, functionapp_name))
     
@@ -2033,7 +2033,7 @@ class FunctionAppConfigTest(ScenarioTest):
                      JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
 
 
-        with self.assertRaises(UnsupportOperationError):
+        with self.assertRaises(ValidationError):
             self.cmd('functionapp config show -g {} -n {}'
             .format(resource_group, functionapp_name))
 


### PR DESCRIPTION
**Related command**
`az functionapp config set`
`az functionapp config show`

**Description**<!--Mandatory-->
For Centauri (function apps deployed in container app environments), we want to block the customer from setting or updating their site configurations at the function app level since that should be done at the container app environment level. 

**Testing Guide**
1. Create a function app deployed in a container app environment (`az functionapp create -g {resourceGroup} -n {name} -s {storage} --environment {managedEnvName} --functions-version 4`)
2. You should get an error when you try to view or update the function app's site configuration (`az functionapp config set -g {resourceGroup} -n {name}` or `az functionapp config show -g {resourceGroup} -n {name}`)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
