### PR TITLE
Supports JMESPath Community dependencies and assets.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ LABEL maintainer="Microsoft" \
 # openssh - included for ssh-keygen
 # ca-certificates
 
-# curl - required for installing jp
+# wget - required for installing jp
 # jq - we include jq as a useful tool
 # pip wheel - required for CLI packaging
-# jmespath-terminal - we include jpterm as a useful tool
+# jmespath-community-terminal - we include jpterm as a useful tool
 # libintl and icu-libs - required by azure devops artifact (az extension add --name azure-devops)
 
 # We don't use openssl (3.0) for now. We only install it so that users can use it.
@@ -44,10 +44,11 @@ RUN apk add --no-cache bash openssh ca-certificates jq curl openssl openssl1.1-c
  && apk add --no-cache bash-completion \
  && update-ca-certificates
 
-ARG JP_VERSION="0.1.3"
+ARG JP_VERSION="1.1.0"
 
-RUN curl -L https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
- && chmod +x /usr/local/bin/jp
+RUN curl -L https://github.com/jmespath-community/jp/releases/download/v${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
+ && chmod +x /usr/local/bin/jp \
+ && pip install --no-cache-dir --upgrade jmespath-community-terminal
 
 WORKDIR azure-cli
 COPY . /azure-cli

--- a/Dockerfile.spot
+++ b/Dockerfile.spot
@@ -7,7 +7,7 @@
 # This allows Spots to be created directly from PRs.
 # The major difference between Dockerfile.spot and Dockerfile is the latter depends on alpine and this one does not.
 
-ARG PYTHON_VERSION="3.6.4"
+ARG PYTHON_VERSION="3.7.16"
 
 FROM python:$PYTHON_VERSION
 
@@ -15,11 +15,11 @@ RUN apt-get install -y ca-certificates curl openssl git \
  && apt-get install -y gcc make libffi-dev \
  && update-ca-certificates
 
-ARG JP_VERSION="0.1.3"
+ARG JP_VERSION="1.1.0"
 
-RUN curl https://github.com/jmespath/jp/releases/download/${JP_VERSION}/jp-linux-amd64 -o /usr/local/bin/jp \
+RUN wget https://github.com/jmespath-community/jp/releases/download/v${JP_VERSION}/jp-linux-amd64 -O /usr/local/bin/jp \
  && chmod +x /usr/local/bin/jp \
- && pip install --no-cache-dir --upgrade jmespath-terminal
+ && pip install --no-cache-dir --upgrade jmespath-community-terminal
 
 WORKDIR azure-cli
 COPY . /azure-cli
@@ -28,9 +28,9 @@ COPY . /azure-cli
 # openssh - included for ssh-keygen
 # ca-certificates
 
-# curl - required for installing jp
+# wget - required for installing jp
 # pip wheel - required for CLI packaging
-# jmespath-terminal - we include jpterm as a useful tool
+# jmespath-community-terminal - we include jpterm as a useful tool
 # 1. Build packages and store in tmp dir
 # 2. Install the cli and the other command modules that weren't included
 RUN /bin/bash -c 'TMP_PKG_DIR=$(mktemp -d); \

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2262,7 +2262,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-jmespath 0.10.0 - MIT
+jmespath-community 1.1.0 - MIT
 
 
 Copyright (c) 2013 Amazon.com, Inc.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ az vm show -g WebPropertiesRG -n Bizlogic
 
 #### Query
 
-You can use the `--query` parameter and the [JMESPath](http://jmespath.org/) query syntax to customize your output.
+You can use the `--query` parameter and the [JMESPath](http://jmespath.site/main) query syntax to customize your output.
 
 ```bash
 $ az vm list --query "[?provisioningState=='Succeeded'].{ name: name, os: storageProfile.osDisk.osType }"

--- a/build_scripts/windows/resources/ThirdPartyNotices.txt
+++ b/build_scripts/windows/resources/ThirdPartyNotices.txt
@@ -2,7 +2,7 @@
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-Microsoft Azure CLI for Azure incorporates components from the projects listed below. The components in Section A are being relicensed to you by Microsoft under the licensing terms for Microsoft CLI 2.0 for Azure, and the components in Section B are being made available to you under their original licensing terms.  The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
+Microsoft Azure CLI for Azure incorporates components from the projects listed below. The components in Section A are being relicensed to you by Microsoft under the licensing terms for Microsoft CLI 2.0 for Azure, and the components in Section B are being made available to you under their original licensing terms.ï¿½ The original copyright notices and the licenses under which Microsoft received such components are set forth below. Microsoft reserves all rights not expressly granted herein, whether by implication, estoppel or otherwise.
 
 Section A: Microsoft is offering you a license to use the following components, subject to the Microsoft Azure CLI license terms.
 
@@ -22,7 +22,7 @@ Section A: Microsoft is offering you a license to use the following components, 
 9.	idna (https://github.com/kjd/idna/releases/tag/v2.5)
 10.	ipaddress (https://github.com/phihag/ipaddress/)
 11.	isodate  (https://github.com/gweis/isodate)
-12.	jmespath  (https://github.com/jmespath/jmespath.py)
+12.	jmespath  (https://github.com/jmespath-community/jmespath.py)
 13.	keyring (https://github.com/jaraco/keyring)
 		Includes:jaraco.util 
 		Includes:six.py 
@@ -42,7 +42,7 @@ Section A: Microsoft is offering you a license to use the following components, 
 24.	Python v2.5 (https://www.python.org)
 25.	Python Cryptography Project (https://cryptography.io/en/latest/)
 26.	python-dateutil (https://github.com/dateutil/dateutil/)
-		Includes:GM Arts with an algorithm by Claus Tøndering 
+		Includes:GM Arts with an algorithm by Claus Tï¿½ndering 
 		Includes:tz library 
 27.	Python distutils (https://www.python.org)
 28.	Python programming language (https://www.python.org)
@@ -139,7 +139,7 @@ Copyright (c) 2008-2017 Matt Gallagher ( https://cocoawithlove.com ). All rights
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies. 
 
-THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+THE SOFTWARE IS PROVIDED ï¿½AS ISï¿½ AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 =========================================
 LuaJIT FFI
 -------------------------------
@@ -1380,7 +1380,7 @@ END OF Pygments  NOTICES AND INFORMATION
 =========================================
 The MIT License (MIT)
 
-Copyright (c) 2015 José Padilla
+Copyright (c) 2015 Josï¿½ Padilla
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1420,16 +1420,16 @@ Copyright (c)2001-2016 The pyOpenSSL developers
 =========================================
 Creative Commons Attribution 4.0 International Public License - https://creativecommons.org/licenses/by/4.0/
 
-Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+Creative Commons Corporation (ï¿½Creative Commonsï¿½) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an ï¿½as-isï¿½ basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
 Using Creative Commons Public Licenses
 Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
 Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
-Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensorï¿½s permission is not necessary for any reasonï¿½for example, because of any applicable exception or limitation to copyrightï¿½then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
 
 Creative Commons Attribution 4.0 International Public License
 
 By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
-Section 1 – Definitions.
+Section 1 ï¿½ Definitions.
 Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
 Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
 Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
@@ -1441,7 +1441,7 @@ Licensor means the individual(s) or entity(ies) granting rights under this Publi
 Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
 Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
 You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
-Section 2 – Scope.
+Section 2 ï¿½ Scope.
 License grant. 
 Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to: 
 reproduce and Share the Licensed Material, in whole or in part; and
@@ -1450,14 +1450,14 @@ Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Lim
 Term. The term of this Public License is specified in Section 6(a).
 Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
 Downstream recipients. 
-Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+Offer from the Licensor ï¿½ Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
 No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
 No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
 Other rights.
 Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
 Patent and trademark rights are not licensed under this Public License.
 To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
-Section 3 – License Conditions.
+Section 3 ï¿½ License Conditions.
 Your exercise of the Licensed Rights is expressly made subject to the following conditions.
 Attribution.
 If You Share the Licensed Material (including in modified form), You must:
@@ -1472,17 +1472,17 @@ indicate the Licensed Material is licensed under this Public License, and includ
 You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
 If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
 If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
-Section 4 – Sui Generis Database Rights.
+Section 4 ï¿½ Sui Generis Database Rights.
 Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
 for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
 if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
 You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
 For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights. 
-Section 5 – Disclaimer of Warranties and Limitation of Liability.
+Section 5 ï¿½ Disclaimer of Warranties and Limitation of Liability.
 Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
 To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
 The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
-Section 6 – Term and Termination.
+Section 6 ï¿½ Term and Termination.
 This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
 Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
 automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
@@ -1490,10 +1490,10 @@ upon express reinstatement by the Licensor.
 For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
 For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
 Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
-Section 7 – Other Terms and Conditions.
+Section 7 ï¿½ Other Terms and Conditions.
 The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
 Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
-Section 8 – Interpretation.
+Section 8 ï¿½ Interpretation.
 For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
 To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
 No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
@@ -1530,7 +1530,7 @@ Jonathan D. Simms
 Jonathan Jacobs
 Jonathan Lange
 Julian Berman
-Jürgen Hermann
+Jï¿½rgen Hermann
 Kevin Horn
 Kevin Turner
 Laurens Van Houtven
@@ -1711,7 +1711,7 @@ END OF Python Cryptography Project NOTICES AND INFORMATION
 dateutil - Extensions to the standard Python datetime module.
 
 Copyright (c) 2003-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
-Copyright (c) 2012-2014 - Tomi Pieviläinen <tomi.pievilainen@iki.fi>
+Copyright (c) 2012-2014 - Tomi Pievilï¿½inen <tomi.pievilainen@iki.fi>
 Copyright (c) 2014      - Yaron de Leeuw <me@jarondl.net>
 
 All rights reserved.
@@ -1740,7 +1740,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 =========================================
-GM Arts with an algorithm by Claus Tøndering
+GM Arts with an algorithm by Claus Tï¿½ndering
 -------------------------------
 (1) GM Arts Copyright - Web Page Information
 1.1 What You CAN Do
@@ -1770,11 +1770,11 @@ Simply, you can't copy information in any manner that does not meet the guidelin
 
 
 Copyright and disclaimer
-This document is Copyright ©2017 by Claus Tøndering.
+This document is Copyright ï¿½2017 by Claus Tï¿½ndering.
 
 The document may be freely distributed, provided this copyright notice is included and no money is charged for the document.
 
-This document is provided “as is”. No warranties are made as to its correctness.
+This document is provided ï¿½as isï¿½. No warranties are made as to its correctness.
 =========================================
 tz library
 -------------------------------
@@ -2073,7 +2073,7 @@ Python programming language
    analyze, test, perform and/or display publicly, prepare derivative works,
    distribute, and otherwise use Python 3.6.1 alone or in any derivative
    version, provided, however, that PSF's License Agreement and PSF's notice of
-   copyright, i.e., "Copyright © 2001-2017 Python Software Foundation; All Rights
+   copyright, i.e., "Copyright ï¿½ 2001-2017 Python Software Foundation; All Rights
    Reserved" are retained in Python 3.6.1 alone or in any derivative version
    prepared by Licensee.
 
@@ -2123,7 +2123,7 @@ PSF LICENSE AGREEMENT FOR PYTHON 3.5.2
    analyze, test, perform and/or display publicly, prepare derivative works,
    distribute, and otherwise use Python 3.5.2 alone or in any derivative
    version, provided, however, that PSF's License Agreement and PSF's notice of
-   copyright, i.e., "Copyright © 2001-2016 Python Software Foundation; All Rights
+   copyright, i.e., "Copyright ï¿½ 2001-2016 Python Software Foundation; All Rights
    Reserved" are retained in Python 3.5.2 alone or in any derivative version
    prepared by Licensee.
 
@@ -2210,7 +2210,7 @@ CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
    analyze, test, perform and/or display publicly, prepare derivative works,
    distribute, and otherwise use Python 1.6.1 alone or in any derivative version,
    provided, however, that CNRI's License Agreement and CNRI's notice of copyright,
-   i.e., "Copyright © 1995-2001 Corporation for National Research Initiatives; All
+   i.e., "Copyright ï¿½ 1995-2001 Corporation for National Research Initiatives; All
    Rights Reserved" are retained in Python 1.6.1 alone or in any derivative version
    prepared by Licensee.  Alternately, in lieu of CNRI's License Agreement,
    Licensee may substitute the following text (omitting the quotes): "Python 1.6.1
@@ -2259,7 +2259,7 @@ CNRI LICENSE AGREEMENT FOR PYTHON 1.6.1
    conditions of this License Agreement.
 
  LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
-Copyright © 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The
+Copyright ï¿½ 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The
 Netherlands.  All rights reserved.
 
 Permission to use, copy, modify, and distribute this software and its
@@ -2995,7 +2995,7 @@ written authorization of the copyright holder.
 =========================================
 END OF Whoosh NOTICES AND INFORMATION
 
-Section B: The following components are offered subject to their original license terms. For those third party components licensed under open source licenses with source code availability obligations you may obtain the complete corresponding source code from Microsoft, if and as required under the relevant open source licenses, by sending a money order or check for $5.00 to: Source Code Compliance Team, Microsoft Corporation, 1 Microsoft Way, Redmond, WA 98052 USA. Please write “ [name of component]” in the memo line of your payment.  We may also make the source available at http://3rdpartysource.microsoft.com/.
+Section B: The following components are offered subject to their original license terms. For those third party components licensed under open source licenses with source code availability obligations you may obtain the complete corresponding source code from Microsoft, if and as required under the relevant open source licenses, by sending a money order or check for $5.00 to: Source Code Compliance Team, Microsoft Corporation, 1 Microsoft Way, Redmond, WA 98052 USA. Please write ï¿½ [name of component]ï¿½ in the memo line of your payment.  We may also make the source available at http://3rdpartysource.microsoft.com/.
 
 1.	certifi  (https://github.com/certifi/python-certifi)
 2.	chardet 

--- a/doc/authoring_tests.md
+++ b/doc/authoring_tests.md
@@ -135,7 +135,7 @@ class StorageAccountTests(ScenarioTest):
 
 Notes:
 
-1. The first argument in the `check` method is a JMESPath query. [JMESPath is a query language for JSON](http://jmespath.org/).
+1. The first argument in the `check` method is a JMESPath query. [JMESPath is a query language for JSON](http://jmespath.site/main/).
 2. If a command returns JSON, multiple JMESPath based checks can be added to the checks list to validate the result.
 3. In addition to the `check` method, there are other checks like `is_empty` which validate the output is `None`. The check mechanism is extensible. Any callable accepting a single `ExecutionResult` argument can act as a check: see [checkers.py](https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-testsdk/azure/cli/testsdk/checkers.py).
 

--- a/doc/classic_cli_migration.md
+++ b/doc/classic_cli_migration.md
@@ -187,7 +187,7 @@ $ azure vm list --json \
 $ MY_SUBSCRIPTION_ID=$(azure account show --json | jq -r '.[0].id')
 ```
 
-With the Azure CLI, you can now use the `--query '[expression]'` parameter and the [JMESPath](http://jmespath.org/)
+With the Azure CLI, you can now use the `--query '[expression]'` parameter and the [JMESPath](http://jmespath.site/main)
 query language to extract values.
 
 ```azurecli

--- a/src/azure-cli/azure/cli/command_modules/acs/_format.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_format.py
@@ -72,7 +72,9 @@ def _aks_table_format(result):
         fqdn: fqdn || privateFqdn
     }""")
     # use ordered dicts so headers are predictable
-    return parsed.search(result, Options(dict_cls=OrderedDict))
+    # enable compatibility with legacy JSON literals
+    return parsed.search(result,
+        Options(dict_cls=OrderedDict, enable_legacy_literals=True))
 
 
 def aks_upgrades_table_format(result):

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.1.11.help.txt
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.1.11.help.txt
@@ -54,7 +54,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -70,7 +70,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -88,7 +88,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -113,7 +113,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -135,7 +135,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -155,7 +155,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -185,7 +185,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -217,7 +217,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -237,7 +237,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -273,7 +273,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -292,7 +292,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -315,7 +315,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -340,7 +340,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -360,7 +360,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -393,7 +393,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -415,7 +415,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -435,7 +435,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -458,7 +458,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -496,7 +496,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -525,7 +525,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                  json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -561,7 +561,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -600,7 +600,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --verbose                    : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -627,7 +627,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --verbose              : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -655,7 +655,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --verbose              : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -683,7 +683,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -878,7 +878,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -906,7 +906,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -955,7 +955,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -995,7 +995,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1116,7 +1116,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1187,7 +1187,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1233,7 +1233,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                  json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1270,7 +1270,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1338,7 +1338,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1388,7 +1388,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1423,7 +1423,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1501,7 +1501,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1525,7 +1525,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1563,7 +1563,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --verbose                      : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1641,7 +1641,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1669,7 +1669,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1697,7 +1697,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1735,7 +1735,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1774,7 +1774,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1832,7 +1832,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1860,7 +1860,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1907,7 +1907,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1957,7 +1957,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1983,7 +1983,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2023,7 +2023,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2065,7 +2065,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2109,7 +2109,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2149,7 +2149,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2184,7 +2184,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2214,7 +2214,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2330,7 +2330,7 @@ Global Arguments
     --help -h                              : Show this help message and exit.
     --output -o                            : Output format.  Allowed values: json, jsonc, table,
                                              tsv.  Default: json.
-    --query                                : JMESPath query string. See http://jmespath.org/ for
+    --query                                : JMESPath query string. See http://jmespath.site/main for
                                              more information and examples.
     --verbose                              : Increase logging verbosity. Use --debug for full debug
                                              logs.
@@ -2377,7 +2377,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2417,7 +2417,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2501,7 +2501,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2589,7 +2589,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2619,7 +2619,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2669,7 +2669,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2712,7 +2712,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2755,7 +2755,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2790,7 +2790,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2836,7 +2836,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2874,7 +2874,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3043,7 +3043,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3092,7 +3092,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3137,7 +3137,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3346,7 +3346,7 @@ Global Arguments
     --output -o                                      : Output format.  Allowed values: json, jsonc,
                                                        table, tsv.  Default: json.
     --query                                          : JMESPath query string. See
-                                                       http://jmespath.org/ for more information and
+                                                       http://jmespath.site/main for more information and
                                                        examples.
     --verbose                                        : Increase logging verbosity. Use --debug for
                                                        full debug logs.
@@ -3555,7 +3555,7 @@ Global Arguments
     --output -o                                      : Output format.  Allowed values: json, jsonc,
                                                        table, tsv.  Default: json.
     --query                                          : JMESPath query string. See
-                                                       http://jmespath.org/ for more information and
+                                                       http://jmespath.site/main for more information and
                                                        examples.
     --verbose                                        : Increase logging verbosity. Use --debug for
                                                        full debug logs.
@@ -3600,7 +3600,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3643,7 +3643,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3686,7 +3686,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3714,7 +3714,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3798,7 +3798,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3829,7 +3829,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3873,7 +3873,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3916,7 +3916,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3977,7 +3977,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4023,7 +4023,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4065,7 +4065,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4104,7 +4104,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4149,7 +4149,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4189,7 +4189,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4223,7 +4223,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4253,6 +4253,6 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.2.0.help.txt
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.2.0.help.txt
@@ -54,7 +54,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -70,7 +70,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -88,7 +88,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -113,7 +113,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -135,7 +135,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -155,7 +155,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -185,7 +185,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -217,7 +217,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -237,7 +237,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -273,7 +273,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -292,7 +292,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -315,7 +315,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -340,7 +340,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -360,7 +360,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -393,7 +393,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -415,7 +415,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -435,7 +435,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -458,7 +458,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -496,7 +496,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -525,7 +525,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                  json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -561,7 +561,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -600,7 +600,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --verbose                    : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -627,7 +627,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --verbose              : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -655,7 +655,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                              json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --verbose              : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -685,7 +685,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -881,7 +881,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -911,7 +911,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -960,7 +960,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1000,7 +1000,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1121,7 +1121,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1192,7 +1192,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1238,7 +1238,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                  json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --verbose                  : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1277,7 +1277,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1345,7 +1345,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --verbose                     : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1395,7 +1395,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1430,7 +1430,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1508,7 +1508,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1532,7 +1532,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1570,7 +1570,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --verbose                      : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1605,7 +1605,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1684,7 +1684,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1712,7 +1712,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1742,7 +1742,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1771,7 +1771,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1801,7 +1801,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1859,7 +1859,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1887,7 +1887,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1934,7 +1934,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -1975,7 +1975,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2001,7 +2001,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2041,7 +2041,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2083,7 +2083,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2147,7 +2147,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2191,7 +2191,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2231,7 +2231,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2266,7 +2266,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2298,7 +2298,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2414,7 +2414,7 @@ Global Arguments
     --help -h                              : Show this help message and exit.
     --output -o                            : Output format.  Allowed values: json, jsonc, table,
                                              tsv.  Default: json.
-    --query                                : JMESPath query string. See http://jmespath.org/ for
+    --query                                : JMESPath query string. See http://jmespath.site/main for
                                              more information and examples.
     --verbose                              : Increase logging verbosity. Use --debug for full debug
                                              logs.
@@ -2461,7 +2461,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2501,7 +2501,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2585,7 +2585,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2673,7 +2673,7 @@ Global Arguments
     --help -h                 : Show this help message and exit.
     --output -o               : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                 json.
-    --query                   : JMESPath query string. See http://jmespath.org/ for more information
+    --query                   : JMESPath query string. See http://jmespath.site/main for more information
                                 and examples.
     --verbose                 : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2703,7 +2703,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2750,7 +2750,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2793,7 +2793,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2836,7 +2836,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2871,7 +2871,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2917,7 +2917,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -2955,7 +2955,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3124,7 +3124,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv.
                                        Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --verbose                        : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3173,7 +3173,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3218,7 +3218,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3427,7 +3427,7 @@ Global Arguments
     --output -o                                      : Output format.  Allowed values: json, jsonc,
                                                        table, tsv.  Default: json.
     --query                                          : JMESPath query string. See
-                                                       http://jmespath.org/ for more information and
+                                                       http://jmespath.site/main for more information and
                                                        examples.
     --verbose                                        : Increase logging verbosity. Use --debug for
                                                        full debug logs.
@@ -3636,7 +3636,7 @@ Global Arguments
     --output -o                                      : Output format.  Allowed values: json, jsonc,
                                                        table, tsv.  Default: json.
     --query                                          : JMESPath query string. See
-                                                       http://jmespath.org/ for more information and
+                                                       http://jmespath.site/main for more information and
                                                        examples.
     --verbose                                        : Increase logging verbosity. Use --debug for
                                                        full debug logs.
@@ -3681,7 +3681,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3724,7 +3724,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3767,7 +3767,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                                   json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --verbose                   : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3797,7 +3797,7 @@ Global Arguments
     --debug           : Increase logging verbosity to show all debug logs.
     --help -h         : Show this help message and exit.
     --output -o       : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query           : JMESPath query string. See http://jmespath.org/ for more information and
+    --query           : JMESPath query string. See http://jmespath.site/main for more information and
                         examples.
     --verbose         : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3885,7 +3885,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --verbose                       : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3918,7 +3918,7 @@ Global Arguments
     --debug            : Increase logging verbosity to show all debug logs.
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --verbose          : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -3962,7 +3962,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4005,7 +4005,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4066,7 +4066,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4112,7 +4112,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4154,7 +4154,7 @@ Global Arguments
     --debug              : Increase logging verbosity to show all debug logs.
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --verbose            : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4193,7 +4193,7 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4238,7 +4238,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4278,7 +4278,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --verbose               : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4312,7 +4312,7 @@ Global Arguments
     --debug               : Increase logging verbosity to show all debug logs.
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --verbose             : Increase logging verbosity. Use --debug for full debug logs.
 
@@ -4344,6 +4344,6 @@ Global Arguments
     --debug             : Increase logging verbosity to show all debug logs.
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv.  Default: json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --verbose           : Increase logging verbosity. Use --debug for full debug logs.

--- a/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.4.0.help.txt
+++ b/src/azure-cli/azure/cli/command_modules/batch/tests/latest/recordings/cli-3.4.0.help.txt
@@ -54,7 +54,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -75,7 +75,7 @@ Global Arguments
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                           json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --subscription      : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
@@ -98,7 +98,7 @@ Global Arguments
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                           json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --subscription      : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
@@ -126,7 +126,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -151,7 +151,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -174,7 +174,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -207,7 +207,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -242,7 +242,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -265,7 +265,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -304,7 +304,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -326,7 +326,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -352,7 +352,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -380,7 +380,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -403,7 +403,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -439,7 +439,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -464,7 +464,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -487,7 +487,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -513,7 +513,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -555,7 +555,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -587,7 +587,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                   Default: json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --subscription              : Name or ID of subscription. You can configure the default
                                   subscription using `az account set -s NAME_OR_ID`.
@@ -626,7 +626,7 @@ Global Arguments
     --help -h                : Show this help message and exit.
     --output -o              : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                Default: json.
-    --query                  : JMESPath query string. See http://jmespath.org/ for more information
+    --query                  : JMESPath query string. See http://jmespath.site/main for more information
                                and examples.
     --subscription           : Name or ID of subscription. You can configure the default
                                subscription using `az account set -s NAME_OR_ID`.
@@ -668,7 +668,7 @@ Global Arguments
     --help -h                     : Show this help message and exit.
     --output -o                   : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                     Default: json.
-    --query                       : JMESPath query string. See http://jmespath.org/ for more
+    --query                       : JMESPath query string. See http://jmespath.site/main for more
                                     information and examples.
     --subscription                : Name or ID of subscription. You can configure the default
                                     subscription using `az account set -s NAME_OR_ID`.
@@ -698,7 +698,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                               Default: json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --subscription          : Name or ID of subscription. You can configure the default subscription
                               using `az account set -s NAME_OR_ID`.
@@ -729,7 +729,7 @@ Global Arguments
     --help -h               : Show this help message and exit.
     --output -o             : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                               Default: json.
-    --query                 : JMESPath query string. See http://jmespath.org/ for more information
+    --query                 : JMESPath query string. See http://jmespath.site/main for more information
                               and examples.
     --subscription          : Name or ID of subscription. You can configure the default subscription
                               using `az account set -s NAME_OR_ID`.
@@ -763,7 +763,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -977,7 +977,7 @@ Global Arguments
     --help -h                         : Show this help message and exit.
     --output -o                       : Output format.  Allowed values: json, jsonc, table, tsv,
                                         yaml.  Default: json.
-    --query                           : JMESPath query string. See http://jmespath.org/ for more
+    --query                           : JMESPath query string. See http://jmespath.site/main for more
                                         information and examples.
     --subscription                    : Name or ID of subscription. You can configure the default
                                         subscription using `az account set -s NAME_OR_ID`.
@@ -1011,7 +1011,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -1064,7 +1064,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -1108,7 +1108,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -1243,7 +1243,7 @@ Global Arguments
     --help -h                         : Show this help message and exit.
     --output -o                       : Output format.  Allowed values: json, jsonc, table, tsv,
                                         yaml.  Default: json.
-    --query                           : JMESPath query string. See http://jmespath.org/ for more
+    --query                           : JMESPath query string. See http://jmespath.site/main for more
                                         information and examples.
     --subscription                    : Name or ID of subscription. You can configure the default
                                         subscription using `az account set -s NAME_OR_ID`.
@@ -1321,7 +1321,7 @@ Global Arguments
     --help -h                         : Show this help message and exit.
     --output -o                       : Output format.  Allowed values: json, jsonc, table, tsv,
                                         yaml.  Default: json.
-    --query                           : JMESPath query string. See http://jmespath.org/ for more
+    --query                           : JMESPath query string. See http://jmespath.site/main for more
                                         information and examples.
     --subscription                    : Name or ID of subscription. You can configure the default
                                         subscription using `az account set -s NAME_OR_ID`.
@@ -1370,7 +1370,7 @@ Global Arguments
     --help -h                   : Show this help message and exit.
     --output -o                 : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                   Default: json.
-    --query                     : JMESPath query string. See http://jmespath.org/ for more
+    --query                     : JMESPath query string. See http://jmespath.site/main for more
                                   information and examples.
     --subscription              : Name or ID of subscription. You can configure the default
                                   subscription using `az account set -s NAME_OR_ID`.
@@ -1413,7 +1413,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -1484,7 +1484,7 @@ Global Arguments
     --help -h                      : Show this help message and exit.
     --output -o                    : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                      Default: json.
-    --query                        : JMESPath query string. See http://jmespath.org/ for more
+    --query                        : JMESPath query string. See http://jmespath.site/main for more
                                      information and examples.
     --subscription                 : Name or ID of subscription. You can configure the default
                                      subscription using `az account set -s NAME_OR_ID`.
@@ -1538,7 +1538,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -1577,7 +1577,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -1658,7 +1658,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv,
                                        yaml.  Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --subscription                   : Name or ID of subscription. You can configure the default
                                        subscription using `az account set -s NAME_OR_ID`.
@@ -1686,7 +1686,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -1727,7 +1727,7 @@ Global Arguments
     --help -h                       : Show this help message and exit.
     --output -o                     : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                       Default: json.
-    --query                         : JMESPath query string. See http://jmespath.org/ for more
+    --query                         : JMESPath query string. See http://jmespath.site/main for more
                                       information and examples.
     --subscription                  : Name or ID of subscription. You can configure the default
                                       subscription using `az account set -s NAME_OR_ID`.
@@ -1768,7 +1768,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -1850,7 +1850,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                  Default: json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --subscription             : Name or ID of subscription. You can configure the default
                                  subscription using `az account set -s NAME_OR_ID`.
@@ -1882,7 +1882,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -1916,7 +1916,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -1949,7 +1949,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -1983,7 +1983,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -2046,7 +2046,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -2078,7 +2078,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -2130,7 +2130,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -2174,7 +2174,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv,
                                        yaml.  Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --subscription                   : Name or ID of subscription. You can configure the default
                                        subscription using `az account set -s NAME_OR_ID`.
@@ -2204,7 +2204,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -2248,7 +2248,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -2293,7 +2293,7 @@ Global Arguments
     --help -h                : Show this help message and exit.
     --output -o              : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                Default: json.
-    --query                  : JMESPath query string. See http://jmespath.org/ for more information
+    --query                  : JMESPath query string. See http://jmespath.site/main for more information
                                and examples.
     --subscription           : Name or ID of subscription. You can configure the default
                                subscription using `az account set -s NAME_OR_ID`.
@@ -2362,7 +2362,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -2410,7 +2410,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -2454,7 +2454,7 @@ Global Arguments
     --help -h                : Show this help message and exit.
     --output -o              : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                Default: json.
-    --query                  : JMESPath query string. See http://jmespath.org/ for more information
+    --query                  : JMESPath query string. See http://jmespath.site/main for more information
                                and examples.
     --subscription           : Name or ID of subscription. You can configure the default
                                subscription using `az account set -s NAME_OR_ID`.
@@ -2493,7 +2493,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -2529,7 +2529,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -2664,7 +2664,7 @@ Global Arguments
     --help -h                               : Show this help message and exit.
     --output -o                             : Output format.  Allowed values: json, jsonc, table,
                                               tsv, yaml.  Default: json.
-    --query                                 : JMESPath query string. See http://jmespath.org/ for
+    --query                                 : JMESPath query string. See http://jmespath.site/main for
                                               more information and examples.
     --subscription                          : Name or ID of subscription. You can configure the
                                               default subscription using `az account set -s
@@ -2716,7 +2716,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -2760,7 +2760,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -2847,7 +2847,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                  Default: json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --subscription             : Name or ID of subscription. You can configure the default
                                  subscription using `az account set -s NAME_OR_ID`.
@@ -2938,7 +2938,7 @@ Global Arguments
     --help -h                  : Show this help message and exit.
     --output -o                : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                  Default: json.
-    --query                    : JMESPath query string. See http://jmespath.org/ for more
+    --query                    : JMESPath query string. See http://jmespath.site/main for more
                                  information and examples.
     --subscription             : Name or ID of subscription. You can configure the default
                                  subscription using `az account set -s NAME_OR_ID`.
@@ -2972,7 +2972,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -3023,7 +3023,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -3070,7 +3070,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -3120,7 +3120,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -3159,7 +3159,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -3209,7 +3209,7 @@ Global Arguments
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                           json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --subscription      : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
@@ -3249,7 +3249,7 @@ Global Arguments
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                           json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --subscription      : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
@@ -3432,7 +3432,7 @@ Global Arguments
     --help -h                         : Show this help message and exit.
     --output -o                       : Output format.  Allowed values: json, jsonc, table, tsv,
                                         yaml.  Default: json.
-    --query                           : JMESPath query string. See http://jmespath.org/ for more
+    --query                           : JMESPath query string. See http://jmespath.site/main for more
                                         information and examples.
     --subscription                    : Name or ID of subscription. You can configure the default
                                         subscription using `az account set -s NAME_OR_ID`.
@@ -3484,7 +3484,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --subscription               : Name or ID of subscription. You can configure the default
                                    subscription using `az account set -s NAME_OR_ID`.
@@ -3532,7 +3532,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --subscription               : Name or ID of subscription. You can configure the default
                                    subscription using `az account set -s NAME_OR_ID`.
@@ -3763,7 +3763,7 @@ Global Arguments
     --output -o                                       : Output format.  Allowed values: json, jsonc,
                                                         table, tsv, yaml.  Default: json.
     --query                                           : JMESPath query string. See
-                                                        http://jmespath.org/ for more information
+                                                        http://jmespath.site/main for more information
                                                         and examples.
     --subscription                                    : Name or ID of subscription. You can
                                                         configure the default subscription using `az
@@ -3995,7 +3995,7 @@ Global Arguments
     --output -o                                       : Output format.  Allowed values: json, jsonc,
                                                         table, tsv, yaml.  Default: json.
     --query                                           : JMESPath query string. See
-                                                        http://jmespath.org/ for more information
+                                                        http://jmespath.site/main for more information
                                                         and examples.
     --subscription                                    : Name or ID of subscription. You can
                                                         configure the default subscription using `az
@@ -4044,7 +4044,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --subscription               : Name or ID of subscription. You can configure the default
                                    subscription using `az account set -s NAME_OR_ID`.
@@ -4090,7 +4090,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --subscription               : Name or ID of subscription. You can configure the default
                                    subscription using `az account set -s NAME_OR_ID`.
@@ -4136,7 +4136,7 @@ Global Arguments
     --help -h                    : Show this help message and exit.
     --output -o                  : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                    Default: json.
-    --query                      : JMESPath query string. See http://jmespath.org/ for more
+    --query                      : JMESPath query string. See http://jmespath.site/main for more
                                    information and examples.
     --subscription               : Name or ID of subscription. You can configure the default
                                    subscription using `az account set -s NAME_OR_ID`.
@@ -4170,7 +4170,7 @@ Global Arguments
     --help -h          : Show this help message and exit.
     --output -o        : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                          json.
-    --query            : JMESPath query string. See http://jmespath.org/ for more information and
+    --query            : JMESPath query string. See http://jmespath.site/main for more information and
                          examples.
     --subscription     : Name or ID of subscription. You can configure the default subscription
                          using `az account set -s NAME_OR_ID`.
@@ -4269,7 +4269,7 @@ Global Arguments
     --help -h                        : Show this help message and exit.
     --output -o                      : Output format.  Allowed values: json, jsonc, table, tsv,
                                        yaml.  Default: json.
-    --query                          : JMESPath query string. See http://jmespath.org/ for more
+    --query                          : JMESPath query string. See http://jmespath.site/main for more
                                        information and examples.
     --subscription                   : Name or ID of subscription. You can configure the default
                                        subscription using `az account set -s NAME_OR_ID`.
@@ -4306,7 +4306,7 @@ Global Arguments
     --help -h           : Show this help message and exit.
     --output -o         : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                           json.
-    --query             : JMESPath query string. See http://jmespath.org/ for more information and
+    --query             : JMESPath query string. See http://jmespath.site/main for more information and
                           examples.
     --subscription      : Name or ID of subscription. You can configure the default subscription
                           using `az account set -s NAME_OR_ID`.
@@ -4354,7 +4354,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -4401,7 +4401,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -4471,7 +4471,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -4521,7 +4521,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -4567,7 +4567,7 @@ Global Arguments
     --help -h             : Show this help message and exit.
     --output -o           : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                             json.
-    --query               : JMESPath query string. See http://jmespath.org/ for more information and
+    --query               : JMESPath query string. See http://jmespath.site/main for more information and
                             examples.
     --subscription        : Name or ID of subscription. You can configure the default subscription
                             using `az account set -s NAME_OR_ID`.
@@ -4610,7 +4610,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.
@@ -4659,7 +4659,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -4702,7 +4702,7 @@ Global Arguments
     --help -h                : Show this help message and exit.
     --output -o              : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                                Default: json.
-    --query                  : JMESPath query string. See http://jmespath.org/ for more information
+    --query                  : JMESPath query string. See http://jmespath.site/main for more information
                                and examples.
     --subscription           : Name or ID of subscription. You can configure the default
                                subscription using `az account set -s NAME_OR_ID`.
@@ -4740,7 +4740,7 @@ Global Arguments
     --help -h              : Show this help message and exit.
     --output -o            : Output format.  Allowed values: json, jsonc, table, tsv, yaml.
                              Default: json.
-    --query                : JMESPath query string. See http://jmespath.org/ for more information
+    --query                : JMESPath query string. See http://jmespath.site/main for more information
                              and examples.
     --subscription         : Name or ID of subscription. You can configure the default subscription
                              using `az account set -s NAME_OR_ID`.
@@ -4777,7 +4777,7 @@ Global Arguments
     --help -h            : Show this help message and exit.
     --output -o          : Output format.  Allowed values: json, jsonc, table, tsv, yaml.  Default:
                            json.
-    --query              : JMESPath query string. See http://jmespath.org/ for more information and
+    --query              : JMESPath query string. See http://jmespath.site/main for more information and
                            examples.
     --subscription       : Name or ID of subscription. You can configure the default subscription
                            using `az account set -s NAME_OR_ID`.

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -104,7 +104,7 @@ invoke==1.2.0
 isodate==0.6.1
 javaproperties==0.5.1
 Jinja2==3.0.3
-jmespath==0.9.5
+jmespath-community==1.1.0
 jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -105,7 +105,7 @@ invoke==1.2.0
 isodate==0.6.1
 javaproperties==0.5.1
 Jinja2==3.0.3
-jmespath==0.9.5
+jmespath-community==1.1.0
 jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -104,7 +104,7 @@ invoke==1.2.0
 isodate==0.6.1
 javaproperties==0.5.1
 Jinja2==3.0.3
-jmespath==0.9.5
+jmespath-community==1.1.0
 jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1


### PR DESCRIPTION
**Description**

This PR addresses #24542 by updating the current dependency on the JMESPath language used in the `--query` command-line argument.

**Testing Guide**

az CLI uses the JMESPath language to power its `--query` command-line argument.
For instance, consider the following current behaviour:

- `` az storage account list --query "[].{location: location, name:name}" ``: 

```json
[
  { "location": "westeurope", "name": "storageaccount-001" },
  { "location": "westeurope", "name": "storageaccount-002" },
  { "location": "northeurope", "name": "storageaccount-003" },
  { "location": "westus", "name": "storageaccount-004" },
  { "location": "westus", "name": "storageaccount-005" }
]
```

Here is a new query that can be performed using JMESPath Community:

```sh
az storage account list \
  --query "group_by([].{loc: location, n:name}, &loc).*.let( {key: [0].loc, values: [*].n}, &{key: key, values: values})|from_items(zip([*].key, [*].values))"
``` 

with the corresponding result:

```json
{
  "westeurope": [ "storageaccount-001", "storageaccount-002" ],
  "northeurope": [ "storageaccount-003" ],
  "westus": [ "storageaccount-004", "storageaccount-005" ]
}
```

While there is definitely a learning curve to JMESPath, this example features most of the improvements we’ve made to the specification.

The full expression can be broken down into chunks:

- `` group_by([].{loc: location, n: name}, &loc) ``: creates a new hash with the subset of interesting `location` and `names` properties from the original object. It uses the new `group_by()` function to split the result by location.
- `` .* ``: is a value projection to create an array that can be iterated upon subsequently.
- `` let( {key: [0].loc, values: [*].n}, &{key:key, values:values}) ``: expression that is evaluated for each item in the projected array. It uses the new `let()` function to take advantage of lexical scoping.
  - Its first argument initialize a new scope with the two `key` and `values` properties that contain the value of the `loc` property from the first array entry – as all entries contain the same location at this stage – and the list of names respectively.
  - Its second argument creates a hash with the two aforementioned properties.
- `` | ``: the pipe stops the projection so that later expressions operate on the full array instead of being evaluated iteratively on each array element.
- `` from_items(zip([*].key, [*].values)) ``: creates the expected result.
  - It uses the new `zip()` function to combine the list of `key` elements and the `values` arrays into a single entity.
  - It then uses the new `from_items()` functions to combine those two lists like for like to produce the resulting object shown above.

**Overview**

This PR is a draft as I would like to make the most effort to help include an updated JMESPath language with an improved feature set to az CLI. However, I’m not sure what would be the reasonable changes to do or if it should be broken into multiple pull requests. I would also likely need guidance over how to best fill the PR description template.

This PR makes the following changes:

- Replaces all mentions of the `jmespath.org` original web site to the new `jmespath.site`.
- Replaces original dependencies over `jmespath` Python package to the new `jmespath-community` Python package.
- Replaces original dependencies over `jmespath-terminal` (`jpterm` helper) Python CLI tool to the new `jmespath-community-terminal` tool in Docker images.
- Replaces original `github.com/jmespath/jp` CLI tool by the new `github.com/jmespath-community/jp` CLI tool in Docker images.
- Updates minimum Python version to `3.7.16` for some Docker image.
- Updates various documentation pages while keeping the same LICENSE requirements.

I’m not sure if all the documentation pages must be updated though.

**JMESPath Community**

This PR aims to include [JMESPath Community](https://jmespath.site/main/) assets into az CLI.

JMESPath Community is a new initiative to bring improvements to and steward the specification going forward,
as the language and its tools no longer appear to be maintained. As its first milestone,
JMESPath Community includes the following improvements to the original specification:

- JEP-11 Lexical Scoping
- JEP-12a Raw String Literals
- JEP-13 Object Manipulation functions
- JEP-14 String functions
- JEP-15 String Slices
- JEP-16 Arithmetic Expressions
- JEP-17 Root Reference
- JEP-18 Grouping
- JEP-19 Standardized Evaluation of Pipe Expressions

JMESPath Community also aims to be an umbrella for specific programming language implementations. It currently hosts the following 100% compliant implementations:

- [jmespath-community (Python)](https://pypi.org/project/jmespath-community/)
- [jmespath-community-terminal (Python)](https://pypi.org/project/jmespath-community-terminal/)
- [go-jmespath (Golang)](https://pkg.go.dev/github.com/jmespath-community/go-jmespath)
- [jp (Golang)](https://github.com/jmespath-community/jp)

I’m also the co-author of the [JMESPath.Net](https://jdevillard.github.io/JmesPath.Net/) implementation 🤐.

For the purpose of az CLI, JMESPath Community is a drop-in replacement for the original `jmespath` Python package. It maintains backwards compatibility with the original language to prevent breaking existing syntax and scripts.

The various built-in Docker images re-introduce `jpterm` which has seen its dependencies updated and [no longer breaks the CI](https://github.com/Azure/azure-cli/pull/21206).

The accompanying `jp` executable has also been brought up to standards and is included in this PR.