### PR TITLE
{Storage} Fix #25563: `az storage blob copy start`: Enable to use `--auth-mode login` when converting blob type

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -818,7 +818,8 @@ def generate_sas_blob_uri(cmd, client, permission=None, expiry=None, start=None,
     account_key = None
     if as_user:
         user_delegation_key = client.get_user_delegation_key(
-            get_datetime_from_string(start) if start else datetime.utcnow(), get_datetime_from_string(expiry))
+            start if start else datetime.utcnow(), expiry)
+
     else:
         account_key = client.credential.account_key
 
@@ -1008,8 +1009,11 @@ def copy_blob(cmd, client, source_url, metadata=None, **kwargs):
     if blob_type is not None and blob_type != 'Detect':
         blob_service_client = src_client._get_container_client()._get_blob_service_client()
         if blob_service_client.credential is not None:
+            as_user = True
+            if hasattr(blob_service_client.credential, 'account_key'):
+                as_user = False
             source_url = generate_sas_blob_uri(cmd, blob_service_client, full_uri=True, blob_url=source_url,
-                                               blob_name=None, container_name=None,
+                                               blob_name=None, container_name=None, as_user=as_user,
                                                expiry=datetime.utcnow() + timedelta(hours=1), permission='r')
 
         params = {"source_if_modified_since": kwargs.get("source_if_modified_since"),

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -818,7 +818,7 @@ def generate_sas_blob_uri(cmd, client, permission=None, expiry=None, start=None,
     account_key = None
     if as_user:
         user_delegation_key = client.get_user_delegation_key(
-            start if start else datetime.utcnow(), expiry)
+            get_datetime_from_string(start) if start else datetime.utcnow(), get_datetime_from_string(expiry))
 
     else:
         account_key = client.credential.account_key
@@ -1012,9 +1012,10 @@ def copy_blob(cmd, client, source_url, metadata=None, **kwargs):
             as_user = True
             if hasattr(blob_service_client.credential, 'account_key'):
                 as_user = False
+            expiry = (datetime.utcnow() + timedelta(hours=1)).strftime('%Y-%m-%dT%H:%MZ')
             source_url = generate_sas_blob_uri(cmd, blob_service_client, full_uri=True, blob_url=source_url,
                                                blob_name=None, container_name=None, as_user=as_user,
-                                               expiry=datetime.utcnow() + timedelta(hours=1), permission='r')
+                                               expiry=expiry, permission='r')
 
         params = {"source_if_modified_since": kwargs.get("source_if_modified_since"),
                   "source_if_unmodified_since": kwargs.get("source_if_unmodified_since"),

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -819,7 +819,6 @@ def generate_sas_blob_uri(cmd, client, permission=None, expiry=None, start=None,
     if as_user:
         user_delegation_key = client.get_user_delegation_key(
             get_datetime_from_string(start) if start else datetime.utcnow(), get_datetime_from_string(expiry))
-
     else:
         account_key = client.credential.account_key
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob copy start`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #25563 
Fix the bug that cannot use `login` for auth when converting blob type in the command `az storage blob copy start`.


**Testing Guide**
<!--Example commands with explanations.-->
`az storage blob copy start --account-name {} --auth-mode login -c {} -b {} --source-account-name {} --source-container {} --source-blob {} --destination-blob-type {}`


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
