### PR TITLE
{Storage} Fix #25595: `az storage blob list`: Enable to return `nextMarker` when combining with `--query`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/commands/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/commands/__init__.py
@@ -673,7 +673,9 @@ class AzCliCommandInvoker(CommandInvoker):
 
         event_data = {'result': results}
         self.cli_ctx.raise_event(EVENT_INVOKER_FILTER_RESULT, event_data=event_data)
-
+        if results and len(results) > 0 and 'nextMarker' in results[-1] and \
+                'nextMarker' not in event_data['result'][-1]:
+            event_data['result'].append(results[-1])
         # save to local context if it is turned on after command executed successfully
         if self.cli_ctx.local_context.is_on and command and command in self.commands_loader.command_table and \
                 command in self.parser.subparser_map and self.parser.subparser_map[command].specified_arguments:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
 `az storage blob list`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #25595 
Fix the bug that do not return `nextMarker` when combining with `--query`. `nextMarker` should not be filtered falsely by JMESPath.

**Testing Guide**
<!--Example commands with explanations.-->
`az storage blob list --account-name {} --container-name {} --num-results 1 --show-next-marker --include t --query {}`
`nextMarker` should be included in the JSON output.


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
