### PR TITLE
{Doc} `az netappfiles volume quota-rule`: Fixed typo in release notes

### DIFF
--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -208,11 +208,11 @@ Release History
 
 **NetAppFiles**
 
-* `az volumes qouta-rule create`: Add volume quota rule create command (#24956)
-* `az volumes qouta-rule show`: Add volume quota rule show command (#24956)
-* `az volumes qouta-rule list`: Add volume quota rule list command (#24956)
-* `az volumes qouta-rule update`: Add volume quota rule update command (#24956)
-* `az volumes qouta-rule delete`: Add volume quota rule delete command (#24956)
+* `az volumes quota-rule create`: Add volume quota rule create command (#24956)
+* `az volumes quota-rule show`: Add volume quota rule show command (#24956)
+* `az volumes quota-rule list`: Add volume quota rule list command (#24956)
+* `az volumes quota-rule update`: Add volume quota rule update command (#24956)
+* `az volumes quota-rule delete`: Add volume quota rule delete command (#24956)
 
 **Network**
 

--- a/src/azure-cli/HISTORY.rst
+++ b/src/azure-cli/HISTORY.rst
@@ -208,11 +208,11 @@ Release History
 
 **NetAppFiles**
 
-* `az volumes quota-rule create`: Add volume quota rule create command (#24956)
-* `az volumes quota-rule show`: Add volume quota rule show command (#24956)
-* `az volumes quota-rule list`: Add volume quota rule list command (#24956)
-* `az volumes quota-rule update`: Add volume quota rule update command (#24956)
-* `az volumes quota-rule delete`: Add volume quota rule delete command (#24956)
+* `az netappfiles volume quota-rule create`: Add volume quota rule create command (#24956)
+* `az netappfiles volume quota-rule show`: Add volume quota rule show command (#24956)
+* `az netappfiles volume quota-rule list`: Add volume quota rule list command (#24956)
+* `az netappfiles volume quota-rule update`: Add volume quota rule update command (#24956)
+* `az netappfiles volume quota-rule delete`: Add volume quota rule delete command (#24956)
 
 **Network**
 


### PR DESCRIPTION
This PR is in response to Issue #[3517](https://github.com/MicrosoftDocs/azure-docs-cli/issues/3517).  Both the command name and the typo are fixed in this PR.  I'm closing the MicrosoftDocs/azure-docs-cli Issue as a result.