### PR TITLE
{sql} Code fix for sql db show-connection-string

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/custom.py
@@ -798,15 +798,17 @@ def db_show_conn_str(
     formats = {
         ClientType.ado_net.value: {
             ClientAuthenticationType.sql_password.value:
-                'Server=tcp:{server_fqdn},1433;Database={db};User ID=<username>;'
-                'Password=<password>;Encrypt=true;Connection Timeout=30;',
+                'Server=tcp:{server_fqdn},1433;Initial Catalog={db};Persist Security Info=False;'
+                'User ID=<username>;Password=<password>;MultipleActiveResultSets=False;Encrypt=true;'
+                'TrustServerCertificate=False;Connection Timeout=30;',
             ClientAuthenticationType.active_directory_password.value:
-                'Server=tcp:{server_fqdn},1433;Database={db};User ID=<username>;'
-                'Password=<password>;Encrypt=true;Connection Timeout=30;'
-                'Authentication="Active Directory Password"',
+                'Server=tcp:{server_fqdn},1433;Initial Catalog={db};Persist Security Info=False;'
+                'User ID=<username>;Password=<password>;MultipleActiveResultSets=False;Encrypt=true;'
+                'TrustServerCertificate=False;Authentication="Active Directory Password"',
             ClientAuthenticationType.active_directory_integrated.value:
-                'Server=tcp:{server_fqdn},1433;Database={db};Encrypt=true;'
-                'Connection Timeout=30;Authentication="Active Directory Integrated"'
+                'Server=tcp:{server_fqdn},1433;Initial Catalog={db};Persist Security Info=False;'
+                'User ID=<username>;MultipleActiveResultSets=False;Encrypt=true;'
+                'TrustServerCertificate=False;Authentication="Active Directory Integrated"'
         },
         ClientType.sqlcmd.value: {
             ClientAuthenticationType.sql_password.value:

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -3780,19 +3780,19 @@ class SqlServerConnectionStringScenarioTest(ScenarioTest):
         # ADO.NET, username/password
         conn_str = self.cmd('sql db show-connection-string -s myserver -n mydb -c ado.net').get_output_in_json()
         self.assertEqual(conn_str,
-                         'Server=tcp:myserver.database.windows.net,1433;Database=mydb;User ID=<username>;Password=<password>;Encrypt=true;Connection Timeout=30;')
+                         'Server=tcp:myserver.database.windows.net,1433;Initial Catalog=mydb;Persist Security Info=False;User ID=<username>;Password=<password>;MultipleActiveResultSets=False;Encrypt=true;TrustServerCertificate=False;Connection Timeout=30;')
 
         # ADO.NET, ADPassword
         conn_str = self.cmd(
             'sql db show-connection-string -s myserver -n mydb -c ado.net -a ADPassword').get_output_in_json()
         self.assertEqual(conn_str,
-                         'Server=tcp:myserver.database.windows.net,1433;Database=mydb;User ID=<username>;Password=<password>;Encrypt=true;Connection Timeout=30;Authentication="Active Directory Password"')
+                         'Server=tcp:myserver.database.windows.net,1433;Initial Catalog=mydb;Persist Security Info=False;User ID=<username>;Password=<password>;MultipleActiveResultSets=False;Encrypt=true;TrustServerCertificate=False;Authentication="Active Directory Password"')
 
         # ADO.NET, ADIntegrated
         conn_str = self.cmd(
             'sql db show-connection-string -s myserver -n mydb -c ado.net -a ADIntegrated').get_output_in_json()
         self.assertEqual(conn_str,
-                         'Server=tcp:myserver.database.windows.net,1433;Database=mydb;Encrypt=true;Connection Timeout=30;Authentication="Active Directory Integrated"')
+                         'Server=tcp:myserver.database.windows.net,1433;Initial Catalog=mydb;Persist Security Info=False;User ID=<username>;MultipleActiveResultSets=False;Encrypt=true;TrustServerCertificate=False;Authentication="Active Directory Integrated"')
 
         # SqlCmd, username/password
         conn_str = self.cmd('sql db show-connection-string -s myserver -n mydb -c sqlcmd').get_output_in_json()


### PR DESCRIPTION
**Related command**
`az sql db show-connection-string`

**Description**<!--Mandatory-->
Updated code to make ADO connection string identical to Azure Portal when using `sql db show-connection-string` cmdlet.
Fixes [GitHub Issue 25546](https://github.com/Azure/azure-cli/issues/25546)
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
