### PR TITLE
[RDBMS] `az mysql flexible-server update`: Fix `--storage-auto-grow` parameter unable to be set

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_mysql.py
@@ -462,7 +462,7 @@ def flexible_server_update_custom_func(cmd, client, instance,
                                             sku_name=instance.sku.name)
 
     if auto_grow:
-        instance.storage.storage_autogrow = auto_grow
+        instance.storage.auto_grow = auto_grow
 
     params = ServerForUpdate(sku=instance.sku,
                              storage=instance.storage,


### PR DESCRIPTION
**Related command**
 az mysql flexible-server update --storage-auto-grow

**Description**
--storage-auto-grow cannot be set as expected value, due to false instance property name assignment. This PR modify the property name assignment.
