### PR TITLE
{CI} Increase Check CLI Style job timeout to 120 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -507,7 +507,7 @@ jobs:
 - job: TestExtensionsLoading
   displayName: Test Extensions Loading
   condition: succeeded()
-  timeoutInMinutes: 60
+  timeoutInMinutes: 40
 
   pool:
     name: ${{ variables.ubuntu_pool }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -507,7 +507,7 @@ jobs:
 - job: TestExtensionsLoading
   displayName: Test Extensions Loading
   condition: succeeded()
-  timeoutInMinutes: 40
+  timeoutInMinutes: 60
 
   pool:
     name: ${{ variables.ubuntu_pool }}
@@ -933,7 +933,7 @@ jobs:
 
 - job: CheckStyle
   displayName: "Check CLI Style"
-
+  timeoutInMinutes: 120
   pool:
     name: ${{ variables.ubuntu_pool }}
   steps:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
![image](https://user-images.githubusercontent.com/18628534/222321689-1b28bfc5-1709-4852-83a9-90208615950c.png)
If no timeoutInMinutes is set, the default timeout of the ADO task is 60 minutes.
Check CLI Style has recently timed out several times, so increased the timeout to 120 minutes.

But it's not a long-term solution：
We found that after migrating to the new org, the test time increased significantly.
The test machines are all single-core, and no SSD storage is used.
![image](https://user-images.githubusercontent.com/18628534/222325621-e5b01fe9-ef4f-4b09-af34-aeefec843cc9.png)
Running the same tests locally is much faster because tests can be run in parallel.
![image](https://user-images.githubusercontent.com/18628534/222326913-16ce200b-3c2e-4708-8216-ebdbb23cbea3.png)

@YanaXu
- If the billing model is based on the total running time, there will be no additional cost for increasing the number of cores.
- And using SSD ( Solid State Driver ) will also greatly increase the speed of some tests, such as installation tests.