### PR TITLE
{Core} Add instruction to fix incomplete extension

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -306,7 +306,7 @@ def get_extension_modname(ext_name=None, ext_dir=None):
                 if n.startswith(EXTENSIONS_MOD_PREFIX) and os.path.isdir(os.path.join(ext_dir, n))]
     if len(pos_mods) != 1:
         raise AssertionError("Expected 1 module to load starting with '{}': got {}. Please delete {} and "
-                             "install the extension again.".format( EXTENSIONS_MOD_PREFIX, pos_mods, ext_dir))
+                             "install the extension again.".format(EXTENSIONS_MOD_PREFIX, pos_mods, ext_dir))
     return pos_mods[0]
 
 

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -305,6 +305,8 @@ def get_extension_modname(ext_name=None, ext_dir=None):
     pos_mods = [n for n in os.listdir(ext_dir)
                 if n.startswith(EXTENSIONS_MOD_PREFIX) and os.path.isdir(os.path.join(ext_dir, n))]
     if len(pos_mods) != 1:
+        logger.warning("Find incomplete extension in '%s'. Please delete this folder and install the extension again.",
+                       ext_dir)
         raise AssertionError("Expected 1 module to load starting with "
                              "'{}': got {}".format(EXTENSIONS_MOD_PREFIX, pos_mods))
     return pos_mods[0]

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -305,10 +305,8 @@ def get_extension_modname(ext_name=None, ext_dir=None):
     pos_mods = [n for n in os.listdir(ext_dir)
                 if n.startswith(EXTENSIONS_MOD_PREFIX) and os.path.isdir(os.path.join(ext_dir, n))]
     if len(pos_mods) != 1:
-        logger.warning("Find incomplete extension in '%s'. Please delete this folder and install the extension again.",
-                       ext_dir)
-        raise AssertionError("Expected 1 module to load starting with "
-                             "'{}': got {}".format(EXTENSIONS_MOD_PREFIX, pos_mods))
+        raise AssertionError("Expected 1 module to load starting with '{}': got {}. Please delete {} and "
+                             "install the extension again.".format( EXTENSIONS_MOD_PREFIX, pos_mods, ext_dir))
     return pos_mods[0]
 
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
If the extension installation is corrupted, CLI may break because of [AssertionError](https://github.com/azure/azure-cli/blob/ed6e829554624894d5c94ad71bb85e788d726a43/src/azure-cli-core/azure/cli/core/extension/__init__.py#L308). See https://github.com/Azure/azure-cli/issues/25473
It is an extension convention that there must be an azext_xxx folder in extension directory.

Add the instruction to delete extension folder.

**Testing Guide**
<!--Example commands with explanations.-->
`az extension add -n interactive` and delete `~/.azure/cliextensions/interactive/azext_interactive`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
