### PR TITLE
{App Service} `az functionapp create`: Revert PR #25223

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -78,7 +78,6 @@ class ResourceType(Enum):  # pylint: disable=too-few-public-methods
     MGMT_CUSTOMLOCATION = ('azure.mgmt.extendedlocation', 'CustomLocations')
     MGMT_CONTAINERSERVICE = ('azure.mgmt.containerservice', 'ContainerServiceClient')
     MGMT_APPCONFIGURATION = ('azure.mgmt.appconfiguration', 'AppConfigurationManagementClient')
-    MGMT_APPCONTAINERS = ('azure.mgmt.appcontainers', 'ContainerAppsAPIClient')
 
     # the "None" below will stay till a command module fills in the type so "get_mgmt_service_client"
     # can be provided with "ResourceType.XXX" to initialize the client object. This usually happens
@@ -256,7 +255,6 @@ AZURE_API_PROFILES = {
         ResourceType.MGMT_APPCONFIGURATION: SDKProfile('2022-05-01', {
             'replicas': '2022-03-01-preview'
         }),
-        ResourceType.MGMT_APPCONTAINERS: '2022-10-01',
     },
     '2020-09-01-hybrid': {
         ResourceType.MGMT_STORAGE: '2019-06-01',

--- a/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_client_factory.py
@@ -53,12 +53,6 @@ def customlocation_client_factory(cli_ctx, api_version=None, **_):
     return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_CUSTOMLOCATION, api_version=api_version)
 
 
-def appcontainers_client_factory(cli_ctx, api_version=None, **_):
-    from azure.cli.core.profiles import ResourceType
-    from azure.cli.core.commands.client_factory import get_mgmt_service_client
-    return get_mgmt_service_client(cli_ctx, ResourceType.MGMT_APPCONTAINERS, api_version=api_version)
-
-
 def cf_plans(cli_ctx, _):
     return web_client_factory(cli_ctx).app_service_plans
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_constants.py
@@ -94,5 +94,3 @@ WINDOWS_FUNCTIONAPP_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH = {
     'java': 'FunctionApp/windows-java-functionapp-on-azure.yml',
     'powershell': 'FunctionApp/windows-powershell-functionapp-on-azure.yml',
 }
-
-HELLO_WORLD_IMAGE = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -223,13 +223,10 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('webapp webjob triggered list') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
 
-    for scope in ['webapp', 'logicapp']:
+    for scope in ['webapp', 'functionapp', 'logicapp']:
         with self.argument_context(scope + ' create') as c:
             c.argument('deployment_container_image_name', options_list=['--deployment-container-image-name', '-i'],
                        help='Container image name from Docker Hub, e.g. publisher/image-name:tag')
-
-    for scope in ['webapp', 'functionapp', 'logicapp']:
-        with self.argument_context(scope + ' create') as c:
             c.argument('deployment_local_git', action='store_true', options_list=['--deployment-local-git', '-l'],
                        help='enable local git')
             c.argument('deployment_zip', options_list=['--deployment-zip', '-z'],
@@ -359,6 +356,14 @@ subscription than the app service environment, please use the resource ID for --
                        help='Provide site configuration list in a format of either `key=value` pair or `@<json_file>`. PowerShell and Windows Command Prompt users should use a JSON file to provide these configurations to avoid compatibility issues with escape characters.')
 
         with self.argument_context(scope + ' config container') as c:
+            c.argument('docker_registry_server_url', options_list=['--docker-registry-server-url', '-r'],
+                       help='the container registry server url')
+            c.argument('docker_custom_image_name', options_list=['--docker-custom-image-name', '-c', '-i'],
+                       help='the container custom image name and optionally the tag name (e.g., <registry-name>/<image-name>:<tag>)')
+            c.argument('docker_registry_server_user', options_list=['--docker-registry-server-user', '-u'],
+                       help='the container registry server username')
+            c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-p'],
+                       help='the container registry server password')
             c.argument('websites_enable_app_service_storage', options_list=['--enable-app-service-storage', '-t'],
                        help='enables platform storage (custom container only)',
                        arg_type=get_three_state_flag(return_label=True))
@@ -372,26 +377,6 @@ subscription than the app service environment, please use the resource ID for --
         with self.argument_context(scope + ' deployment container config') as c:
             c.argument('enable', options_list=['--enable-cd', '-e'], help='enable/disable continuous deployment',
                        arg_type=get_three_state_flag(return_label=True))
-
-    with self.argument_context('webapp config container') as c:
-        c.argument('docker_registry_server_url', options_list=['--docker-registry-server-url', '-r'],
-                   help='the container registry server url')
-        c.argument('docker_custom_image_name', options_list=['--docker-custom-image-name', '-c', '-i'],
-                   help='the container custom image name and optionally the tag name (e.g., <registry-name>/<image-name>:<tag>)')
-        c.argument('docker_registry_server_user', options_list=['--docker-registry-server-user', '-u'],
-                   help='the container registry server username')
-        c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-p'],
-                   help='the container registry server password')
-
-    with self.argument_context('functionapp config container') as c:
-        c.argument('registry_server', options_list=['--registry-server', '-r', c.deprecate(target='--docker-registry-server-url', redirect='--registry-server')],
-                   help='the container registry server url')
-        c.argument('image', options_list=['--image', '-c', '-i', c.deprecate(target='--docker-custom-image-name', redirect='--image')],
-                   help='the container custom image name and optionally the tag name (e.g., <registry-name>/<image-name>:<tag>)')
-        c.argument('registry_username', options_list=['--registry-username', '-u', c.deprecate(target='--docker-registry-server-user', redirect='--registry-username')],
-                   help='the container registry server username')
-        c.argument('registry_password', options_list=['--registry-password', '-p', c.deprecate(target='--docker-registry-server-password', redirect='--registry-password')],
-                   help='the container registry server password')
 
     with self.argument_context('webapp config connection-string list') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
@@ -722,12 +707,6 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('functionapp create') as c:
         c.argument('vnet', options_list=['--vnet'], help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
         c.argument('subnet', options_list=['--subnet'], help="Name or resource ID of the pre-existing subnet to have the webapp join. The --vnet is argument also needed if specifying subnet by name.")
-        c.argument('environment', help="Name of the container app environment.", is_preview=True)
-        c.argument('image', options_list=['--image', '-i', c.deprecate(target='--deployment-container-image-name', redirect='--image')],
-                   help='Container image, e.g. publisher/image-name:tag')
-        c.argument('registry_username', options_list=['--registry-username', '-d', c.deprecate(target='--docker-registry-server-user', redirect='--registry-username')], help='The container registry server username.')
-        c.argument('registry_password', options_list=['--registry-password', '-w', c.deprecate(target='--docker-registry-server-password', redirect='--registry-password')],
-                   help='The container registry server password. Required for private registries.')
 
     with self.argument_context('functionapp cors credentials') as c:
         c.argument('enable', help='enable/disable access-control-allow-credentials', arg_type=get_three_state_flag())
@@ -769,6 +748,9 @@ subscription than the app service environment, please use the resource ID for --
                        "same resource group.")
             c.argument('disable_app_insights', arg_type=get_three_state_flag(return_label=True),
                        help="Disable creating application insights resource during {} create. No logs will be available.".format(scope))
+            c.argument('docker_registry_server_user', options_list=['--docker-registry-server-user', '-d'], help='The container registry server username.')
+            c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-w'],
+                       help='The container registry server password. Required for private registries.')
             if scope == 'functionapp':
                 c.argument('functions_version', help='The functions app version. NOTE: This will be required starting the next release cycle', arg_type=get_enum_type(FUNCTIONS_VERSIONS))
                 c.argument('runtime', help='The functions runtime stack. Use "az functionapp list-runtimes" to check supported runtimes and versions')
@@ -790,11 +772,6 @@ subscription than the app service environment, please use the resource ID for --
 
     with self.argument_context('logicapp') as c:
         c.argument('name', arg_type=logicapp_name_arg_type)
-
-    with self.argument_context('logicapp create') as c:
-        c.argument('docker_registry_server_user', options_list=['--docker-registry-server-user', '-d'], help='The container registry server username.')
-        c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-w'],
-                   help='The container registry server password. Required for private registries.')
 
     with self.argument_context('logicapp show') as c:
         c.argument('name', arg_type=logicapp_name_arg_type)
@@ -884,11 +861,11 @@ subscription than the app service environment, please use the resource ID for --
     with self.argument_context('functionapp deployment slot create') as c:
         c.argument('configuration_source',
                    help="source slot to clone configurations from. Use function app's name to refer to the production slot")
-        c.argument('image', options_list=['--image', '-i', c.deprecate(target='--deployment-container-image-name', redirect='--image')],
-                   help='Container image, e.g. publisher/image-name:tag')
-        c.argument('registry_password', options_list=['--registry-password', '-d', c.deprecate(target='--docker-registry-server-password', redirect='--registry-password')],
+        c.argument('deployment_container_image_name', options_list=['--deployment-container-image-name', '-i'],
+                   help='Container image name, e.g. publisher/image-name:tag')
+        c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-d'],
                    help='The container registry server password')
-        c.argument('registry_username', options_list=['--registry-username', '-u', c.deprecate(target='--docker-registry-server-user', redirect='--registry-username')], help='the container registry server username')
+        c.argument('docker_registry_server_user', options_list=['--docker-registry-server-user', '-u'], help='the container registry server username')
     with self.argument_context('functionapp deployment slot swap') as c:
         c.argument('action',
                    help="swap types. use 'preview' to apply target slot's settings on the source slot first; use 'swap' to complete it; use 'reset' to reset the swap",

--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -181,14 +181,6 @@ def validate_add_vnet(cmd, namespace):
                               "Cannot integrate a regional VNET to an app in a different region")
 
 
-def validate_same_location(cmd, first_location, second_location, error_message):
-    normalized_first_location = _normalize_location(cmd, first_location)
-    normalized_second_location = _normalize_location(cmd, second_location)
-
-    if normalized_first_location != normalized_second_location:
-        raise ValidationError(error_message or 'The resources are in different locations.')
-
-
 def validate_front_end_scale_factor(namespace):
     if namespace.front_end_scale_factor:
         min_scale_factor = 5

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -54,8 +54,7 @@ from azure.cli.core.azclierror import (InvalidArgumentValueError, MutuallyExclus
 from .tunnel import TunnelServer
 
 from ._params import AUTH_TYPES, MULTI_CONTAINER_TYPES
-from ._client_factory import (web_client_factory, ex_handler_factory, providers_client_factory,
-                              appcontainers_client_factory)
+from ._client_factory import web_client_factory, ex_handler_factory, providers_client_factory
 from ._appservice_utils import _generic_site_operation, _generic_settings_operation
 from .utils import (_normalize_sku,
                     get_sku_tier,
@@ -79,9 +78,9 @@ from ._constants import (FUNCTIONS_STACKS_API_KEYS, FUNCTIONS_LINUX_RUNTIME_VERS
                          LINUX_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH, WINDOWS_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH,
                          DOTNET_RUNTIME_NAME, NETCORE_RUNTIME_NAME, ASPDOTNET_RUNTIME_NAME, LINUX_OS_NAME,
                          WINDOWS_OS_NAME, LINUX_FUNCTIONAPP_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH,
-                         WINDOWS_FUNCTIONAPP_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH, HELLO_WORLD_IMAGE)
+                         WINDOWS_FUNCTIONAPP_GITHUB_ACTIONS_WORKFLOW_TEMPLATE_PATH)
 from ._github_oauth import (get_github_access_token, cache_github_token)
-from ._validators import validate_and_convert_to_int, validate_range_of_int_flag, validate_same_location
+from ._validators import validate_and_convert_to_int, validate_range_of_int_flag
 
 logger = get_logger(__name__)
 
@@ -355,16 +354,6 @@ def _get_subnet_info(cmd, resource_group_name, vnet, subnet):
     subnet_info["subnet_resource_id"] = subnet_rid
     subnet_info["subnet_subscription_id"] = subscription_id
     return subnet_info
-
-
-def get_managed_environment(cmd, resource_group_name, environment_name):
-    try:
-        appcontainers_client = appcontainers_client_factory(cmd.cli_ctx)
-        return appcontainers_client.managed_environments.get(resource_group_name, environment_name)
-    except Exception as ex:  # pylint: disable=broad-except
-        error_message = "Retrieving managed environment failed with an exception: {}".format(ex)
-        recommendation_message = "Please verify the managed environment is valid"
-        raise ResourceNotFoundError(error_message, recommendation_message)
 
 
 def validate_container_app_create_options(runtime=None, deployment_container_image_name=None,
@@ -1610,12 +1599,12 @@ def update_container_settings(cmd, resource_group_name, name, docker_registry_se
                                                                           slot=slot))
 
 
-def update_container_settings_functionapp(cmd, resource_group_name, name, registry_server=None,
-                                          image=None, registry_username=None,
-                                          registry_password=None, slot=None):
-    return update_container_settings(cmd, resource_group_name, name, registry_server,
-                                     image, registry_username, None,
-                                     registry_password, multicontainer_config_type=None,
+def update_container_settings_functionapp(cmd, resource_group_name, name, docker_registry_server_url=None,
+                                          docker_custom_image_name=None, docker_registry_server_user=None,
+                                          docker_registry_server_password=None, slot=None):
+    return update_container_settings(cmd, resource_group_name, name, docker_registry_server_url,
+                                     docker_custom_image_name, docker_registry_server_user, None,
+                                     docker_registry_server_password, multicontainer_config_type=None,
                                      multicontainer_config_file=None, slot=slot)
 
 
@@ -1789,14 +1778,15 @@ def create_webapp_slot(cmd, resource_group_name, webapp, slot, configuration_sou
 
 
 def create_functionapp_slot(cmd, resource_group_name, name, slot, configuration_source=None,
-                            image=None, registry_password=None,
-                            registry_username=None):
-    container_args = image or registry_password or registry_username
+                            deployment_container_image_name=None, docker_registry_server_password=None,
+                            docker_registry_server_user=None):
+    container_args = deployment_container_image_name or docker_registry_server_password or docker_registry_server_user
     if container_args and not configuration_source:
-        raise ArgumentUsageError("Cannot use image, password and username arguments without "
-                                 "--configuration-source argument")
+        raise ArgumentUsageError("Cannot use arguments --deployment-container-image_name, "
+                                 "--docker-registry-server_password, or --docker-registry-server-user without argument "
+                                 "--configuration-source")
 
-    docker_registry_server_url = parse_docker_image_name(image)
+    docker_registry_server_url = parse_docker_image_name(deployment_container_image_name)
 
     Site = cmd.get_models('Site')
     client = web_client_factory(cmd.cli_ctx)
@@ -1811,8 +1801,8 @@ def create_functionapp_slot(cmd, resource_group_name, name, slot, configuration_
 
     if configuration_source:
         update_slot_configuration_from_source(cmd, client, resource_group_name, name, slot, configuration_source,
-                                              image, registry_password,
-                                              registry_username,
+                                              deployment_container_image_name, docker_registry_server_password,
+                                              docker_registry_server_user,
                                               docker_registry_server_url=docker_registry_server_url)
 
     result.name = result.name.split('/')[-1]
@@ -3516,9 +3506,9 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                        consumption_plan_location=None, app_insights=None, app_insights_key=None,
                        disable_app_insights=None, deployment_source_url=None,
                        deployment_source_branch='master', deployment_local_git=None,
-                       registry_password=None, registry_username=None,
-                       image=None, tags=None, assign_identities=None,
-                       role='Contributor', scope=None, vnet=None, subnet=None, https_only=False, environment=None):
+                       docker_registry_server_password=None, docker_registry_server_user=None,
+                       deployment_container_image_name=None, tags=None, assign_identities=None,
+                       role='Contributor', scope=None, vnet=None, subnet=None, https_only=False):
     # pylint: disable=too-many-statements, too-many-branches
     if functions_version is None:
         logger.warning("No functions version specified so defaulting to 3. In the future, specifying a version will "
@@ -3531,7 +3521,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
                                              "--plan NAME_OR_ID | --consumption-plan-location LOCATION")
     from azure.mgmt.web.models import Site
     SiteConfig, NameValuePair = cmd.get_models('SiteConfig', 'NameValuePair')
-    docker_registry_server_url = parse_docker_image_name(image)
+    docker_registry_server_url = parse_docker_image_name(deployment_container_image_name)
     disable_app_insights = (disable_app_insights == "true")
 
     site_config = SiteConfig(app_settings=[])
@@ -3601,33 +3591,12 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         raise ValidationError("2.x functions are not supported in this region. To create a 3.x function, "
                               "pass in the flag '--functions-version 3'")
 
-    if is_linux and not runtime and (consumption_plan_location or not image):
+    if is_linux and not runtime and (consumption_plan_location or not deployment_container_image_name):
         raise ArgumentUsageError(
             "usage error: --runtime RUNTIME required for linux functions apps without custom image.")
 
     if runtime is None and runtime_version is not None:
         raise ArgumentUsageError('Must specify --runtime to use --runtime-version')
-
-    # TODO use managed-environment field on ASP model when we the latest SDK is avaliable.
-    if environment is not None:
-        if consumption_plan_location is not None:
-            raise ArgumentUsageError(
-                'The --consumption-plan-location argument is not relevant for managed environment deployments')
-
-        managed_environment = get_managed_environment(cmd, resource_group_name, environment)
-
-        validate_same_location(cmd,
-                               managed_environment.location,
-                               functionapp_def.location,
-                               'The plan location must match the managed environment location')
-
-        functionapp_def.enable_additional_properties_sending()
-        existing_properties = functionapp_def.serialize()["properties"]
-        functionapp_def.additional_properties["properties"] = existing_properties
-        functionapp_def.additional_properties["properties"]["managedEnvironment"] = managed_environment.id
-
-        if image is None:
-            image = HELLO_WORLD_IMAGE
 
     runtime_helper = _FunctionAppStackRuntimeHelper(cmd, linux=is_linux, windows=(not is_linux))
     matched_runtime = runtime_helper.resolve("dotnet" if not runtime else runtime,
@@ -3645,14 +3614,14 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         if not is_consumption:
             site_config.app_settings.append(NameValuePair(name='MACHINEKEY_DecryptionKey',
                                                           value=str(hexlify(urandom(32)).decode()).upper()))
-            if image:
+            if deployment_container_image_name:
                 functionapp_def.kind = 'functionapp,linux,container'
                 site_config.app_settings.append(NameValuePair(name='DOCKER_CUSTOM_IMAGE_NAME',
-                                                              value=image))
+                                                              value=deployment_container_image_name))
                 site_config.app_settings.append(NameValuePair(name='FUNCTION_APP_EDIT_MODE', value='readOnly'))
                 site_config.app_settings.append(NameValuePair(name='WEBSITES_ENABLE_APP_SERVICE_STORAGE',
                                                               value='false'))
-                site_config.linux_fx_version = _format_fx_version(image)
+                site_config.linux_fx_version = _format_fx_version(deployment_container_image_name)
 
                 # clear all runtime specific configs and settings
                 site_config_dict.use32_bit_worker_process = False
@@ -3728,10 +3697,10 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
             update_app_settings(cmd, functionapp.resource_group, functionapp.name,
                                 ['AzureWebJobsDashboard={}'.format(con_string)])
 
-    if image:
+    if deployment_container_image_name:
         update_container_settings_functionapp(cmd, resource_group_name, name, docker_registry_server_url,
-                                              image, registry_username,
-                                              registry_password)
+                                              deployment_container_image_name, docker_registry_server_user,
+                                              docker_registry_server_password)
 
     if assign_identities is not None:
         identity = assign_identity(cmd, resource_group_name, name, assign_identities,

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -15,7 +15,7 @@ from azure.cli.testsdk.scenario_tests import AllowLargeResponse, record_only
 from azure.cli.testsdk import (ScenarioTest, LocalContextScenarioTest, LiveScenarioTest, ResourceGroupPreparer,
                                StorageAccountPreparer, JMESPathCheck, live_only)
 from azure.cli.testsdk.checkers import JMESPathCheckNotExists, JMESPathPatternCheck
-from azure.cli.core.azclierror import ResourceNotFoundError, ValidationError, ArgumentUsageError
+from azure.cli.core.azclierror import ResourceNotFoundError
 
 TEST_DIR = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
 
@@ -508,79 +508,6 @@ class FunctionAppWithLinuxConsumptionPlanTest(ScenarioTest):
         self.cmd('functionapp config show -g {} -n {}'.format(resource_group, functionapp_name), checks=[
             JMESPathCheck('linuxFxVersion', 'PowerShell|7.2')])
 
-class FunctionAppManagedEnvironment(LiveScenarioTest):
-    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
-    @StorageAccountPreparer()
-    def test_functionapp_create_with_appcontainer_managed_environment(self, resource_group, storage_account):
-        functionapp_name = self.create_random_name(
-            'functionappwindowsruntime', 40)
-        managed_environment_name = self.create_random_name(
-            'containerappmanagedenvironment', 40
-        )
-        plan_name = self.create_random_name(
-            'functionappplan', 40
-        )
-
-        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
-        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
-                     JMESPathCheck('name', managed_environment_name),
-                     JMESPathCheck('resourceGroup', resource_group),
-                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
-
-        self.cmd('functionapp plan create -g {} -n {} --sku S1 --is-linux --location {}'.format(resource_group, plan_name, WINDOWS_ASP_LOCATION_FUNCTIONAPP))
-
-        self.cmd('functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-                 .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name)).assert_with_checks([
-                     JMESPathCheck('state', 'Running'),
-                     JMESPathCheck('name', functionapp_name),
-                     JMESPathCheck('kind', 'functionapp,linux'),
-                     JMESPathCheck('hostNames[0]', functionapp_name + '.azurewebsites.net')])
-
-        self.cmd('functionapp config show -g {} -n {}'.format(resource_group, functionapp_name), checks=[
-            JMESPathCheck('linuxFxVersion', 'DOCKER|mcr.microsoft.com/azuredocs/containerapps-helloworld:latest')])
-
-    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
-    @StorageAccountPreparer()
-    def test_functionapp_create_with_appcontainer_managed_environment_location_mismatch_error(self, resource_group, storage_account):
-        functionapp_name = self.create_random_name(
-            'functionappwindowsruntime', 40)
-        managed_environment_name = self.create_random_name(
-            'containerappmanagedenvironment', 40
-        )
-        plan_name = self.create_random_name(
-            'functionappplan', 40
-        )
-
-        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
-        .format(managed_environment_name, resource_group, LINUX_ASP_LOCATION_WEBAPP)).assert_with_checks([
-                     JMESPathCheck('name', managed_environment_name),
-                     JMESPathCheck('resourceGroup', resource_group),
-                     JMESPathCheck('location', LINUX_ASP_LOCATION_WEBAPP)])
-
-        self.cmd('functionapp plan create -g {} -n {} --sku S1 --is-linux --location {}'.format(resource_group, plan_name, WINDOWS_ASP_LOCATION_FUNCTIONAPP))
-
-        with self.assertRaises(ValidationError):
-            self.cmd('functionapp create -g {} -n {} -p {} -s {} --environment {} --runtime dotnet --functions-version 4'
-                    .format(resource_group, functionapp_name, plan_name, storage_account, managed_environment_name))
-
-    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
-    @StorageAccountPreparer()
-    def test_functionapp_create_with_appcontainer_managed_environment_consumption_plan_error(self, resource_group, storage_account):
-        functionapp_name = self.create_random_name(
-            'functionappwindowsruntime', 40)
-        managed_environment_name = self.create_random_name(
-            'containerappmanagedenvironment', 40
-        )
-
-        self.cmd('containerapp env create --name {} --resource-group {} --location {}'
-        .format(managed_environment_name, resource_group, WINDOWS_ASP_LOCATION_FUNCTIONAPP)).assert_with_checks([
-                     JMESPathCheck('name', managed_environment_name),
-                     JMESPathCheck('resourceGroup', resource_group),
-                     JMESPathCheck('location', WINDOWS_ASP_LOCATION_FUNCTIONAPP)])
-
-        with self.assertRaises(ArgumentUsageError):
-            self.cmd('functionapp create -g {} -n {} -c {} -s {} --environment {} --runtime dotnet --functions-version 4'
-                    .format(resource_group, functionapp_name, WINDOWS_ASP_LOCATION_FUNCTIONAPP, storage_account, managed_environment_name))
 
 class FunctionAppOnWindowsWithRuntime(ScenarioTest):
     @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -20,7 +20,6 @@ azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-appconfiguration==2.2.0
-azure-mgmt-appcontainers==1.0.0
 azure-mgmt-applicationinsights==1.0.0
 azure-mgmt-authorization==3.0.0
 azure-mgmt-batch==17.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -20,7 +20,6 @@ azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-appconfiguration==2.2.0
-azure-mgmt-appcontainers==1.0.0
 azure-mgmt-applicationinsights==1.0.0
 azure-mgmt-authorization==3.0.0
 azure-mgmt-batch==17.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -20,7 +20,6 @@ azure-loganalytics==0.1.0
 azure-mgmt-advisor==9.0.0
 azure-mgmt-apimanagement==3.0.0
 azure-mgmt-appconfiguration==2.2.0
-azure-mgmt-appcontainers==1.0.0
 azure-mgmt-applicationinsights==1.0.0
 azure-mgmt-authorization==3.0.0
 azure-mgmt-batch==17.0.0


### PR DESCRIPTION
…nvironment` to support setting the name of container app environment (#25223)

This reverts commit f156109256a6449cf0ac33d3f8a7af7a19b270f0. We are reverting this commit since we intend to have these changes live in the next release, not this one.

**Related command**
az functionapp create

**Description**<!--Mandatory-->
As part of the Centauri effort, we need to add the `--environment` parameter to the `az functionapp create` command so that customers can pass the managed AKS environment where the function app will be deployed.

**Testing Guide**
1. Create an App Service plan (`az functionapp plan create -g <resource-group-name> -n <plan-name> --sku S1`)
2. Create an managed AKS environment(`az containerapp env create -n <managed-environment-name> -g <resource-group-name>`)
3. Create a function app in the managed AKS environment (`az functionapp create -g <resource-group-name> -n <function-app-name> --plan <plan-name> -s <storage-account-name> --environment <managed-environment-name>`)

**History Notes**

[App Service] `az functionapp create`: Add new parameter `--environment` to support setting the name of container app environment

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
