### PR TITLE
[Log Analytics] Fix #25660: az monitor log-analytics workspace table update --total-retention-time fix upper validation.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/log_analytics/workspace/table/_update.py
+++ b/src/azure-cli/azure/cli/command_modules/monitor/aaz/latest/monitor/log_analytics/workspace/table/_update.py
@@ -101,7 +101,7 @@ class Update(AAZCommand):
             arg_group="Properties",
             help="The table total retention in days, between 4 and 2555.",
             fmt=AAZIntArgFormat(
-                maximum=2555,
+                maximum=2556,
                 minimum=4,
             ),
         )


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

 az monitor log-analytics workspace table update --name {TABLE} --retention-time 730 --total-retention-time 2556 --resource-group {RESOURCEGROUP} --workspace-name {WORKSPACE}

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Previously command would fail with total retention time of `2556` as it was only allowing a value of up to 2555. The ARM API only accepts [4-730], 1095, 1460, 1826, 2191, 2556  

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
