### PR TITLE
{Core} Add random_config_dir param in DummyCli

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -44,11 +44,9 @@ class Session(MutableMapping):
             if isinstance(load_exception, json.JSONDecodeError):
                 log_level = logging.WARNING
 
-            # DummyCLI uses random config folder, it will always use default settings. This avoids unnecessary warning.
-            if 'PYTEST_CURRENT_TEST' not in os.environ:
-                get_logger(__name__).log(log_level,
-                                         "Failed to load or parse file %s. It will be overridden by default settings.",
-                                         self.filename)
+            get_logger(__name__).log(log_level,
+                                     "Failed to load or parse file %s. It will be overridden by default settings.",
+                                     self.filename)
             self.save()
 
     def save(self):

--- a/src/azure-cli-core/azure/cli/core/_session.py
+++ b/src/azure-cli-core/azure/cli/core/_session.py
@@ -44,9 +44,11 @@ class Session(MutableMapping):
             if isinstance(load_exception, json.JSONDecodeError):
                 log_level = logging.WARNING
 
-            get_logger(__name__).log(log_level,
-                                     "Failed to load or parse file %s. It will be overridden by default settings.",
-                                     self.filename)
+            # DummyCLI uses random config folder, it will always use default settings. This avoids unnecessary warning.
+            if 'PYTEST_CURRENT_TEST' not in os.environ:
+                get_logger(__name__).log(log_level,
+                                         "Failed to load or parse file %s. It will be overridden by default settings.",
+                                         self.filename)
             self.save()
 
     def save(self):

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -25,7 +25,7 @@ class DummyCli(AzCli):
 
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=os.path.join(GLOBAL_CONFIG_DIR, random_string()),
+            config_dir=os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir', random_string()),
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -8,27 +8,24 @@ from azure.cli.core import AzCli
 
 class DummyCli(AzCli):
     """A dummy CLI instance can be used to facilitate automation"""
-    def __init__(self, commands_loader_cls=None, **kwargs):
+    def __init__(self, commands_loader_cls=None, random_config_dir=False, **kwargs):
         import os
+        import tempfile
 
         from azure.cli.core import MainCommandsLoader
         from azure.cli.core.commands import AzCliCommandInvoker
         from azure.cli.core.azlogging import AzCliLogging
         from azure.cli.core.cloud import get_active_cloud
         from azure.cli.core.parser import AzCliCommandParser
-        from azure.cli.core.util import random_string
         from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
         from azure.cli.core._help import AzCliHelp
         from azure.cli.core._output import AzOutputProducer
 
         from knack.completion import ARGCOMPLETE_ENV_NAME
 
-        random_config_dir = kwargs.get('random_config_dir', False)
-
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir',
-                                    random_string()) if random_config_dir else GLOBAL_CONFIG_DIR,
+            config_dir=tempfile.TemporaryDirectory().name if random_config_dir else GLOBAL_CONFIG_DIR,
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -16,6 +16,7 @@ class DummyCli(AzCli):
         from azure.cli.core.azlogging import AzCliLogging
         from azure.cli.core.cloud import get_active_cloud
         from azure.cli.core.parser import AzCliCommandParser
+        from azure.cli.core.util import random_string
         from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
         from azure.cli.core._help import AzCliHelp
         from azure.cli.core._output import AzOutputProducer
@@ -24,7 +25,7 @@ class DummyCli(AzCli):
 
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=GLOBAL_CONFIG_DIR,
+            config_dir=GLOBAL_CONFIG_DIR + random_string(),
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -25,7 +25,7 @@ class DummyCli(AzCli):
 
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=GLOBAL_CONFIG_DIR + random_string(),
+            config_dir=os.path.join(GLOBAL_CONFIG_DIR, random_string()),
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -10,13 +10,13 @@ class DummyCli(AzCli):
     """A dummy CLI instance can be used to facilitate automation"""
     def __init__(self, commands_loader_cls=None, random_config_dir=False, **kwargs):
         import os
-        import tempfile
 
         from azure.cli.core import MainCommandsLoader
         from azure.cli.core.commands import AzCliCommandInvoker
         from azure.cli.core.azlogging import AzCliLogging
         from azure.cli.core.cloud import get_active_cloud
         from azure.cli.core.parser import AzCliCommandParser
+        from azure.cli.core.util import random_string
         from azure.cli.core._config import GLOBAL_CONFIG_DIR, ENV_VAR_PREFIX
         from azure.cli.core._help import AzCliHelp
         from azure.cli.core._output import AzOutputProducer
@@ -25,7 +25,8 @@ class DummyCli(AzCli):
 
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=tempfile.TemporaryDirectory().name if random_config_dir else GLOBAL_CONFIG_DIR,
+            config_dir=os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir',
+                                    random_string()) if random_config_dir else GLOBAL_CONFIG_DIR,
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-core/azure/cli/core/mock.py
+++ b/src/azure-cli-core/azure/cli/core/mock.py
@@ -23,9 +23,12 @@ class DummyCli(AzCli):
 
         from knack.completion import ARGCOMPLETE_ENV_NAME
 
+        random_config_dir = kwargs.get('random_config_dir', False)
+
         super(DummyCli, self).__init__(
             cli_name='az',
-            config_dir=os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir', random_string()),
+            config_dir=os.path.join(GLOBAL_CONFIG_DIR, 'dummy_cli_config_dir',
+                                    random_string()) if random_config_dir else GLOBAL_CONFIG_DIR,
             config_env_var_prefix=ENV_VAR_PREFIX,
             commands_loader_cls=commands_loader_cls or MainCommandsLoader,
             parser_cls=AzCliCommandParser,

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -140,8 +140,8 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
         for processor in self._processors_to_reset:
             processor.reset()
         if self.random_config_dir:
-            import shutil
-            shutil.rmtree(self.cli_ctx.config.config_dir, ignore_errors=True)
+            from azure.cli.core.util import rmtree_with_retry
+            rmtree_with_retry(self.cli_ctx.config.config_dir)
         super(ScenarioTest, self).tearDown()
 
     def create_random_name(self, prefix, length):

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -81,8 +81,10 @@ class CheckerMixin(object):
 
 class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
     def __init__(self, method_name, config_file=None, recording_name=None,
-                 recording_processors=None, replay_processors=None, recording_patches=None, replay_patches=None):
-        self.cli_ctx = get_dummy_cli()
+                 recording_processors=None, replay_processors=None, recording_patches=None, replay_patches=None,
+                 random_config_dir=False):
+        self.cli_ctx = get_dummy_cli(random_config_dir=random_config_dir)
+        self.random_config_dir = random_config_dir
         self.name_replacer = GeneralNameReplacer()
         self.kwargs = {}
         self.test_guid_count = 0
@@ -137,6 +139,9 @@ class ScenarioTest(ReplayableTest, CheckerMixin, unittest.TestCase):
     def tearDown(self):
         for processor in self._processors_to_reset:
             processor.reset()
+        if self.random_config_dir:
+            import shutil
+            shutil.rmtree(self.cli_ctx.config.config_dir, ignore_errors=True)
         super(ScenarioTest, self).tearDown()
 
     def create_random_name(self, prefix, length):
@@ -181,7 +186,8 @@ class LocalContextScenarioTest(ScenarioTest):
     def __init__(self, method_name, config_file=None, recording_name=None, recording_processors=None,
                  replay_processors=None, recording_patches=None, replay_patches=None, working_dir=None):
         super(LocalContextScenarioTest, self).__init__(method_name, config_file, recording_name, recording_processors,
-                                                       replay_processors, recording_patches, replay_patches)
+                                                       replay_processors, recording_patches, replay_patches,
+                                                       random_config_dir=True)
         if self.in_recording:
             self.recording_patches.append(patch_get_current_system_username)
         else:

--- a/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
+++ b/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
@@ -13,6 +13,9 @@ from knack.util import CLIError
 
 class ConfigTest(ScenarioTest):
 
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
     def test_config(self):
 
         # [test_section1]

--- a/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
+++ b/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
@@ -50,21 +50,30 @@ class ConfigTest(ScenarioTest):
             # 2. get
             # 2.1 Test get all sections
             output = self.cmd('config get' + args['flag']).get_output_in_json()
+            # 'source' is config dir path, remove it from data as it's random.
+            output['test_section1'][0].pop('source')
+            output['test_section2'][0].pop('source')
+            output['test_section2'][1].pop('source')
             self.assertListEqual(output['test_section1'], test_section1_expected)
             self.assertListEqual(output['test_section2'], test_section2_expected)
 
             # 2.2 Test get one section
             output = self.cmd('config get test_section1' + args['flag']).get_output_in_json()
-            self.assertListEqual(output, test_section1_expected)
+            output[0].pop('source')
             output = self.cmd('config get test_section2' + args['flag']).get_output_in_json()
+            output[0].pop('source')
+            output[1].pop('source')
             self.assertListEqual(output, test_section2_expected)
 
             # 2.3 Test get one item
             output = self.cmd('config get test_section1.test_option1' + args['flag']).get_output_in_json()
+            output.pop('source')
             self.assertDictEqual(output, test_option1_expected)
             output = self.cmd('config get test_section2.test_option21' + args['flag']).get_output_in_json()
+            output.pop('source')
             self.assertDictEqual(output, test_option21_expected)
             output = self.cmd('config get test_section2.test_option22' + args['flag']).get_output_in_json()
+            output.pop('source')
             self.assertDictEqual(output, test_option22_expected)
 
             with self.assertRaises(CLIError):

--- a/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
+++ b/src/azure-cli/azure/cli/command_modules/config/tests/latest/test_config.py
@@ -34,9 +34,9 @@ class ConfigTest(ScenarioTest):
         for args in (global_test_args, local_test_args):
             print("Testing for {}".format(args))
 
-            test_option1_expected = {'name': 'test_option1', 'source': args["source"], 'value': 'test_value1'}
-            test_option21_expected = {'name': 'test_option21', 'source': args["source"], 'value': 'test_value21'}
-            test_option22_expected = {'name': 'test_option22', 'source': args["source"], 'value': 'test_value22'}
+            test_option1_expected = {'name': 'test_option1', 'value': 'test_value1'}
+            test_option21_expected = {'name': 'test_option21', 'value': 'test_value21'}
+            test_option22_expected = {'name': 'test_option22', 'value': 'test_value22'}
 
             test_section1_expected = [test_option1_expected]
             test_section2_expected = [test_option21_expected, test_option22_expected]

--- a/src/azure-cli/azure/cli/command_modules/configure/tests/latest/test_configure.py
+++ b/src/azure-cli/azure/cli/command_modules/configure/tests/latest/test_configure.py
@@ -26,6 +26,9 @@ class TestConfigure(unittest.TestCase):
 
 class ConfigureGlobalDefaultsTest(ScenarioTest):
 
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
     def setUp(self):
         self.local_dir = tempfile.mkdtemp()
 

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -326,6 +326,9 @@ class ResourceCreateAndShowScenarioTest(ScenarioTest):
 
 class TagScenarioTest(ScenarioTest):
 
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
     def test_tag_scenario(self):
 
         self.kwargs.update({

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -567,8 +567,8 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
                 local_defaults_config = self.cmd('configure --list-defaults --scope local').get_output_in_json()
 
                 self.assertGreaterEqual(len(local_defaults_config), 1)
-                actual = set([(x['name'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
-                expected = set([('group', self.kwargs['rg'])])
+                actual = set([(x['name'], x['source'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
+                expected = set([('group', os.path.join(self.cli_ctx.config.config_dir, 'config'), self.kwargs['rg'])])
                 self.assertEqual(actual, expected)
 
                 # test role assignments on a resource group

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -255,6 +255,9 @@ class RoleDefinitionScenarioTest(RoleScenarioTestBase):
 
 class RoleAssignmentScenarioTest(RoleScenarioTestBase):
 
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
     @ResourceGroupPreparer(name_prefix='cli_role_assign')
     @AllowLargeResponse()
     def test_role_assignment_scenario(self, resource_group):

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -571,6 +571,8 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
 
                 self.assertGreaterEqual(len(local_defaults_config), 1)
                 actual = set([(x['name'], x['source'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
+                # If global config_dir is ~/.azure/dummy_cli_config_dir/0azXbKR9OdJuZPFS/config,
+                # local config file is  ./0azXbKR9OdJuZPFS/config
                 expected = set([('group', os.path.join(temp_dir, os.path.basename(self.cli_ctx.config.config_dir), 'config'), self.kwargs['rg'])])
                 self.assertEqual(actual, expected)
 

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -571,7 +571,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
 
                 self.assertGreaterEqual(len(local_defaults_config), 1)
                 actual = set([(x['name'], x['source'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
-                # If global config_dir is ~/.azure/dummy_cli_config_dir/0azXbKR9OdJuZPFS/config,
+                # If global config_dir is ~/.azure/dummy_cli_config_dir/0azXbKR9OdJuZPFS/,
                 # local config file is  ./0azXbKR9OdJuZPFS/config
                 expected = set([('group', os.path.join(temp_dir, os.path.basename(self.cli_ctx.config.config_dir), 'config'), self.kwargs['rg'])])
                 self.assertEqual(actual, expected)

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -568,7 +568,7 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
 
                 self.assertGreaterEqual(len(local_defaults_config), 1)
                 actual = set([(x['name'], x['source'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
-                expected = set([('group', os.path.join(self.cli_ctx.config.config_dir, 'config'), self.kwargs['rg'])])
+                expected = set([('group', os.path.join(temp_dir, os.path.basename(self.cli_ctx.config.config_dir), 'config'), self.kwargs['rg'])])
                 self.assertEqual(actual, expected)
 
                 # test role assignments on a resource group

--- a/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
+++ b/src/azure-cli/azure/cli/command_modules/role/tests/latest/test_role.py
@@ -567,8 +567,8 @@ class RoleAssignmentScenarioTest(RoleScenarioTestBase):
                 local_defaults_config = self.cmd('configure --list-defaults --scope local').get_output_in_json()
 
                 self.assertGreaterEqual(len(local_defaults_config), 1)
-                actual = set([(x['name'], x['source'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
-                expected = set([('group', os.path.join(temp_dir, '.azure', 'config'), self.kwargs['rg'])])
+                actual = set([(x['name'], x['value']) for x in local_defaults_config if x['name'] == 'group'])
+                expected = set([('group', self.kwargs['rg'])])
                 self.assertEqual(actual, expected)
 
                 # test role assignments on a resource group


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
ARM64 machines are multi-core, and some errors occur because of concurrency, as all tests use same config dir.

I add a `random_config_dir` param in `DummyCli`. If it is True, the config dir will be `~/.azure/dummy_cli_config_dir/xxxxxxx`.

If random config is enabled by default, the config file is created for each test, and the performance decrease a lot.
`Azure.azure-cli Full Test` spends 24 min instead of 16min.

I enable `random_config_dir` for the tests which use `az config` or `az configure`.
Example usage:
``` python
class ConfigTest(ScenarioTest):

    def __init__(self, *arg, **kwargs):
        super().__init__(*arg, random_config_dir=True, **kwargs)
```

```
2023-03-03T11:05:05.5590254Z [gw2] [ 65%] FAILED tests/test_cloud.py::TestCloud::test_remove_known_cloud 
2023-03-03T11:05:05.5590455Z 
2023-03-03T11:05:05.5590884Z =================================== FAILURES ===================================
2023-03-03T11:05:05.5591177Z ______________________ TestCloud.test_remove_known_cloud _______________________
2023-03-03T11:05:05.5592042Z [gw2] linux -- Python 3.10.10 /opt/az/bin/python3
2023-03-03T11:05:05.5592295Z self = <core.tests.test_cloud.TestCloud testMethod=test_remove_known_cloud>
2023-03-03T11:05:05.5592422Z 
2023-03-03T11:05:05.5592577Z     def test_remove_known_cloud(self):
2023-03-03T11:05:05.5592756Z >       cli = DummyCli()
2023-03-03T11:05:05.5592824Z 
2023-03-03T11:05:05.5593120Z /opt/az/lib/python3.10/site-packages/azure/cli/core/tests/test_cloud.py:216: 
2023-03-03T11:05:05.5593362Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-03-03T11:05:05.5593706Z /opt/az/lib/python3.10/site-packages/azure/cli/core/mock.py:25: in __init__
2023-03-03T11:05:05.5593932Z     super(DummyCli, self).__init__(
2023-03-03T11:05:05.5594263Z /opt/az/lib/python3.10/site-packages/azure/cli/core/__init__.py:59: in __init__
2023-03-03T11:05:05.5594502Z     super(AzCli, self).__init__(**kwargs)
2023-03-03T11:05:05.5594818Z /opt/az/lib/python3.10/site-packages/knack/cli.py:82: in __init__
2023-03-03T11:05:05.5595028Z     self.config = config_cls(
2023-03-03T11:05:05.5595524Z /opt/az/lib/python3.10/site-packages/knack/config.py:75: in __init__
2023-03-03T11:05:05.5595793Z     self._config_file_chain.append(_ConfigFile(self.config_dir, self.config_path))
2023-03-03T11:05:05.5596156Z /opt/az/lib/python3.10/site-packages/knack/config.py:195: in __init__
2023-03-03T11:05:05.5596418Z     self.config_parser.read(config_path, encoding=CONFIG_FILE_ENCODING)
2023-03-03T11:05:05.5596652Z /opt/az/lib/python3.10/configparser.py:699: in read
2023-03-03T11:05:05.5596854Z     self._read(fp, filename)
2023-03-03T11:05:05.5597051Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-03-03T11:05:05.5597146Z 
2023-03-03T11:05:05.5597321Z self = <configparser.ConfigParser object at 0xffff9808a770>
2023-03-03T11:05:05.5597664Z fp = <_io.TextIOWrapper name='/root/.azure/config' mode='r' encoding='utf-8'>
2023-03-03T11:05:05.5597957Z fpname = '/root/.azure/config'
2023-03-03T11:05:05.5598040Z 
2023-03-03T11:05:05.5598203Z     def _read(self, fp, fpname):
2023-03-03T11:05:05.5598387Z         """Parse a sectioned configuration file.
2023-03-03T11:05:05.5598554Z     
2023-03-03T11:05:05.5598736Z         Each section in a configuration file contains a header, indicated by
2023-03-03T11:05:05.5598980Z         a name in square brackets (`[]`), plus key/value options, indicated by
2023-03-03T11:05:05.5599218Z         `name` and `value` delimited with a specific substring (`=` or `:` by
2023-03-03T11:05:05.5599400Z         default).
2023-03-03T11:05:05.5599542Z     
2023-03-03T11:05:05.5599721Z         Values can span multiple lines, as long as they are indented deeper
2023-03-03T11:05:05.5600070Z         than the first line of the value. Depending on the parser's mode, blank
2023-03-03T11:05:05.5600312Z         lines may be treated as parts of multiline values or ignored.
2023-03-03T11:05:05.5600485Z     
2023-03-03T11:05:05.5600673Z         Configuration files may include comments, prefixed by specific
2023-03-03T11:05:05.5600918Z         characters (`#` and `;` by default). Comments may appear on their own
2023-03-03T11:05:05.5601152Z         in an otherwise empty line or may be entered in lines holding values or
2023-03-03T11:05:05.5601417Z         section names. Please note that comments get stripped off when reading configuration files.
2023-03-03T11:05:05.5601624Z         """
2023-03-03T11:05:05.5601770Z         elements_added = set()
2023-03-03T11:05:05.5601956Z         cursect = None                        # None, or a dictionary
2023-03-03T11:05:05.5602124Z         sectname = None
2023-03-03T11:05:05.5602282Z         optname = None
2023-03-03T11:05:05.5602434Z         lineno = 0
2023-03-03T11:05:05.5602582Z         indent_level = 0
2023-03-03T11:05:05.5602759Z         e = None                              # None, or an exception
2023-03-03T11:05:05.5602950Z         for lineno, line in enumerate(fp, start=1):
2023-03-03T11:05:05.5603141Z             comment_start = sys.maxsize
2023-03-03T11:05:05.5603465Z             # strip inline comments
2023-03-03T11:05:05.5603763Z             inline_prefixes = {p: -1 for p in self._inline_comment_prefixes}
2023-03-03T11:05:05.5604005Z             while comment_start == sys.maxsize and inline_prefixes:
2023-03-03T11:05:05.5604200Z                 next_prefixes = {}
2023-03-03T11:05:05.5604382Z                 for prefix, index in inline_prefixes.items():
2023-03-03T11:05:05.5604589Z                     index = line.find(prefix, index+1)
2023-03-03T11:05:05.5604760Z                     if index == -1:
2023-03-03T11:05:05.5604914Z                         continue
2023-03-03T11:05:05.5605086Z                     next_prefixes[prefix] = index
2023-03-03T11:05:05.5605373Z                     if index == 0 or (index > 0 and line[index-1].isspace()):
2023-03-03T11:05:05.5605592Z                         comment_start = min(comment_start, index)
2023-03-03T11:05:05.5605797Z                 inline_prefixes = next_prefixes
2023-03-03T11:05:05.5605976Z             # strip full line comments
2023-03-03T11:05:05.5606312Z             for prefix in self._comment_prefixes:
2023-03-03T11:05:05.5606506Z                 if line.strip().startswith(prefix):
2023-03-03T11:05:05.5606686Z                     comment_start = 0
2023-03-03T11:05:05.5606840Z                     break
2023-03-03T11:05:05.5607001Z             if comment_start == sys.maxsize:
2023-03-03T11:05:05.5607180Z                 comment_start = None
2023-03-03T11:05:05.5607376Z             value = line[:comment_start].strip()
2023-03-03T11:05:05.5607552Z             if not value:
2023-03-03T11:05:05.5607730Z                 if self._empty_lines_in_values:
2023-03-03T11:05:05.5607927Z                     # add empty line to the value, but only if there was no
2023-03-03T11:05:05.5608119Z                     # comment on the line
2023-03-03T11:05:05.5608294Z                     if (comment_start is None and
2023-03-03T11:05:05.5608466Z                         cursect is not None and
2023-03-03T11:05:05.5608632Z                         optname and
2023-03-03T11:05:05.5608798Z                         cursect[optname] is not None):
2023-03-03T11:05:05.5609098Z                         cursect[optname].append('') # newlines added at join
2023-03-03T11:05:05.5609286Z                 else:
2023-03-03T11:05:05.5609444Z                     # empty line marks end of value
2023-03-03T11:05:05.5609627Z                     indent_level = sys.maxsize
2023-03-03T11:05:05.5609790Z                 continue
2023-03-03T11:05:05.5609940Z             # continuation line?
2023-03-03T11:05:05.5610134Z             first_nonspace = self.NONSPACECRE.search(line)
2023-03-03T11:05:05.5610360Z             cur_indent_level = first_nonspace.start() if first_nonspace else 0
2023-03-03T11:05:05.5610584Z             if (cursect is not None and optname and
2023-03-03T11:05:05.5610779Z                 cur_indent_level > indent_level):
2023-03-03T11:05:05.5610961Z                 cursect[optname].append(value)
2023-03-03T11:05:05.5611153Z             # a section header or option header?
2023-03-03T11:05:05.5611322Z             else:
2023-03-03T11:05:05.5611483Z                 indent_level = cur_indent_level
2023-03-03T11:05:05.5611660Z                 # is it a section header?
2023-03-03T11:05:05.5611831Z                 mo = self.SECTCRE.match(value)
2023-03-03T11:05:05.5611996Z                 if mo:
2023-03-03T11:05:05.5612241Z                     sectname = mo.group('header')
2023-03-03T11:05:05.5612426Z                     if sectname in self._sections:
2023-03-03T11:05:05.5612627Z                         if self._strict and sectname in elements_added:
2023-03-03T11:05:05.5612844Z                             raise DuplicateSectionError(sectname, fpname,
2023-03-03T11:05:05.5613028Z                                                         lineno)
2023-03-03T11:05:05.5613206Z                         cursect = self._sections[sectname]
2023-03-03T11:05:05.5613392Z                         elements_added.add(sectname)
2023-03-03T11:05:05.5613747Z                     elif sectname == self.default_section:
2023-03-03T11:05:05.5613945Z                         cursect = self._defaults
2023-03-03T11:05:05.5614099Z                     else:
2023-03-03T11:05:05.5614259Z                         cursect = self._dict()
2023-03-03T11:05:05.5614443Z                         self._sections[sectname] = cursect
2023-03-03T11:05:05.5614648Z                         self._proxies[sectname] = SectionProxy(self, sectname)
2023-03-03T11:05:05.5614855Z                         elements_added.add(sectname)
2023-03-03T11:05:05.5615136Z                     # So sections can't start with a continuation line
2023-03-03T11:05:05.5615328Z                     optname = None
2023-03-03T11:05:05.5615501Z                 # no section header in the file?
2023-03-03T11:05:05.5615669Z                 elif cursect is None:
2023-03-03T11:05:05.5615870Z                     raise MissingSectionHeaderError(fpname, lineno, line)
2023-03-03T11:05:05.5616063Z                 # an option line?
2023-03-03T11:05:05.5616211Z                 else:
2023-03-03T11:05:05.5616510Z                     mo = self._optcre.match(value)
2023-03-03T11:05:05.5616672Z                     if mo:
2023-03-03T11:05:05.5616951Z                         optname, vi, optval = mo.group('option', 'vi', 'value')
2023-03-03T11:05:05.5617150Z                         if not optname:
2023-03-03T11:05:05.5617332Z                             e = self._handle_error(e, fpname, lineno, line)
2023-03-03T11:05:05.5617548Z                         optname = self.optionxform(optname.rstrip())
2023-03-03T11:05:05.5617742Z                         if (self._strict and
2023-03-03T11:05:05.5617923Z                             (sectname, optname) in elements_added):
2023-03-03T11:05:05.5618134Z >                           raise DuplicateOptionError(sectname, optname,
2023-03-03T11:05:05.5618323Z                                                        fpname, lineno)
2023-03-03T11:05:05.5618826Z E                           configparser.DuplicateOptionError: While reading from '/root/.azure/config' [line 31]: option 'cache_ttl' in section 'core' already exists
2023-03-03T11:05:05.5619016Z 
2023-03-03T11:05:05.5619208Z /opt/az/lib/python3.10/configparser.py:1098: DuplicateOptionError
```


**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
