### PR TITLE
{Packaging} revert cryptography to 38.0.4 and pyOpenSSL to 22.1.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -95,7 +95,7 @@ certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-cryptography==39.0.1
+cryptography==38.0.4
 fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
@@ -123,7 +123,7 @@ PyGithub==1.55
 PyJWT==2.4.0
 PyMySQL==1.0.2
 PyNaCl==1.5.0
-pyOpenSSL==23.0.0
+pyOpenSSL==22.1.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.26.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -95,7 +95,7 @@ certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-cryptography==39.0.1
+cryptography==38.0.4
 distro==1.6.0
 fabric==2.4.0
 humanfriendly==10.0
@@ -124,7 +124,7 @@ PyGithub==1.55
 PyJWT==2.4.0
 PyMySQL==1.0.2
 PyNaCl==1.5.0
-pyOpenSSL==23.0.0
+pyOpenSSL==22.1.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.26.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -95,7 +95,7 @@ certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-cryptography==39.0.1
+cryptography==38.0.4
 fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
@@ -125,7 +125,7 @@ PyJWT==2.4.0
 PyMySQL==1.0.2
 PyNaCl==1.5.0
 pyodbc==4.0.35
-pyOpenSSL==23.0.0
+pyOpenSSL==22.1.0
 python-dateutil==2.8.0
 pywin32==305
 requests-oauthlib==1.2.0


### PR DESCRIPTION
This reverts #25544

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In cryptography 39, this warn is display on Windows build.
```
>>> import cryptography.hazmat.bindings.openssl.binding
<stdin>:1: UserWarning: You are using cryptography on a 32-bit Python on a 64-bit Windows Operating System. Cryptography will be significantly faster if you switch to using a 64-bit Python.
```
Revert this change to prevent breaking change.

Related PR: https://github.com/pyca/cryptography/pull/7641
**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
