### PR TITLE
[App Service] Fix #25375: `az functionapp deployment source config-zip`: Fix the `Could not find a 'AzureWebJobsStorage' application setting` error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -694,7 +694,7 @@ def validate_zip_deploy_app_setting_exists(cmd, resource_group_name, name, slot=
     if storage_connection is None:
         raise ValidationError(('Unable to automatically deploy using the Azure CLI. Please '
                                'configure the app to deploy from a remote package using the steps here: '
-                               'https://aka.ms/zipdeploy'))
+                               'https://aka.ms/deployfromurl'))
 
 
 def upload_zip_to_storage(cmd, resource_group_name, name, src, slot=None):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -692,7 +692,7 @@ def validate_zip_deploy_app_setting_exists(cmd, resource_group_name, name, slot=
             storage_connection = str(keyval['value'])
 
     if storage_connection is None:
-        raise ValidationError(('Unable to automatically deploy using the Azure CLI. Please '
+        raise ValidationError(('The Azure CLI does not support this deployment path. Please '
                                'configure the app to deploy from a remote package using the steps here: '
                                'https://aka.ms/deployfromurl'))
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands_thru_mock.py
@@ -92,11 +92,13 @@ class TestFunctionappMocked(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.custom.parse_resource_id')
+    @mock.patch('azure.cli.command_modules.appservice.custom.validate_zip_deploy_app_setting_exists')
     @mock.patch('azure.cli.command_modules.appservice.custom.upload_zip_to_storage')
     @mock.patch('azure.cli.command_modules.appservice.custom.is_plan_consumption', return_value=True)
     def test_functionapp_linux_consumption_non_remote_build(self,
                                                             is_plan_consumption_mock,
                                                             upload_zip_to_storage_mock,
+                                                            validate_zip_deploy_app_setting_exists_mock,
                                                             parse_resource_id_mock,
                                                             web_client_factory_mock):
         # prepare
@@ -122,11 +124,13 @@ class TestFunctionappMocked(unittest.TestCase):
 
     @mock.patch('azure.cli.command_modules.appservice.custom.web_client_factory', autospec=True)
     @mock.patch('azure.cli.command_modules.appservice.custom.parse_resource_id')
+    @mock.patch('azure.cli.command_modules.appservice.custom.validate_zip_deploy_app_setting_exists')
     @mock.patch('azure.cli.command_modules.appservice.custom.upload_zip_to_storage')
     @mock.patch('azure.cli.command_modules.appservice.custom.is_plan_consumption', return_value=True)
     def test_functionapp_linux_consumption_non_remote_build_with_slot(self,
                                                             is_plan_consumption_mock,
                                                             upload_zip_to_storage_mock,
+                                                            validate_zip_deploy_app_setting_exists_mock,
                                                             parse_resource_id_mock,
                                                             web_client_factory_mock):
         # prepare


### PR DESCRIPTION
**Related command**
`az functionapp deployment source config-zip`

**Description**<!--Mandatory-->
Related GitHub issue: #25375 
In order for deployments not to rely on the AzureWebJobsStorage app setting but on managed identity, we would have to make substantial changes in the way we currently handle deployments for Linux consumption in the backend. Since it is currently not supported, we have decided to change the logic such that if customers attempt to deploy a Linux consumption function app (regardless of remote build or non remote build), they would have to do it manually by following documentation.

**Testing Guide**
1. Create a Linux consumption function app: `az functionapp create -g <resource-group-name> -n <functionapp-name> -c <location> -s <storage-account-name> --os-type Linux --runtime dotnet --functions-version 4`
2. Delete the `AzureWebJobsStorage` app setting: `az functionapp config appsettings delete -g <resource-group-name> -n <functionapp-name> --setting-names AzureWebJobsStorage`
3. Attempt to do zip deployment on function app: `az functionapp deployment source config-zip -g <resource-group-name> -n <functionapp-name> --src <zip-file-path>`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
