### PR TITLE
{Packaging} Use latest setuptools on Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # basic
-setuptools==65.5.1
+setuptools>=65.5.1
 pip>=9.0.1

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -46,7 +46,7 @@ $PYTHON_SRC_DIR/*/configure --srcdir $PYTHON_SRC_DIR/* --prefix $WORKDIR/python_
 make
 make install
 
-$WORKDIR/python_env/bin/python3 -m pip install --upgrade pip
+$WORKDIR/python_env/bin/python3 -m pip install --upgrade pip setuptools
 
 export PATH=$PATH:$WORKDIR/python_env/bin
 

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -46,7 +46,7 @@ A great cloud needs great tools; we're excited to introduce Azure CLI,
 # Create a fully instantiated virtual environment, ready to use the CLI.
 %{python_cmd} -m venv %{buildroot}%{cli_lib_dir}
 source %{buildroot}%{cli_lib_dir}/bin/activate
-%{python_cmd} -m pip install --upgrade pip
+%{python_cmd} -m pip install --upgrade pip setuptools
 source %{repo_path}/scripts/install_full.sh
 
 # cffi 1.15.0 doesn't work with RPM: https://foss.heptapod.net/pypy/cffi/-/issues/513


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
On windows, the latest `setuptools` is installed, as it use `get-pip.py` to install pip and setuptools.
https://github.com/Azure/azure-cli/blob/3a793a0ae1caa9a361cc626d70a6b3eec359b4d9/build_scripts/windows/scripts/build.cmd#L98

On macOS, it depends on the python3.10 `setuptools` version, brew updates it automatically?
https://github.com/Azure/azure-cli/blob/3a793a0ae1caa9a361cc626d70a6b3eec359b4d9/scripts/release/homebrew/docker/formula_template.txt#L31

On Linux, `setuptools` is installed when create Python virtual [env](https://docs.python.org/3/library/venv.html). It may be an old version.

Update it to latest version to prevent security issue.

Related: https://github.com/Azure/azure-cli/pull/24992#discussion_r1098335454
Close https://github.com/Azure/azure-cli/issues/25682

**Testing Guide**
```
root@1495cb1c7434:/# /opt/az/bin/python3 -Im pip list | grep setup
setuptools                              67.5.1
```

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
