### PR TITLE
[CosmosDB] `az cosmosdb identity assign`: Allow refreshing user assigned identities if they're reassigned to an account

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/cosmosdb/custom.py
@@ -1520,12 +1520,7 @@ def cli_cosmosdb_identity_assign(client,
 
     only_enabling_system = enable_system and len(new_user_identities) == 0
     system_already_added = existing.identity.type == ResourceIdentityType.system_assigned or existing.identity.type == ResourceIdentityType.system_assigned_user_assigned
-    all_new_users_already_added = new_user_identities and existing.identity and existing.identity.user_assigned_identities and all(x in existing.identity.user_assigned_identities for x in new_user_identities)
     if only_enabling_system and system_already_added:
-        return existing.identity
-    if (not enable_system) and all_new_users_already_added:
-        return existing.identity
-    if enable_system and system_already_added and all_new_users_already_added:
         return existing.identity
 
     if existing.identity and existing.identity.type == ResourceIdentityType.system_assigned_user_assigned:


### PR DESCRIPTION
**Related command**
az cosmosdb identity assign

**Description**<!--Mandatory-->
This PR aims to bring the cli's identity assignment (and reassignment) to be consistent with the current state of ARM.

Due to system issues or bugs in the communication with MSI, an account's identity might be left stale. This change makes the refresh, via cli, as easy as just readding said identity.

This is all already possible via ARM.

**Testing Guide**
Before: az cosmosdb identity assign just returned the resource as a no op.
after: It should reassign the identity, renewing its properties.

**History Notes**
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
