### PR TITLE
[ARM] Fix #25715: `az bicep install/upgrade`: Fix the `configparser.NoSectionError: No section: 'bicep'`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -138,8 +138,8 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
 
         os.chmod(installation_path, os.stat(installation_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-        use_binary_from_path = cli_ctx.config.get("bicep", "use_binary_from_path").lower()
-        if use_binary_from_path in ["0", "no", "false", "off"]:
+        use_binary_from_path = cli_ctx.config.get("bicep", "use_binary_from_path", "if_found_in_ci").lower()
+        if use_binary_from_path not in ["0", "no", "false", "off"]:
             _logger.warning("The configuration value of bicep.use_binary_from_path has been set to 'false'.")
             cli_ctx.config.set_value("bicep", "use_binary_from_path", "false")
 

--- a/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py
@@ -154,7 +154,7 @@ def ensure_bicep_installation(cli_ctx, release_tag=None, target_platform=None, s
         raise ClientRequestError(f"Error while attempting to download Bicep CLI: {err}")
 
 
-def remove_bicep_installation():
+def remove_bicep_installation(cli_ctx):
     system = platform.system()
     installation_path = _get_bicep_installation_path(system)
 
@@ -162,6 +162,11 @@ def remove_bicep_installation():
         os.remove(installation_path)
     if os.path.exists(_bicep_version_check_file_path):
         os.remove(_bicep_version_check_file_path)
+
+    use_binary_from_path = cli_ctx.config.get("bicep", "use_binary_from_path", "if_found_in_ci").lower()
+    if use_binary_from_path in ["0", "no", "false", "off"]:
+        _logger.warning("The configuration value of bicep.use_binary_from_path has been reset")
+        cli_ctx.config.remove_option("bicep", "use_binary_from_path")
 
 
 def is_bicep_file(file_path):

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3649,7 +3649,7 @@ def install_bicep_cli(cmd, version=None, target_platform=None):
 
 
 def uninstall_bicep_cli(cmd):
-    remove_bicep_installation()
+    remove_bicep_installation(cmd.cli_ctx)
 
 
 def upgrade_bicep_cli(cmd, target_platform=None):

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -29,6 +29,8 @@ class TestBicep(unittest.TestCase):
 
         with contextlib.suppress(FileNotFoundError):
             remove_bicep_installation(cli_ctx)
+
+        cli_ctx.config.set_value("bicep", "use_binary_from_path", "false")
         with self.assertRaisesRegex(CLIError, 'Bicep CLI not found. Install it now by running "az bicep install".'):
             run_bicep_command(cli_ctx, ["--version"], auto_install=False)
 
@@ -110,6 +112,7 @@ class TestBicep(unittest.TestCase):
         get_bicep_latest_release_tag_stub.return_value = "v2.0.0"
 
         cli_ctx.config.set_value("bicep", "check_version", "True")
+        cli_ctx.config.set_value("bicep", "use_binary_from_path", "false")
         run_bicep_command(cli_ctx, ["--version"])
 
         warning_mock.assert_called_once_with(

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -28,7 +28,7 @@ class TestBicep(unittest.TestCase):
         isfile_stub.return_value = False
 
         with contextlib.suppress(FileNotFoundError):
-            remove_bicep_installation()
+            remove_bicep_installation(cli_ctx)
         with self.assertRaisesRegex(CLIError, 'Bicep CLI not found. Install it now by running "az bicep install".'):
             run_bicep_command(cli_ctx, ["--version"], auto_install=False)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
```
az bicep install
az bicep upgrade
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In #25541, we are checking for the current value of `bicep.use_binary_from_path` config value and updating it to `false` when `bicep` is installed via Azure CLI.

This check was missing a default value, throwing an error in the process. This PR fixes this.

resolves #25715, resolves #25710

**Testing Guide**
<!--Example commands with explanations.-->
```
az bicep upgrade
az bicep install
```
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
