### PR TITLE
[App Service] `az functionapp function delete`: Raise ValidationError when running on project Centauri

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_validators.py
@@ -421,3 +421,14 @@ def validate_app_is_functionapp(cmd, namespace):
         raise ValidationError(f"App '{name}' in group '{rg}' is a logic app.")
     if is_webapp(app):
         raise ValidationError(f"App '{name}' in group '{rg}' is a web app.")
+
+
+def validate_centauri_delete_function(cmd, namespace):
+    resource_group_name = namespace.resource_group_name
+    name = namespace.name
+    slot = namespace.slot
+    function_app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if function_app.managed_environment_id is not None:
+        raise ValidationError(
+            'Delete function for a function app on container app environment is not supported.',
+            'This function app is created in an App Environment. Go to App environment to delete functions.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -11,7 +11,7 @@ from ._client_factory import cf_web_client, cf_plans, cf_webapps
 from ._validators import (validate_onedeploy_params, validate_staticsite_link_function, validate_staticsite_sku,
                           validate_vnet_integration, validate_asp_create, validate_functionapp_asp_create,
                           validate_webapp_up, validate_app_exists, validate_add_vnet, validate_app_is_functionapp,
-                          validate_app_is_webapp)
+                          validate_app_is_webapp, validate_centauri_delete_function)
 
 
 def output_slots_in_table(slots):
@@ -412,7 +412,7 @@ def load_command_table(self, _):
 
     with self.command_group('functionapp function') as g:
         g.custom_command('show', 'show_function')  # pylint: disable=show-command
-        g.custom_command('delete', 'delete_function')
+        g.custom_command('delete', 'delete_function', validator=validate_centauri_delete_function, exception_handler=ex_handler_factory())
         g.custom_command('list', 'list_functions')
 
     with self.command_group('functionapp function keys') as g:


### PR DESCRIPTION
**Related command**
Update delete function logics for project centauri using functionapp commands:
1. when running `az functionapp function delete` command on a functionapp that's on container app enviornment, raise an error with help message and stop proceed. 


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

For project Centauri, when customer provide the managed environment while creating function app, the delete function command for normal functions will not be supported in this case. 

**Testing Guide**
<!--Example commands with explanations.-->
1. create a function app on container app environment, and then trying to delete function using command `az functionapp function delete` should fail. Currently, this test case is failing, it should pass once the swagger API for `site` is updated. https://github.com/Azure/azure-rest-api-specs/pull/22341


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
