### PR TITLE
[App Service] `az functionapp show`: Do not set ftpPublishingUrl for Centauri

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/commands.py
@@ -317,7 +317,7 @@ def load_command_table(self, _):
                          validator=validate_vnet_integration)
         g.custom_command('list-runtimes', 'list_function_app_runtimes')
         g.custom_command('list', 'list_function_app', table_transformer=transform_web_list_output)
-        g.custom_show_command('show', 'show_app', table_transformer=transform_web_output)
+        g.custom_show_command('show', 'show_functionapp', table_transformer=transform_web_output)
         g.custom_command('delete', 'delete_function_app')
         g.custom_command('stop', 'stop_webapp')
         g.custom_command('start', 'start_webapp')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -915,6 +915,19 @@ def list_function_app(cmd, resource_group_name=None):
                 _list_app(cmd.cli_ctx, resource_group_name)))
 
 
+def show_functionapp(cmd, resource_group_name, name, slot=None):
+    app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
+    if not app:
+        raise ResourceNotFoundError("Unable to find resource'{}', in ResourceGroup '{}'.".format(name,
+                                                                                                 resource_group_name))
+    app.site_config = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get_configuration',
+                                              slot)
+    _rename_server_farm_props(app)
+    if app.managed_environment_id is None:
+        _fill_ftp_publishing_url(cmd, app, resource_group_name, name, slot)
+    return app
+
+
 def show_app(cmd, resource_group_name, name, slot=None):
     app = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'get', slot)
     if not app:

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_functionapp_commands.py
@@ -332,6 +332,17 @@ class FunctionAppWithPlanE2ETest(ScenarioTest):
         self.cmd('functionapp config show -g {} -n {}'.format(resource_group, functionapp), checks=[
             JMESPathCheck('linuxFxVersion', 'PowerShell|7.2')])
 
+    @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)
+    @StorageAccountPreparer
+    def test_functionapp_quick_create(self, resource_group, storage_account):
+        functionapp_name = self.create_random_name('functionapp', 24)
+        plan = self.create_random_name('functionapp-plan', 24)
+
+        self.cmd('appservice plan create -g {} -n {}'.format(resource_group, plan))
+
+        r = self.cmd('functionapp create -g {} -n {} -p {} -s {}'.format(resource_group, functionapp_name, plan, storage)).get_output_in_json()
+        self.assertTrue(r['ftpPublishingUrl'].startswith('ftp://'))
+
 
 class FunctionUpdatePlan(ScenarioTest):
     @ResourceGroupPreparer(location=WINDOWS_ASP_LOCATION_FUNCTIONAPP)


### PR DESCRIPTION
**Related command**
az functionapp show 

**Description**<!--Mandatory-->
For Private Preview, the backend team will not support the publishxml POST API which we call in the `az functionapp show` command to show customers the ftpPublishingUrl information. 

**Testing Guide**
1. Create function app
2. Run `az functionapp show -g <resource-group-name> -n <functionapp-name>` and see that the `ftpPublishingUrl` value is only shown in the response if the function app is not deployed in a container app environment

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
