### PR TITLE
[Core] `aaz`: Add support for changing subscription of `AAZCommand` in customization code

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command_ctx.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command_ctx.py
@@ -30,6 +30,11 @@ class AAZCommandCtx:
                     cmd_arg.apply(self.args, dest)
                 elif cmd_arg != AAZUndefined:
                     self.args[dest] = cmd_arg
+            elif dest == "subscription":
+                # support to specify the command's subscription when call AAZCommand directly in code
+                if isinstance(cmd_arg, str):
+                    self._subscription_id = cmd_arg
+
         self._clients = {}
         self._vars_schema = AAZObjectType()
         self.vars = AAZObject(schema=self._vars_schema, data={})

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_command_ctx.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_command_ctx.py
@@ -1,0 +1,45 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import base64
+import json
+import random
+import unittest
+
+from azure.cli.core import azclierror
+from azure.cli.core.aaz import exceptions as aazerror
+from azure.cli.core.aaz._command_ctx import AAZCommandCtx
+from azure.cli.core.aaz import AAZArgumentsSchema
+from azure.cli.core.mock import DummyCli
+
+
+class TestAAZCommandCtx(unittest.TestCase):
+
+    def test_ctx_subscription(self):
+        from azure.cli.core.aaz import AAZStrArg
+        schema = AAZArgumentsSchema()
+        schema.str1 = AAZStrArg()
+        sub_id = "10101111-0000-0000-0000-000000000000"
+        ctx = AAZCommandCtx(
+            cli_ctx=DummyCli(),
+            schema=schema,
+            command_args={
+                "subscription": sub_id,
+            }
+        )
+        self.assertEqual(ctx._subscription_id, sub_id)
+        self.assertEqual(ctx.subscription_id, sub_id)
+
+        schema = AAZArgumentsSchema()
+        schema.subscription = AAZStrArg()
+        sub_id = "10101111-0000-0000-0000-000000000000"
+        ctx = AAZCommandCtx(
+            cli_ctx=DummyCli(),
+            schema=schema,
+            command_args={
+                "subscription": sub_id,
+            }
+        )
+        self.assertEqual(ctx.args.subscription, sub_id)
+        self.assertEqual(ctx._subscription_id, None)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
