### PR TITLE
{ARM} fixes Azure/azure-cli#25760 Fix the typo for Az Bicep CLI description

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_help.py
@@ -2750,19 +2750,19 @@ helps['bicep format'] = """
 type: command
 short-summary: Format a Bicep file.
 examples:
-  - name: Foramt a Bicep file.
+  - name: Format a Bicep file.
     text: az bicep format --file {bicep_file}
-  - name: Foramt a Bicep file and print all output to stdout.
+  - name: Format a Bicep file and print all output to stdout.
     text: az bicep format --file {bicep_file} --stdout
-  - name: Foramt a Bicep file and save the result to the specified directory.
+  - name: Format a Bicep file and save the result to the specified directory.
     text: az bicep format --file {bicep_file} --outdir {out_dir}
-  - name: Foramt a Bicep file and save the result to the specified file.
+  - name: Format a Bicep file and save the result to the specified file.
     text: az bicep format --file {bicep_file} --outfile {out_file}
-  - name: Foramt a Bicep file insert a final newline.
+  - name: Format a Bicep file insert a final newline.
     text: az bicep format --file {bicep_file} --insert-final-newline
-  - name: Foramt a Bicep file set indentation kind. Valid values are ( Space | Tab ).
+  - name: Format a Bicep file set indentation kind. Valid values are ( Space | Tab ).
     text: az bicep format --file {bicep_file} --indent-kind {indent_kind}
-  - name: Foramt a Bicep file set number of spaces to indent with (Only valid with --indent-kind set to Space).
+  - name: Format a Bicep file set number of spaces to indent with (Only valid with --indent-kind set to Space).
     text: az bicep format --file {bicep_file} --indent-size {indent_size}
 """
 


### PR DESCRIPTION
fixes Azure/azure-cli#25760 

Fix the typo for Az Bicep CLI description

The word `Format` is misspelled multiple times in the `az bicep format` examples section. Currently says `Foramt` instead of `Format`.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
