### PR TITLE
{CI} Fix `NoneType` error by add condition for pipeline result display feature

### DIFF
--- a/.azure-pipelines/templates/automation_test.yml
+++ b/.azure-pipelines/templates/automation_test.yml
@@ -26,7 +26,7 @@ parameters:
 - name: jobName
   displayName: Job name
   type: string
-  default: 'FullTest'
+  default: ''
 
 steps:
   - task: UsePythonVersion@0

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -33,7 +33,7 @@ working_directory = os.getenv('BUILD_SOURCESDIRECTORY') if target == 'cli' else 
 azdev_test_result_dir = os.path.expanduser("~/.azdev/env_config/mnt/vss/_work/1/s/env")
 python_version = os.environ.get('PYTHON_VERSION')
 job_name = os.environ.get('JOB_NAME')
-unique_job_name = ' '.join([job_name, python_version, profile, str(instance_idx)])
+unique_job_name = ' '.join([job_name, python_version, profile, str(instance_idx)]) if job_name == 'FullTest' else None
 pull_request_number = os.environ.get('PULL_REQUEST_NUMBER')
 cli_jobs = {
             'acr': 45,
@@ -562,20 +562,20 @@ class AutomaticScheduling(object):
                 serial_tests.append(k)
             else:
                 parallel_tests.append(k)
-        pipeline_result = build_pipeline_result()
+        pipeline_result = build_pipeline_result() if job_name == 'FullTest' else None
         if serial_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.serial.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + serial_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
             serial_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result)
+            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if job_name == 'FullTest' else None
         if parallel_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.parallel.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallel_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
             parallel_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result)
-        save_pipeline_result(pipeline_result)
+            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if job_name == 'FullTest' else None
+        save_pipeline_result(pipeline_result) if job_name == 'FullTest' else None
         return serial_error_flag or parallel_error_flag
 
     def run_extension_instance_modules(self, instance_modules):

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -31,10 +31,11 @@ fix_failure_tests = sys.argv[5].lower() == 'true' if len(sys.argv) >= 6 else Fal
 target = sys.argv[6].lower() if len(sys.argv) >= 7 else 'cli'
 working_directory = os.getenv('BUILD_SOURCESDIRECTORY') if target == 'cli' else f"{os.getenv('BUILD_SOURCESDIRECTORY')}/azure-cli-extensions"
 azdev_test_result_dir = os.path.expanduser("~/.azdev/env_config/mnt/vss/_work/1/s/env")
-python_version = os.environ.get('PYTHON_VERSION')
-job_name = os.environ.get('JOB_NAME')
-unique_job_name = ' '.join([job_name, python_version, profile, str(instance_idx)]) if job_name == 'FullTest' else None
-pull_request_number = os.environ.get('PULL_REQUEST_NUMBER')
+python_version = os.environ.get('PYTHON_VERSION', None)
+job_name = os.environ.get('JOB_NAME', None)
+pull_request_number = os.environ.get('PULL_REQUEST_NUMBER', None)
+enable_pipeline_result = bool(job_name and python_version)
+unique_job_name = ' '.join([job_name, python_version, profile, str(instance_idx)]) if enable_pipeline_result else None
 cli_jobs = {
             'acr': 45,
             'acs': 62,
@@ -562,20 +563,20 @@ class AutomaticScheduling(object):
                 serial_tests.append(k)
             else:
                 parallel_tests.append(k)
-        pipeline_result = build_pipeline_result() if job_name == 'FullTest' else None
+        pipeline_result = build_pipeline_result() if enable_pipeline_result else None
         if serial_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.serial.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + serial_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
             serial_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if job_name == 'FullTest' else None
+            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if enable_pipeline_result else None
         if parallel_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.parallel.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallel_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
             parallel_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if job_name == 'FullTest' else None
-        save_pipeline_result(pipeline_result) if job_name == 'FullTest' else None
+            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if enable_pipeline_result else None
+        save_pipeline_result(pipeline_result) if enable_pipeline_result else None
         return serial_error_flag or parallel_error_flag
 
     def run_extension_instance_modules(self, instance_modules):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add the condition for the pipeline result display feature to avoid error like:
![image](https://user-images.githubusercontent.com/18628534/224626296-741f80ca-5657-4a74-8925-8df6ea409ea0.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
