### PR TITLE
{ams} Fix account identity error while assigning system managed identity

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/ams/operations/identity.py
+++ b/src/azure-cli/azure/cli/command_modules/ams/operations/identity.py
@@ -16,10 +16,12 @@ def assign_identity(client, resource_group_name, account_name, system_assigned=F
 
     account_info = client.get(resource_group_name,
                               account_name) if resource_group_name else client.get_by_subscription(account_name)
-
-    current_identity_types = account_info.identity.type.split(',')
-    if 'None' in current_identity_types:
+    if account_info.identity is None:
         current_identity_types = []
+    else:
+        current_identity_types = account_info.identity.type.split(',')
+        if 'None' in current_identity_types:
+            current_identity_types = []
 
     media_service = MediaServiceUpdate(identity=MediaServiceIdentity(type=''))
 


### PR DESCRIPTION
**Related command**
`az ams account identity assign --system-assigned true`

**Description**<!--Mandatory-->
Managed identity assignment (using --system-assigned true) is not working on a newly created media service account.
Fixes [GitHub Issue 25677](https://github.com/Azure/azure-cli/issues/25677)
**Testing Guide**
`az ams account identity assign --system-assigned true`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
