### PR TITLE
[App Service] `az functionapp config container`: Handle slotConfigNames not supported

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1235,7 +1235,12 @@ def get_site_configs(cmd, resource_group_name, name, slot=None):
 def get_app_settings(cmd, resource_group_name, name, slot=None):
     result = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_application_settings', slot)
     client = web_client_factory(cmd.cli_ctx)
-    slot_app_setting_names = client.web_apps.list_slot_configuration_names(resource_group_name, name).app_setting_names
+    slot_app_setting_names = None
+    try:
+        slot_app_setting_names = client.web_apps.list_slot_configuration_names(resource_group_name, name) \
+                                       .app_setting_names
+    except:  # pylint: disable=bare-except
+        pass
     return _build_app_settings_output(result.properties, slot_app_setting_names)
 
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1235,7 +1235,7 @@ def get_site_configs(cmd, resource_group_name, name, slot=None):
 def get_app_settings(cmd, resource_group_name, name, slot=None):
     result = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_application_settings', slot)
     client = web_client_factory(cmd.cli_ctx)
-    slot_app_setting_names = None
+    slot_app_setting_names = []
     try:
         slot_app_setting_names = client.web_apps.list_slot_configuration_names(resource_group_name, name) \
                                        .app_setting_names
@@ -1464,11 +1464,17 @@ def delete_app_settings(cmd, resource_group_name, name, setting_names, slot=None
     app_settings = _generic_site_operation(cmd.cli_ctx, resource_group_name, name, 'list_application_settings', slot)
     client = web_client_factory(cmd.cli_ctx)
 
-    slot_cfg_names = client.web_apps.list_slot_configuration_names(resource_group_name, name)
+    slot_cfg_names = {}
     is_slot_settings = False
+
+    try:
+        slot_cfg_names = client.web_apps.list_slot_configuration_names(resource_group_name, name)
+    except:  # pylint: disable=bare-except
+        pass
+
     for setting_name in setting_names:
         app_settings.properties.pop(setting_name, None)
-        if slot_cfg_names.app_setting_names and setting_name in slot_cfg_names.app_setting_names:
+        if slot_cfg_names and slot_cfg_names.app_setting_names and setting_name in slot_cfg_names.app_setting_names:
             slot_cfg_names.app_setting_names.remove(setting_name)
             is_slot_settings = True
 


### PR DESCRIPTION
**Related command**
`az functionapp config container set`
`az functionapp config container delete`
`az functionapp config container show`

**Description**<!--Mandatory-->
For Private Preview, the backend team will not support the slotConfigNames APIs which we call in the `az functionapp config container` commands to obtain/update slot configuration settings.

**Testing Guide**
1. Create function app deployed in a container app environment
2. Run `az functionapp config container set` or `az functionapp config container delete` or `az functionapp config container show`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
