### PR TITLE
{Core} Support preview extension to override GA extension

### DIFF
--- a/doc/overwrite_order_in_cli.md
+++ b/doc/overwrite_order_in_cli.md
@@ -1,0 +1,24 @@
+**Background**  
+Now, our command table is loaded three times.
+The commands loaded later will override the commands loaded earlier
+1. Load the CLI module
+2. Load the wheel extension (az extension add)
+3. Load dev extension (azdev extension add)  
+
+If modules or extensions are at the same level, they will be loaded in **alphabetical order**, so the modules and extensions loaded later will also override the commands in the modules and extensions loaded earlier.
+
+**What if I want to my preview extension overwrite my GA extension?**
+
+You need to ensure that the extension name of preview is sorted after the extension name of GA
+For example：
+GA extension name： containerapp
+Preview extension name: containerapp-preview
+
+**Testing result**
+
+1. If the command only exists in the ga extension, keep it
+![image](https://user-images.githubusercontent.com/18628534/225559734-c4e37f84-7f52-4f32-9bba-85243a3e1b85.png)
+1. If the command exists at the same time, the preview command will overwrite ga
+![image](https://user-images.githubusercontent.com/18628534/225559840-8523583c-24dd-45eb-aa82-eb8de72d75b3.png)
+1. If the command only exists in the preview extension, keep it
+![image](https://user-images.githubusercontent.com/18628534/225559911-dae4ec3b-dbe4-4fb6-a612-f6e7af814bf8.png)

--- a/doc/overwrite_order_in_cli.md
+++ b/doc/overwrite_order_in_cli.md
@@ -1,4 +1,5 @@
 **Background**  
+
 Now, our command table is loaded three times.
 The commands loaded later will override the commands loaded earlier
 1. Load the CLI module
@@ -18,7 +19,7 @@ Preview extension name: containerapp-preview
 
 1. If the command only exists in the ga extension, keep it
 ![image](https://user-images.githubusercontent.com/18628534/225559734-c4e37f84-7f52-4f32-9bba-85243a3e1b85.png)
-1. If the command exists at the same time, the preview command will overwrite ga
+2. If the command exists at the same time, the preview command will overwrite ga
 ![image](https://user-images.githubusercontent.com/18628534/225559840-8523583c-24dd-45eb-aa82-eb8de72d75b3.png)
-1. If the command only exists in the preview extension, keep it
+3. If the command only exists in the preview extension, keep it
 ![image](https://user-images.githubusercontent.com/18628534/225559911-dae4ec3b-dbe4-4fb6-a612-f6e7af814bf8.png)

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -206,7 +206,7 @@ class WheelExtension(Extension):
                     if ext not in exts:
                         exts.append(ext)
         # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
-        # Sort the extensions by name to support https://github.com/Azure/azure-cli/issues/25782.
+        # Sort the extensions by name to support overwrite extension feature: https://github.com/Azure/azure-cli/issues/25782.
         exts.sort(key=lambda ext: ext.name)
         return exts
 
@@ -276,7 +276,7 @@ class DevExtension(Extension):
         for source in DEV_EXTENSION_SOURCES:
             _collect(source)
         # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
-        # Sort the extensions by name to support https://github.com/Azure/azure-cli/issues/25782.
+        # Sort the extensions by name to support overwrite extension feature: https://github.com/Azure/azure-cli/issues/25782.
         exts.sort(key=lambda ext: ext.name)
         return exts
 

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -205,6 +205,8 @@ class WheelExtension(Extension):
                     ext = WheelExtension(ext_name, ext_path)
                     if ext not in exts:
                         exts.append(ext)
+        # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
+        exts.sort(key=lambda ext: ext.name)
         return exts
 
 
@@ -272,6 +274,8 @@ class DevExtension(Extension):
                     _collect(os.path.join(path, item), depth + 1, max_depth)
         for source in DEV_EXTENSION_SOURCES:
             _collect(source)
+        # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
+        exts.sort(key=lambda ext: ext.name)
         return exts
 
 

--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -206,6 +206,7 @@ class WheelExtension(Extension):
                     if ext not in exts:
                         exts.append(ext)
         # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
+        # Sort the extensions by name to support https://github.com/Azure/azure-cli/issues/25782.
         exts.sort(key=lambda ext: ext.name)
         return exts
 
@@ -275,6 +276,7 @@ class DevExtension(Extension):
         for source in DEV_EXTENSION_SOURCES:
             _collect(source)
         # https://docs.python.org/3/library/os.html#os.listdir, listdir is in arbitrary order.
+        # Sort the extensions by name to support https://github.com/Azure/azure-cli/issues/25782.
         exts.sort(key=lambda ext: ext.name)
         return exts
 


### PR DESCRIPTION
**Instructions for use**

You need to ensure that the extension name of preview is sorted after the extension name of GA
For example：
GA extension name： containerapp
Preview extension name: containerapp-preview

**Testing result**

1. If the command only exists in the ga extension, keep it
![image](https://user-images.githubusercontent.com/18628534/225559734-c4e37f84-7f52-4f32-9bba-85243a3e1b85.png)
2. If the command exists at the same time, the preview command will overwrite ga
![image](https://user-images.githubusercontent.com/18628534/225559840-8523583c-24dd-45eb-aa82-eb8de72d75b3.png)
3. If the command only exists in the preview extension, keep it
![image](https://user-images.githubusercontent.com/18628534/225559911-dae4ec3b-dbe4-4fb6-a612-f6e7af814bf8.png)

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Now, our command table is loaded three times
1. Load the CLI module 
2. Load the wheel extension (az extension add)
3. Load dev extension (azdev extension add)

[Load the modules first and then the extensions](https://github.com/Azure/azure-cli/blob/5a80d3507270cc3b9313a3e6e60daf291489a80d/src/azure-cli-core/azure/cli/core/__init__.py#L424-L426)
```
                _update_command_table_from_modules(args, index_modules)
                # The index won't contain suppressed extensions
                _update_command_table_from_extensions([], index_extensions)
```
[Load wheel extensions then dev extensions](https://github.com/Azure/azure-cli/blob/16bffd6b3a23131fd98e63a0fa2b23c9f7d81855/src/azure-cli-core/azure/cli/core/extension/__init__.py#L330-L338)
```
EXTENSION_TYPES = [WheelExtension, DevExtension]
def get_extensions(ext_type=None):
    extensions = []
    if not ext_type:
        ext_type = EXTENSION_TYPES
    elif not isinstance(ext_type, list):
        ext_type = [ext_type]
    for t in ext_type:
        extensions.extend(t.get_all())
    return extensions
```
[Load wheel extensions](https://github.com/Azure/azure-cli/blob/ed6e829554624894d5c94ad71bb85e788d726a43/src/azure-cli-core/azure/cli/core/extension/__init__.py#L188-L208)
```
    def get_all():
        """
        Returns all wheel-based extensions.
        """
        from glob import glob
        exts = []
        if os.path.isdir(EXTENSIONS_DIR):
            for ext_name in os.listdir(EXTENSIONS_DIR):
                ext_path = os.path.join(EXTENSIONS_DIR, ext_name)
                pattern = os.path.join(ext_path, '*.*-info')    # include *.egg-info and *.dist-info
                if os.path.isdir(ext_path) and glob(pattern):
                    exts.append(WheelExtension(ext_name, ext_path))
        if os.path.isdir(EXTENSIONS_SYS_DIR):
            for ext_name in os.listdir(EXTENSIONS_SYS_DIR):
                ext_path = os.path.join(EXTENSIONS_SYS_DIR, ext_name)
                pattern = os.path.join(ext_path, '*.*-info')    # include *.egg-info and *.dist-info
                if os.path.isdir(ext_path) and glob(pattern):
                    ext = WheelExtension(ext_name, ext_path)
                    if ext not in exts:
                        exts.append(ext)
        return exts
```
[Load dev extensions](https://github.com/Azure/azure-cli/blob/ed6e829554624894d5c94ad71bb85e788d726a43/src/azure-cli-core/azure/cli/core/extension/__init__.py#L254-L275)
```
    def get_all():
        """
        Returns all dev extensions.
        """
        from glob import glob
        exts = []


        def _collect(path, depth=0, max_depth=3):
            if not os.path.isdir(path) or depth == max_depth or os.path.split(path)[-1].startswith('.'):
                return
            pattern = os.path.join(path, '*.egg-info')
            match = glob(pattern)
            if match:
                ext_path = os.path.dirname(match[0])
                ext_name = os.path.split(ext_path)[-1]
                exts.append(DevExtension(ext_name, ext_path))
            else:
                for item in os.listdir(path):
                    _collect(os.path.join(path, item), depth + 1, max_depth)
        for source in DEV_EXTENSION_SOURCES:
            _collect(source)
        return exts
```

The extensions in each level are loaded in order determined by the order of os.listdir results.
But [os.listdir is in arbitrary order](https://docs.python.org/3/library/os.html#os.listdir), if the name contains numbers, the order will be messed up.
For example：
listdir with name does not contain number
![image](https://user-images.githubusercontent.com/18628534/224947749-0a6fe24a-7610-404a-b2b5-9458f5712175.png)
listdir with name contain number
![image](https://user-images.githubusercontent.com/18628534/224947494-d04921fd-f573-44f2-bf8b-5a14ee91337d.png)


So add a sort to ensure alphabetical order.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
