### PR TITLE
Clearing values between enable/disable static_website

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -350,6 +350,10 @@ def set_service_properties_track2(client, parameters, delete_retention=None, del
     if not parameters.minute_metrics.enabled:
         parameters.minute_metrics.include_apis = None
 
+    if not parameters.static_website.enabled:
+        parameters.static_website.index_document = None
+        parameters.static_website.error_document404_path = None
+
     # checks
     policy = kwargs.get('delete_retention_policy', None)
     if policy and policy.enabled and not policy.days:


### PR DESCRIPTION
**Related command**
az storage blob service-properties update --account-name account_name --static-website false

**Description**<!--Mandatory-->
Fix issue with enable/disable static website where values are not cleared causing issue below after static was enabled


**Testing Guide**
  Create Blob with static content enabled
  Command line disable static content
  Command line enable static content again

Error:
        "ERROR: XML specified is not syntactically valid.",
        "RequestId:5cca2535-201e-0029-094c-427c79000000",
        "Time:2023-02-16T21:23:46.4764389Z",
        "ErrorCode:InvalidXmlDocument",
        "linenumber:2",
        "lineposition:714",
        "reason:Element IndexDocument is only expected when StaticWebsite/Enabled is enabled
 