### PR TITLE
{Telemetry} Fix KeyError: 'x-ms-client-request-id'

### DIFF
--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -178,8 +178,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'Source', source)
         set_custom_properties(result,
                               'ClientRequestId',
-                              lambda: self.application.data['headers'][
-                                  'x-ms-client-request-id'])
+                              lambda: self.application.data['headers'].get('x-ms-client-request-id', ''))
         set_custom_properties(result, 'CoreVersion', _get_core_version)
         set_custom_properties(result, 'TelemetryVersion', "2.0")
         set_custom_properties(result, 'InstallationId', _get_installation_id)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az -v --debug` shows this error:
```
Traceback (most recent call last):
  File "c:\users\hanglei\developer\azure-cli\src\azure-cli\azure\cli\__main__.py", line 62, in <module>
    raise ex
  File "c:\users\hanglei\developer\azure-cli\src\azure-cli\azure\cli\__main__.py", line 55, in <module>
    sys.exit(exit_code)
SystemExit: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "c:\users\hanglei\developer\azure-cli\src\azure-cli-core\azure\cli\core\decorators.py", line 79, in _wrapped_func
    return func(*args, **kwargs)
  File "c:\users\hanglei\developer\azure-cli\src\azure-cli-core\azure\cli\core\telemetry.py", line 324, in set_custom_properties
    actual_value = value() if hasattr(value, '__call__') else value
  File "c:\users\hanglei\developer\azure-cli\src\azure-cli-core\azure\cli\core\telemetry.py", line 184, in <lambda>
    lambda: self.application.data['headers']['x-ms-client-request-id'])
KeyError: 'x-ms-client-request-id'
```
`self.application.data['headers']` is `{}` when run this command.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
