### PR TITLE
[SQL] `az sql server refresh-external-governance-status`: New command for refreshing external governance status

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -1649,7 +1649,7 @@ short-summary: Refreshes external governance status.
 
 examples:
   - name:  Refreshes external governance status.
-    text: az sql server refresh-external-governance-status --resource_group_name MyResourceGroup --server_name MyServer
+    text: az sql server refresh-external-governance-status  --resource-group MyResourceGroup --server MyServer
 """
 
 helps['sql server key'] = """

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -1648,7 +1648,7 @@ type: command
 short-summary: Refreshes external governance status.
 
 examples:
-  - name:  Refreshes external governance status.
+  - name:  Refresh external governance status for server
     text: az sql server refresh-external-governance-status  --resource-group MyResourceGroup --server MyServer
 """
 

--- a/src/azure-cli/azure/cli/command_modules/sql/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_help.py
@@ -1643,6 +1643,15 @@ examples:
     text: az sql server outbound-firewall-rule delete -g mygroup -s myserver --outbound-rule-fqdn allowedFQDN
 """
 
+helps['sql server refresh-external-governance-status'] = """
+type: command
+short-summary: Refreshes external governance status.
+
+examples:
+  - name:  Refreshes external governance status.
+    text: az sql server refresh-external-governance-status --resource_group_name MyResourceGroup --server_name MyServer
+"""
+
 helps['sql server key'] = """
 type: group
 short-summary: Manage a server's keys.

--- a/src/azure-cli/azure/cli/command_modules/sql/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/_params.py
@@ -2017,6 +2017,13 @@ def load_arguments(self, _):
         c.argument('kid',
                    arg_type=kid_param_type,
                    required=True)
+    #####
+    #           sql server refresh-external-governance-status
+    #####
+    with self.argument_context('sql server refresh-external-governance-status') as c:
+        c.argument('server_name',
+                   arg_type=server_param_type)
+        c.argument('resource_group_name', arg_type=resource_group_name_type)
 
     #####
     #           sql server tde-key

--- a/src/azure-cli/azure/cli/command_modules/sql/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/commands.py
@@ -580,6 +580,7 @@ def load_command_table(self, _):
                                  custom_func_name='server_update',
                                  setter_name='begin_create_or_update',
                                  supports_no_wait=True)
+        g.command('refresh-external-governance-status', 'begin_refresh_status')
         g.wait_command('wait')
 
     server_usages_operations = CliCommandType(

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_refresh_external_governance_status.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_refresh_external_governance_status.yaml
@@ -1,0 +1,612 @@
+interactions:
+- request:
+    body: '{"location": "eastus2euap", "properties": {"administratorLogin": "admin123",
+      "administratorLoginPassword": "SecretPassword123", "administrators": {}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"operation":"UpsertLogicalServer","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '74'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverOperationResults/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:00:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:01:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '108'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:01:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"Succeeded","startTime":"2023-03-17T16:00:46.967Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:01:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -l -g -n -u -p
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"kind":"v12.0","properties":{"administratorLogin":"admin123","version":"12.0","state":"Ready","fullyQualifiedDomainName":"clitestserver000002.database.windows.net","privateEndpointConnections":[],"publicNetworkAccess":"Enabled","restrictOutboundNetworkAccess":"Disabled","externalGovernanceStatus":"Disabled"},"location":"eastus2euap","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002","name":"clitestserver000002","type":"Microsoft.Sql/servers"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '539'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:01:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server refresh-external-governance-status
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g --server
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/refreshExternalGovernanceStatus?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"operation":"UpdatePurviewMetadata","startTime":"2023-03-17T16:01:54.467Z"}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '76'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:01:54 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1199'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server refresh-external-governance-status
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"name":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","status":"Succeeded","startTime":"2023-03-17T16:01:54.467Z"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '107'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:02:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sql server refresh-external-governance-status
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g --server
+      User-Agent:
+      - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+  response:
+    body:
+      string: '{"properties":{"requestId":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","requestType":"UpdatePurviewMetadata","queuedTime":"3/17/2023
+        4:01:54 PM","serverName":"clitestserver000002","status":"Succeeded"},"id":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","name":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","type":"Microsoft.Sql/locations/refreshExternalGovernanceStatusOperationResults"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '368'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Fri, 17 Mar 2023 16:02:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_refresh_external_governance_status.yaml
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_refresh_external_governance_status.yaml
@@ -23,10 +23,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"operation":"UpsertLogicalServer","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"operation":"UpsertLogicalServer","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -34,11 +34,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:46 GMT
+      - Fri, 17 Mar 2023 16:08:05 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverOperationResults/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverOperationResults/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
       pragma:
       - no-cache
       server:
@@ -68,10 +68,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -80,7 +80,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:47 GMT
+      - Fri, 17 Mar 2023 16:08:06 GMT
       expires:
       - '-1'
       pragma:
@@ -114,10 +114,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -126,7 +126,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:49 GMT
+      - Fri, 17 Mar 2023 16:08:08 GMT
       expires:
       - '-1'
       pragma:
@@ -160,10 +160,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -172,7 +172,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:50 GMT
+      - Fri, 17 Mar 2023 16:08:09 GMT
       expires:
       - '-1'
       pragma:
@@ -206,10 +206,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -218,7 +218,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:51 GMT
+      - Fri, 17 Mar 2023 16:08:10 GMT
       expires:
       - '-1'
       pragma:
@@ -252,10 +252,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -264,7 +264,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:00:52 GMT
+      - Fri, 17 Mar 2023 16:08:11 GMT
       expires:
       - '-1'
       pragma:
@@ -298,10 +298,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -310,7 +310,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:01:12 GMT
+      - Fri, 17 Mar 2023 16:08:32 GMT
       expires:
       - '-1'
       pragma:
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"InProgress","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"InProgress","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -356,7 +356,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:01:32 GMT
+      - Fri, 17 Mar 2023 16:08:52 GMT
       expires:
       - '-1'
       pragma:
@@ -390,10 +390,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/serverAzureAsyncOperation/23b36854-1e4b-4bbd-8970-737d89e415b4?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"2e5e4d22-c4c5-4f30-98fe-04cf3ca5af62","status":"Succeeded","startTime":"2023-03-17T16:00:46.967Z"}'
+      string: '{"name":"23b36854-1e4b-4bbd-8970-737d89e415b4","status":"Succeeded","startTime":"2023-03-17T16:08:06.517Z"}'
     headers:
       cache-control:
       - no-cache
@@ -402,7 +402,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:01:53 GMT
+      - Fri, 17 Mar 2023 16:09:12 GMT
       expires:
       - '-1'
       pragma:
@@ -448,7 +448,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:01:53 GMT
+      - Fri, 17 Mar 2023 16:09:12 GMT
       expires:
       - '-1'
       pragma:
@@ -487,10 +487,10 @@ interactions:
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/servers/clitestserver000002/refreshExternalGovernanceStatus?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"operation":"UpdatePurviewMetadata","startTime":"2023-03-17T16:01:54.467Z"}'
+      string: '{"operation":"UpdatePurviewMetadata","startTime":"2023-03-17T16:09:14.143Z"}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf?api-version=2022-08-01-preview
       cache-control:
       - no-cache
       content-length:
@@ -498,11 +498,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:01:54 GMT
+      - Fri, 17 Mar 2023 16:09:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf?api-version=2022-08-01-preview
       pragma:
       - no-cache
       server:
@@ -532,10 +532,10 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusAzureAsyncOperation/91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"name":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","status":"Succeeded","startTime":"2023-03-17T16:01:54.467Z"}'
+      string: '{"name":"91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf","status":"Succeeded","startTime":"2023-03-17T16:09:14.143Z"}'
     headers:
       cache-control:
       - no-cache
@@ -544,7 +544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:02:09 GMT
+      - Fri, 17 Mar 2023 16:09:29 GMT
       expires:
       - '-1'
       pragma:
@@ -578,11 +578,11 @@ interactions:
       User-Agent:
       - AZURECLI/2.46.0 azsdk-python-mgmt-sql/4.0.0b8 Python/3.8.0 (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/a9d9f084-77ad-4255-8ff7-0a9de2e1b6be?api-version=2022-08-01-preview
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Sql/locations/eastus2euap/refreshExternalGovernanceStatusOperationResults/91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf?api-version=2022-08-01-preview
   response:
     body:
-      string: '{"properties":{"requestId":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","requestType":"UpdatePurviewMetadata","queuedTime":"3/17/2023
-        4:01:54 PM","serverName":"clitestserver000002","status":"Succeeded"},"id":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","name":"a9d9f084-77ad-4255-8ff7-0a9de2e1b6be","type":"Microsoft.Sql/locations/refreshExternalGovernanceStatusOperationResults"}'
+      string: '{"properties":{"requestId":"91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf","requestType":"UpdatePurviewMetadata","queuedTime":"3/17/2023
+        4:09:14 PM","serverName":"clitestserver000002","status":"Succeeded"},"id":"91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf","name":"91a3ff3d-1f2d-4115-aaab-e49e3b6aacaf","type":"Microsoft.Sql/locations/refreshExternalGovernanceStatusOperationResults"}'
     headers:
       cache-control:
       - no-cache
@@ -591,7 +591,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Fri, 17 Mar 2023 16:02:09 GMT
+      - Fri, 17 Mar 2023 16:09:29 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -180,7 +180,8 @@ class SqlServerExternalGovernanceTests(ScenarioTest):
         self.cmd('sql server refresh-external-governance-status -g {} --server {}'
                  .format(resource_group, server),
                  checks=[
-                     JMESPathCheck('serverName', server)])
+                     JMESPathCheck('serverName', server),
+                     JMESPathCheck('status', 'Succeeded')])
 
 class SqlServerMgmtScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(parameter_name='resource_group_1', location='westeurope')

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -895,8 +895,8 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('ledgerOn', True)])
 
     def test_sql_per_db_cmk(self):
-        server = "extgov-pstest"
-        resource_group = "extgov-pstest-svr"
+        server = "pstestsvr"
+        resource_group = "pstest"
         database_name_one = "cliautomationdb04"
         database_name_two = "cliautomationdb05"
         encryption_protector = "https://pstestkv.vault.azure.net/keys/testkey4/6638b3667e384aefa31364f94d230361"

--- a/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/sql/tests/latest/test_sql_commands.py
@@ -171,6 +171,16 @@ class ManagedInstancePreparer(AbstractPreparer, SingleValueReplacer):
             except ResourceNotFoundError:
                 pass
 
+class SqlServerExternalGovernanceTests(ScenarioTest):
+    
+    @ResourceGroupPreparer(location='eastus2euap')
+    @SqlServerPreparer(location='eastus2euap')
+    def test_sql_refresh_external_governance_status(self, resource_group, resource_group_location, server):
+        
+        self.cmd('sql server refresh-external-governance-status -g {} --server {}'
+                 .format(resource_group, server),
+                 checks=[
+                     JMESPathCheck('serverName', server)])
 
 class SqlServerMgmtScenarioTest(ScenarioTest):
     @ResourceGroupPreparer(parameter_name='resource_group_1', location='westeurope')
@@ -884,8 +894,8 @@ class SqlServerDbMgmtScenarioTest(ScenarioTest):
                      JMESPathCheck('ledgerOn', True)])
 
     def test_sql_per_db_cmk(self):
-        server = "pstestsvr"
-        resource_group = "pstest"
+        server = "extgov-pstest"
+        resource_group = "extgov-pstest-svr"
         database_name_one = "cliautomationdb04"
         database_name_two = "cliautomationdb05"
         encryption_protector = "https://pstestkv.vault.azure.net/keys/testkey4/6638b3667e384aefa31364f94d230361"


### PR DESCRIPTION
**Related command**
az sql server refresh-external-governance-status 

**Description**<!--Mandatory-->

The cmdlet allows user to refresh the external governance status on a server. 

**Testing Guide**
<!--Example commands with explanations.-->
az sql server refresh-external-governance-status --resource-group nitgup-canary --server nitgup-donotdelete-canary

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
