### PR TITLE
[Storage] `az storage blob copy start`: Fix auth issue when providing source uri containing sas token

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -1044,12 +1044,10 @@ def copy_blob(cmd, client, source_url, metadata=None, **kwargs):
                                                source_offset=0, **params)
             return transform_response_with_bytearray(res)
     if kwargs.get('tier') is not None:
-        src_properties = src_client.get_blob_properties()
-        BlobType = cmd.get_models('_models#BlobType')
         tier = kwargs.pop('tier')
-        if src_properties.blob_type == BlobType.BlockBlob:
+        try:
             kwargs["standard_blob_tier"] = getattr(StandardBlobTier, tier)
-        elif src_properties.blob_type == BlobType.PageBlob:
+        except AttributeError:
             PremiumPageBlobTier = cmd.get_models('_models#PremiumPageBlobTier')
             kwargs["premium_page_blob_tier"] = getattr(PremiumPageBlobTier, tier)
     return client.start_copy_from_url(source_url=source_url, metadata=metadata, incremental_copy=False, **kwargs)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob copy start`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
To fix the issue when copying from source uri containing sas token with specific tier:
```
> az storage blob copy start -b test.copy.txt -c tmpcontainer --account-name yssa --source-uri """https://yssa.blob.core.windows.net/tmpcontainer/test.txt?sp=r&st=2023-03-20T04:35:32Z&se=2023-03-20T12:35:32Z&spr=https&sv=2021-12-02&sr=b&sig=y5g%2BkqmQgOiMBS4pCzjPI8Ihd6EG2HcydEhjq0DZiI8%3D"""
 --tier Cool

ERROR: Authentication information is not given in the correct format. Check the value of Authorization header.
ErrorCode:None
```
This error is throw from line 1047
https://github.com/Azure/azure-cli/blob/e072af7d6531998637007b36c4af88c89f91027a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py#L1046-L1055

The `src_client` doesn't contain proper credential. But we actually don't need to call `src_client.get_blob_properties` here.
The `tier` can be either `StandardBlobTier` type or `PremiumPageBlobTier`, we can simply leverage `AttributeError` to identify the correct type

**Testing Guide**
<!--Example commands with explanations.-->
`az storage blob copy start -b $blobName -c $containerName --account-name $accountName --source-uri $sourceWithSAS --tier Archieve/Cool/Hot`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
