### PR TITLE
{AKS} `az aks update`: Remove the error that could not create a role assignment error when the role assignment already exists

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_roleassignments.py
@@ -21,7 +21,7 @@ from azure.cli.command_modules.acs._graph import resolve_object_id
 from azure.cli.command_modules.acs._helpers import get_property_from_dict_or_object
 from azure.cli.core.azclierror import AzCLIError, UnauthorizedError
 from azure.cli.core.profiles import ResourceType, get_sdk
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from knack.log import get_logger
 from knack.prompting import prompt_y_n
 from msrestazure.azure_exceptions import CloudError
@@ -128,7 +128,7 @@ def add_role_assignment(cmd, role, service_principal_msi_id, is_service_principa
             )
             break
         except (CloudError, HttpResponseError) as ex:
-            if ex.message == "The role assignment already exists.":
+            if isinstance(ex, ResourceExistsError) or "The role assignment already exists." in ex.message:
                 break
             logger.info(ex.message)
         except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks update`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In version 2.46.0 of azure-cli, due to the [update of the API](https://github.com/Azure/azure-cli/pull/25452) used by the role assignment-related operations, when the role assignment already exists, the returned error message is changed, and the code that previously performed this type of error checking can no longer handle such error, so that the command finally raise an error similar to `Cannot create a role assignment for xxx...`.

The error message of adding exiting role assignment is (sending request with API version `2022-04-01`)
```
(RoleAssignmentExists) The role assignment already exists.
Code: RoleAssignmentExists
Message: The role assignment already exists.
```

Previously the error message is (sending request with API version `2020-04-01-preview`)
```
The role assignment already exists.
```

- A simple and **recommended** workaround is to use azure-cli of version 2.45.0.
- A complex workaround is to run the command (`az aks update`) with an extra option `--verbose` and check if the error is caused by _role assignment already exists_, if so, please ignore the error as cluster should have been updated successfully.

This issue should only occur in version 2.46.0, and the fix will be [released in 2.47.0](https://github.com/Azure/azure-cli/milestone/128) (available since 04/04). Having aks-preview installed or not won't mitigate the problem.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
