### PR TITLE
{core} `aaz`: Ignore empty folders while loading `aaz` in modules

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -23,6 +23,10 @@ from ._paging import AAZPaged
 from ._poller import AAZLROPoller
 from ._command_ctx import AAZCommandCtx
 from .exceptions import AAZUnknownFieldError, AAZUnregisteredArg
+from knack.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class AAZCommandGroup:
@@ -447,7 +451,13 @@ def _load_aaz_pkg(loader, pkg, parent_command_table, command_group_table, arg_st
         try:
             sub_pkg = importlib.import_module(f'.{sub_path}', pkg.__name__)
         except ModuleNotFoundError:
+            logger.debug('Failed to load package folder in aaz: %s.', os.path.join(pkg_path, sub_path))
             continue
+
+        if not sub_pkg.__file__:
+            logger.debug('Ignore invalid package folder in aaz: %s.', os.path.join(pkg_path, sub_path))
+            continue
+
         # recursively load sub package
         _load_aaz_pkg(loader, sub_pkg, command_table, command_group_table, arg_str, fully_load)
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_command.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_command.py
@@ -12,6 +12,7 @@ from functools import partial
 from knack.commands import CLICommand, PREVIEW_EXPERIMENTAL_CONFLICT_ERROR
 from knack.deprecation import Deprecated
 from knack.experimental import ExperimentalItem
+from knack.log import get_logger
 from knack.preview import PreviewItem
 
 from azure.cli.core.azclierror import CLIInternalError
@@ -23,7 +24,6 @@ from ._paging import AAZPaged
 from ._poller import AAZLROPoller
 from ._command_ctx import AAZCommandCtx
 from .exceptions import AAZUnknownFieldError, AAZUnregisteredArg
-from knack.log import get_logger
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

closed https://github.com/Azure/azure-cli/issues/25878

Ignore the empty or invalid folders while load aaz, the message will be included in debug logs.
![image](https://user-images.githubusercontent.com/69238381/227098229-749bbf40-9af5-4d27-a411-38bc2083d012.png)


**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
