### PR TITLE
{Core} Add actionable message for extension not found error

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/extension/__init__.py
@@ -55,7 +55,7 @@ class ExtensionNotInstalledException(Exception):
         self.extension_name = extension_name
 
     def __str__(self):
-        return "The extension {} is not installed.".format(self.extension_name)
+        return f"The extension {self.extension_name} is not installed. Please install the extension via `az extension add -n {self.extension_name}`."
 
 
 class Extension:

--- a/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
+++ b/src/azure-cli-core/azure/cli/core/extension/tests/latest/test_extension_commands.py
@@ -301,7 +301,8 @@ class TestExtensionCommands(unittest.TestCase):
     def test_update_extension_not_found(self):
         with self.assertRaises(CLIError) as err:
             update_extension(self.cmd, MY_EXT_NAME)
-        self.assertEqual(str(err.exception), 'The extension {} is not installed.'.format(MY_EXT_NAME))
+        self.assertEqual(str(err.exception),
+            f"The extension {MY_EXT_NAME} is not installed. Please install the extension via `az extension add -n {MY_EXT_NAME}`.")
 
     def test_update_extension_no_updates(self):
         logger_msgs = []

--- a/src/azure-cli/azure/cli/command_modules/feedback/tests/latest/test_feedback.py
+++ b/src/azure-cli/azure/cli/command_modules/feedback/tests/latest/test_feedback.py
@@ -138,7 +138,7 @@ class TestCommandLogFile(ScenarioTest):
         # check failed cli command:
         data_dict = command_log_files[0].command_data_dict
         self.assertTrue(data_dict["success"] is False)
-        self.assertEqual("The extension alias is not installed.", data_dict["errors"][0].strip())
+        self.assertEqual("The extension alias is not installed. Please install the extension via `az extension add -n alias`.", data_dict["errors"][0].strip())
         self.assertEqual(data_dict["command_args"], "extension remove -n {}")
 
         # check successful cli command


### PR DESCRIPTION
**Related command**
`az extension add`

**Description**<!--Mandatory-->
If a command requires an extension and said extension is not installed, this change adds an actionable error message rather than the current behavior of only stating the error.

**Testing Guide**
Fixes https://github.com/Azure/azure-cli-extensions/issues/4342
`az network bastion ssh ...`

**History Notes**
[Extension] `az extension add`: Add actionable message for extension not found error

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
