### PR TITLE
{App Service} `az functionapp deployment source config-zip`: Increase read timeout

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1329,7 +1329,7 @@ def _get_app_settings_from_scm(cmd, resource_group_name, name, slot=None):
     }
 
     import requests
-    response = requests.get(settings_url, headers=headers, auth=(username, password), timeout=3)
+    response = requests.get(settings_url, headers=headers, auth=(username, password), timeout=30)
 
     return response.json() or {}
 

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -1317,7 +1317,7 @@ def validate_app_settings_in_scm(cmd, resource_group_name, name, slot=None,
     return True
 
 
-@retryable_method(3, 5)
+@retryable_method(retries=3, interval_sec=5)
 def _get_app_settings_from_scm(cmd, resource_group_name, name, slot=None):
     scm_url = _get_scm_url(cmd, resource_group_name, name, slot)
     settings_url = '{}/api/settings'.format(scm_url)

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -128,10 +128,10 @@ def retryable_method(retries=3, interval_sec=5, excpt_type=Exception):
             while True:
                 try:
                     return func(*args, **kwargs)
-                except excpt_type as exception:  # pylint: disable=broad-except
+                except excpt_type:  # pylint: disable=broad-except
                     current_retry -= 1
                     if current_retry <= 0:
-                        raise exception
+                        raise
                 time.sleep(interval_sec)
         return call
     return decorate


### PR DESCRIPTION
**Related command**

```sh
az functionapp deployment source config-zip --name "$(myFuncName)" --resource-group "$(myRg)" --src "myZipFile"
```

**Description**<!--Mandatory-->

Attempt to fix #13655.

Exact error I am seeing:

```

    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/opt/az/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/custom.py", line 531, in enable_zip_deploy_functionapp
    remove_remote_build_app_settings(cmd, resource_group_name, name, slot)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/custom.py", line 671, in remove_remote_build_app_settings
    scm_is_up_to_date = validate_app_settings_in_scm(
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/custom.py", line 1230, in validate_app_settings_in_scm
    scm_settings = _get_app_settings_from_scm(cmd, resource_group_name, name, slot)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/utils.py", line 134, in call
    raise exception
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/utils.py", line 130, in call
    return func(*args, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/azure/cli/command_modules/appservice/custom.py", line 1259, in _get_app_settings_from_scm
    response = requests.get(settings_url, headers=headers, auth=(username, password), timeout=3)
  File "/opt/az/lib/python3.10/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/opt/az/lib/python3.10/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/opt/az/lib/python3.10/site-packages/requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)
requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='my-function-name.scm.azurewebsites.net', port=443): Read timed out. (read timeout=3)

```

**Testing Guide**

N/A

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{functionapp} longer read timeout when fetching Source Control Manager (SCM) settings

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
