### PR TITLE
[App Service] `az staticwebapp appsettings`: Add `--environment-name` parameter to allow app setting operation on preview environments

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_help.py
@@ -2556,6 +2556,8 @@ helps['staticwebapp appsettings list'] = """
     examples:
     - name: List app settings of the static app.
       text: az staticwebapp appsettings list -n MyStaticAppName
+    - name: List app settings of the static app environment.
+      text: az staticwebapp appsettings list -n MyStaticAppName --environment-name MyEnvironmentName
 """
 
 helps['staticwebapp appsettings set'] = """
@@ -2564,6 +2566,8 @@ helps['staticwebapp appsettings set'] = """
     examples:
     - name: Add to or change the app settings of the static app.
       text: az staticwebapp appsettings set -n MyStaticAppName --setting-names key1=val1 key2=val2
+    - name: Add to or change the app settings of the static app environment.
+      text: az staticwebapp appsettings set -n MyStaticAppName --setting-names key1=val1 key2=val2 --environment-name MyEnvironmentName
 """
 
 helps['staticwebapp appsettings delete'] = """
@@ -2572,6 +2576,8 @@ helps['staticwebapp appsettings delete'] = """
     examples:
     - name: Delete given app settings of the static app.
       text: az staticwebapp appsettings delete -n MyStaticAppName --setting-names key1 key2
+    - name: Delete given app settings of the static app.
+      text: az staticwebapp appsettings delete -n MyStaticAppName --setting-names key1 key2 --environment-name MyEnvironmentName
 """
 
 helps['staticwebapp identity'] = """

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -1100,6 +1100,7 @@ subscription than the app service environment, please use the resource ID for --
                    help="Validation method for the custom domain.",
                    arg_type=get_enum_type(["cname-delegation", "dns-txt-token"]))
     with self.argument_context('staticwebapp appsettings') as c:
+        c.argument('environment_name', help="Name of the environment of static site")
         c.argument('setting_pairs', options_list=['--setting-names'],
                    help="Space-separated app settings in 'key=value' format. ",
                    nargs='*')

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -272,15 +272,17 @@ def list_staticsite_functions(cmd, name, resource_group_name=None, environment_n
     return client.list_static_site_build_functions(resource_group_name, name, environment_name)
 
 
-def list_staticsite_app_settings(cmd, name, resource_group_name=None):
+def list_staticsite_app_settings(cmd, name, resource_group_name=None, environment_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
 
-    return client.list_static_site_app_settings(resource_group_name, name)
+    if not environment_name:
+        return client.list_static_site_app_settings(resource_group_name, name)
 
+    return client.list_static_site_build_app_settings(resource_group_name, name, environment_name)
 
-def set_staticsite_app_settings(cmd, name, setting_pairs, resource_group_name=None):
+def set_staticsite_app_settings(cmd, name, setting_pairs, resource_group_name=None, environment_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
@@ -291,20 +293,23 @@ def set_staticsite_app_settings(cmd, name, setting_pairs, resource_group_name=No
         setting_dict[key] = value
 
     # fetch current settings to prevent deleting existing app settings
-    settings = list_staticsite_app_settings(cmd, name, resource_group_name)
+    app_settings = list_staticsite_app_settings(cmd, name, resource_group_name, environment_name)
     for k, v in setting_dict.items():
-        settings.properties[k] = v
+        app_settings.properties[k] = v
 
-    return client.create_or_update_static_site_app_settings(
-        resource_group_name, name, app_settings=settings)
+    if not environment_name:
+        return client.create_or_update_static_site_app_settings(
+            resource_group_name, name, app_settings=app_settings)
 
+    return client.create_or_update_static_site_build_app_settings(
+        resource_group_name, name, environment_name, app_settings=app_settings)
 
-def delete_staticsite_app_settings(cmd, name, setting_names, resource_group_name=None):
+def delete_staticsite_app_settings(cmd, name, setting_names, resource_group_name=None, environment_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
         resource_group_name = _get_resource_group_name_of_staticsite(client, name)
 
-    app_settings = client.list_static_site_app_settings(resource_group_name, name)
+    app_settings = list_staticsite_app_settings(cmd, name, resource_group_name, environment_name)
 
     for key in setting_names:
         if key in app_settings.properties:
@@ -312,9 +317,12 @@ def delete_staticsite_app_settings(cmd, name, setting_names, resource_group_name
         else:
             logger.warning("key '%s' not found in app settings", key)
 
-    return client.create_or_update_static_site_app_settings(
-        resource_group_name, name, app_settings=app_settings)
+    if not environment_name:
+        return client.create_or_update_static_site_app_settings(
+            resource_group_name, name, app_settings=app_settings)
 
+    return client.create_or_update_static_site_build_app_settings(
+        resource_group_name, name, environment_name, app_settings=app_settings)
 
 def list_staticsite_users(cmd, name, resource_group_name=None, authentication_provider='all'):
     client = _get_staticsites_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/static_sites.py
@@ -282,6 +282,7 @@ def list_staticsite_app_settings(cmd, name, resource_group_name=None, environmen
 
     return client.list_static_site_build_app_settings(resource_group_name, name, environment_name)
 
+
 def set_staticsite_app_settings(cmd, name, setting_pairs, resource_group_name=None, environment_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
@@ -304,6 +305,7 @@ def set_staticsite_app_settings(cmd, name, setting_pairs, resource_group_name=No
     return client.create_or_update_static_site_build_app_settings(
         resource_group_name, name, environment_name, app_settings=app_settings)
 
+
 def delete_staticsite_app_settings(cmd, name, setting_names, resource_group_name=None, environment_name=None):
     client = _get_staticsites_client_factory(cmd.cli_ctx)
     if not resource_group_name:
@@ -323,6 +325,7 @@ def delete_staticsite_app_settings(cmd, name, setting_names, resource_group_name
 
     return client.create_or_update_static_site_build_app_settings(
         resource_group_name, name, environment_name, app_settings=app_settings)
+
 
 def list_staticsite_users(cmd, name, resource_group_name=None, authentication_provider='all'):
     client = _get_staticsites_client_factory(cmd.cli_ctx)

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -404,13 +404,13 @@ class TestStaticAppCommands(unittest.TestCase):
         # validate
         self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
 
-    def test_list_staticsite_app_settings_with_environment(self):
+    def test_list_staticsite_app_settings_with_resourcegroup_with_environment(self):
         list_staticsite_app_settings(self.mock_cmd, self.name1, self.rg1, self.environment1)
 
         self.staticapp_client.list_static_site_build_app_settings.assert_called_once_with(
             self.rg1, self.name1, self.environment1)
 
-    def test_set_staticsite_app_settings_with_environment(self):
+    def test_set_staticsite_app_settings_with_resourcegroup_with_environment(self):
         from azure.mgmt.web.models import StringDictionary
 
         app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
@@ -421,7 +421,7 @@ class TestStaticAppCommands(unittest.TestCase):
 
         self.staticapp_client.create_or_update_static_site_build_app_settings.assert_called_once()
 
-    def test_delete_staticsite_app_settings_with_environment(self):
+    def test_delete_staticsite_app_settings_with_resourcegroup_with_environment(self):
         # setup
         current_app_settings = {'key1': 'val1', 'key2': 'val2'}
         app_settings_keys_to_delete = ['key1']

--- a/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tests/latest/test_staticapp_commands_thru_mock.py
@@ -404,6 +404,39 @@ class TestStaticAppCommands(unittest.TestCase):
         # validate
         self.staticapp_client.create_or_update_static_site_app_settings.assert_called_once()
 
+    def test_list_staticsite_app_settings_with_environment(self):
+        list_staticsite_app_settings(self.mock_cmd, self.name1, self.rg1, self.environment1)
+
+        self.staticapp_client.list_static_site_build_app_settings.assert_called_once_with(
+            self.rg1, self.name1, self.environment1)
+
+    def test_set_staticsite_app_settings_with_environment(self):
+        from azure.mgmt.web.models import StringDictionary
+
+        app_settings1_input = ['key1=val1', 'key2=val2==', 'key3=val3=']
+
+        self.staticapp_client.list_static_site_build_app_settings.return_value = StringDictionary(properties={})
+
+        set_staticsite_app_settings(self.mock_cmd, self.name1, app_settings1_input, self.rg1, self.environment1)
+
+        self.staticapp_client.create_or_update_static_site_build_app_settings.assert_called_once()
+
+    def test_delete_staticsite_app_settings_with_environment(self):
+        # setup
+        current_app_settings = {'key1': 'val1', 'key2': 'val2'}
+        app_settings_keys_to_delete = ['key1']
+
+        class AppSettings:
+            properties = current_app_settings
+
+        self.staticapp_client.list_static_site_build_app_settings.return_value = AppSettings
+
+        # action
+        delete_staticsite_app_settings(self.mock_cmd, self.name1, app_settings_keys_to_delete, self.rg1, self.environment1)
+
+        # validate
+        self.staticapp_client.create_or_update_static_site_build_app_settings.assert_called_once()
+
     def test_list_staticsite_users_with_resourcegroup(self):
         authentication_provider = 'GitHub'
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az staticwebapp appsettings`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In the `az staticwebapp appsettings` command today, we do not provide any way for app setting operations to be made against the non-production preview environments of a static web app. This PR surfaces the `--environment-name` parameter on app setting requests to allow for this.

**Testing Guide**
<!--Example commands with explanations.-->
Added unit tests and also ran commands like:

`az staticwebapp appsettings list -n MyAppName -g MyResourceGroup --environment-name preview`
`az staticwebapp appsettings set -n MyAppName -g MyResourceGroup --environment-name preview --setting-names key1=val1 key2=val2`
`az staticwebapp appsettings delete -n MyAppName -g MyResourceGroup --environment-name preview --setting-names key2 missingkey`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
