### PR TITLE
[ARM] Fix: `az bicep install`: Use CA bundle environment variables if set

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -38,11 +38,11 @@ class TestBicep(unittest.TestCase):
     @mock.patch("os.stat")
     @mock.patch("io.BufferedWriter")
     @mock.patch("azure.cli.command_modules.resource._bicep.open")
-    @mock.patch("azure.cli.command_modules.resource._bicep.urlopen")
     @mock.patch("os.path.exists")
     @mock.patch("os.path.dirname")
     @mock.patch("os.path.isfile")
-    def test_use_bicep_cli_from_path_false_after_install(self, isfile_stub, dirname_stub, exists_stub, urlopen_stub, open_stub, buffered_writer_stub, stat_stub, chmod_stub):
+    @mock.patch('requests.request', autospec=True)
+    def test_use_bicep_cli_from_path_false_after_install(self, isfile_stub, dirname_stub, exists_stub, mock_requests_get, open_stub, buffered_writer_stub, stat_stub, chmod_stub):
         isfile_stub.return_value = False
         dirname_stub.return_value = "tmp"
         exists_stub.return_value = True
@@ -54,10 +54,11 @@ class TestBicep(unittest.TestCase):
 
         chmod_stub.return_value = None
 
-        response = mock.Mock()
-        response.getcode.return_value = 200
-        response.read.return_value = b"test"
-        urlopen_stub.return_value = response
+        response = mock.MagicMock()
+        response.headers = {}
+        response.status_code = 200
+        response.content = b"test"
+        mock_requests_get.return_value = response
 
         ensure_bicep_installation(cli_ctx, release_tag="v0.14.85", stdout=False)
 


### PR DESCRIPTION
**Related command**
`az bicep install`

**Description**
Added a fallback order equivalent to the one found in the requests package. Also removed the unneeded setdefaults. See #21807 for history, and the [recent comment](https://github.com/Azure/azure-cli/pull/21807/commits/14bf8bbbd571b7ae78f6cd396f2bad0de0d51fa5#r1153983808) done by @jiasli

closes #26007

**Testing Guide**
A clean environment should use the certifi CA bundle path:

```sh
env -i az bicep install
```

If either `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` is set, then it should be picked up:

```sh
env -i REQUESTS_CA_BUNDLE=/path/to/cacert1.pem az bicep install
env -i CURL_CA_BUNDLE=/path/to/cacert1.pem az bicep install
```

If both `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` are set, then it should use `REQUESTS_CA_BUNDLE` (this is by definition of the requests package).

**History Notes**

[ARM] `az bicep install`: Use CA bundle environment variables if set

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
