### PR TITLE
{CI} Install `ca-certificates` in Mariner docker container

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -683,52 +683,52 @@ jobs:
       TargetPath: $(Build.ArtifactStagingDirectory)
       ArtifactName: $(artifact)
 
-#- job: TestRpmPackageMariner
-#  displayName: Test Rpm Package Mariner
-#  timeoutInMinutes: 120
-#  dependsOn:
-#  - BuildRpmPackageMariner
-#  - ExtractMetadata
-#  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
-#  pool:
-#    name: $(pool)
-#  strategy:
-#    matrix:
-#      2.0 AMD64:
-#        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-#        artifact: rpm-mariner2.0-amd64
-#        pool: ${{ variables.ubuntu_pool }}
-#      2.0 ARM64:
-#        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
-#        artifact: rpm-mariner2.0-arm64
-#        pool: ${{ variables.ubuntu_arm64_pool }}
-#  steps:
-#  - task: DownloadPipelineArtifact@1
-#    displayName: 'Download Metadata'
-#    inputs:
-#      TargetPath: '$(Build.ArtifactStagingDirectory)/metadata'
-#      artifactName: metadata
-#
-#  - task: DownloadPipelineArtifact@1
-#    displayName: 'Download Build Artifacts'
-#    inputs:
-#      TargetPath: '$(Build.ArtifactStagingDirectory)/rpm'
-#      artifactName: $(artifact)
-#
-#  - bash: ./scripts/ci/install_docker.sh
-#    displayName: Install Docker
-#
-#  - bash: |
-#      set -ex
-#
-#      CLI_VERSION=`cat $SYSTEM_ARTIFACTSDIRECTORY/metadata/version`
-#      RPM_NAME=$(find $SYSTEM_ARTIFACTSDIRECTORY/rpm/ -type f -name "azure-cli-$CLI_VERSION-1.cm2.*.rpm" -printf '%f\n')
-#
-#      echo "== Test rpm package on ${IMAGE} =="
-#      docker pull $IMAGE
-#      docker run --rm -e RPM_NAME=$RPM_NAME -v $SYSTEM_ARTIFACTSDIRECTORY/rpm:/mnt/rpm -v $(pwd):/azure-cli $IMAGE /bin/bash "/azure-cli/scripts/release/rpm/test_mariner_in_docker.sh"
-#
-#    displayName: 'Test Rpm Package Mariner'
+- job: TestRpmPackageMariner
+  displayName: Test Rpm Package Mariner
+  timeoutInMinutes: 120
+  dependsOn:
+  - BuildRpmPackageMariner
+  - ExtractMetadata
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
+  pool:
+    name: $(pool)
+  strategy:
+    matrix:
+      2.0 AMD64:
+        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
+        artifact: rpm-mariner2.0-amd64
+        pool: ${{ variables.ubuntu_pool }}
+      2.0 ARM64:
+        image: mcr.microsoft.com/cbl-mariner/base/core:2.0
+        artifact: rpm-mariner2.0-arm64
+        pool: ${{ variables.ubuntu_arm64_pool }}
+  steps:
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download Metadata'
+    inputs:
+      TargetPath: '$(Build.ArtifactStagingDirectory)/metadata'
+      artifactName: metadata
+
+  - task: DownloadPipelineArtifact@1
+    displayName: 'Download Build Artifacts'
+    inputs:
+      TargetPath: '$(Build.ArtifactStagingDirectory)/rpm'
+      artifactName: $(artifact)
+
+  - bash: ./scripts/ci/install_docker.sh
+    displayName: Install Docker
+
+  - bash: |
+      set -ex
+
+      CLI_VERSION=`cat $SYSTEM_ARTIFACTSDIRECTORY/metadata/version`
+      RPM_NAME=$(find $SYSTEM_ARTIFACTSDIRECTORY/rpm/ -type f -name "azure-cli-$CLI_VERSION-1.cm2.*.rpm" -printf '%f\n')
+
+      echo "== Test rpm package on ${IMAGE} =="
+      docker pull $IMAGE
+      docker run --rm -e RPM_NAME=$RPM_NAME -v $SYSTEM_ARTIFACTSDIRECTORY/rpm:/mnt/rpm -v $(pwd):/azure-cli $IMAGE /bin/bash "/azure-cli/scripts/release/rpm/test_mariner_in_docker.sh"
+
+    displayName: 'Test Rpm Package Mariner'
 
 # TODO: rpmbuild on Red Hat UBI 8 is slow for unknown reason. Still working with Red Hat to investigate.
 - job: BuildRpmPackages

--- a/scripts/release/rpm/mariner.dockerfile
+++ b/scripts/release/rpm/mariner.dockerfile
@@ -4,8 +4,13 @@ FROM ${image} AS build-env
 ARG cli_version=dev
 
 RUN tdnf update -y
+
 # kernel-headers, glibc-devel, binutils are needed to install psutil python package on ARM64
-RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch dos2unix perl sed kernel-headers glibc-devel binutils
+# ca-certificates: Mariner by default only adds a very minimal set of root certs to trust certain Microsoft
+# resources (primarily packages.microsoft.com). ca-certificates contains the official Microsoft curated set of
+# trusted root certificates. It has replaced the set of Mozilla Trusted Root Certificates.
+RUN tdnf install -y binutils file rpm-build gcc libffi-devel python3-devel openssl-devel make diffutils patch \
+    dos2unix perl sed kernel-headers glibc-devel binutils ca-certificates
 
 WORKDIR /azure-cli
 

--- a/scripts/release/rpm/test_mariner_in_docker.sh
+++ b/scripts/release/rpm/test_mariner_in_docker.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-# This script should be run in a centos7 docker.
+# This script should be run in a Mariner 2.0 docker container.
 set -exv
 
 export USERNAME=azureuser
 
 tdnf --nogpgcheck install /mnt/rpm/$RPM_NAME -y
 
-tdnf install git gcc python3-devel python3-pip findutils -y
+tdnf install git gcc python3-devel python3-pip findutils ca-certificates -y
 
 ln -s -f /usr/bin/python3 /usr/bin/python
 time az self-test


### PR DESCRIPTION
**Description**<!--Mandatory-->
Revert https://github.com/Azure/azure-cli/pull/26005

According to https://eng.ms/docs/products/mariner-linux/gettingstarted/containers/marinercontainerimage

> (Mariner) By default containers include a limited set of [root certificates](https://eng.ms/docs/products/mariner-linux/gettingstarted/packages/certificates) specifically for trusting Microsoft specific web sites like packages.microsoft.com. More complete sets of root certificates may be installed if necessary. Click [here](https://eng.ms/docs/products/mariner-linux/gettingstarted/packages/certificates) to read more.

Now we have to manually install `ca-certificates` to allow Azure CLI on Mariner to access addresses such as

https://github.com/Azure/azure-cli/blob/36786c51a5d42ff1b0a197e72a2c12261ff6743b/src/azure-cli/azure/cli/command_modules/resource/_bicep.py#L278

https://github.com/Azure/azure-cli/blob/4b86ba6619f1d84d91599822d361cbc6d1ba7648/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py#L42

