### PR TITLE
[EventHub] `az eventhubs namespace application-group policy remove`: Add upcoming breaking change notification

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -622,7 +622,8 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
 
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
     logger.warning(
-        'This operation will do removals based on policy name')
+        'This operation will do removals based on policy name. Will not accept metric-id,rate-limit-threshold in the future.'
+        'Also throttling_policy_config will replace with policy only.')
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -623,8 +623,8 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
 
     logger.warning(
-        'Parameter metric-id,rate-limit-threshold would not be required for a command eventhub application-group policy remove in future release '
-        'and the new policy remove cmdlets will br contain only name.')
+        'the policy remove policy cmdlets will do removals based on policy name')
+    
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -622,8 +622,8 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
 
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
     logger.warning(
-        'This operation will do removals based on policy name. Will not accept metric-id,rate-limit-threshold in the future.'
-        'Also throttling_policy_config will replace with policy only.')
+        'This operation will do removals based on policy name. Will not accept metric-id,rate-limit-threshold in the future in future release.'
+        'Also throttling_policy_config parameter will replace with "policy" in same future release.')
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -622,7 +622,7 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
 
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
     logger.warning(
-        'the policy remove policy cmdlets will do removals based on policy name')
+        'This operation will do removals based on policy name')
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -621,10 +621,8 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
     from azure.cli.core import CLIError
 
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
-
     logger.warning(
         'the policy remove policy cmdlets will do removals based on policy name')
-    
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -622,6 +622,9 @@ def cli_remove_appgroup_policy(client, resource_group_name, namespace_name, appl
 
     appGroup = client.get(resource_group_name, namespace_name, application_group_name)
 
+    logger.warning(
+        'Parameter metric-id,rate-limit-threshold would not be required for a command eventhub application-group policy remove in future release '
+        'and the new policy remove cmdlets will br contain only name.')
     if appGroup.policies:
         for policy_object in throttling_policy_config:
             if policy_object in appGroup.policies:


### PR DESCRIPTION
**Related command**
`az eventhubs namespace application-group policy remove`

**Description**<!--Mandatory-->
Removing parameters metric-id, rate-limit-threshold from --throttling-policy-config object only for `az eventhubs namespace application-group policy remove` command.
Additionally changing `throttling-policy-config` name to `policy`,  for `az eventhubs namespace application-group policy remove` command. 
The change will release in Upcoming breaking change cycle i.e May.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
