### PR TITLE
{AzureBotService} fix for the AttributeError in 'az bot show' CLI command

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
@@ -91,8 +91,8 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
             'appPassword': app_password,
             'endpoint': raw_bot_properties.properties.endpoint,
             'resourceGroup': str(resource_group_name),
-            'tenantId': profile.get_subscription(subscription=client._config.subscription_id)['tenantId'],
-            'subscriptionId': client._config.subscription_id,
+            'tenantId': profile.get_subscription(subscription=client._config.subscription_id)['tenantId'], # pylint: disable=protected-access
+            'subscriptionId': client._config.subscription_id, # pylint: disable=protected-access
             'serviceName': resource_name
         }
 

--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
@@ -91,8 +91,8 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
             'appPassword': app_password,
             'endpoint': raw_bot_properties.properties.endpoint,
             'resourceGroup': str(resource_group_name),
-            'tenantId': profile.get_subscription(subscription=client._config.subscription_id)['tenantId'], # pylint: disable=protected-access
-            'subscriptionId': client._config.subscription_id, # pylint: disable=protected-access
+            'tenantId': profile.get_subscription(subscription=client._config.subscription_id)['tenantId'],  # pylint:disable=protected-access
+            'subscriptionId': client._config.subscription_id,  # pylint:disable=protected-access
             'serviceName': resource_name
         }
 

--- a/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
+++ b/src/azure-cli/azure/cli/command_modules/botservice/bot_json_formatter.py
@@ -91,8 +91,8 @@ class BotJsonFormatter:  # pylint:disable=too-few-public-methods
             'appPassword': app_password,
             'endpoint': raw_bot_properties.properties.endpoint,
             'resourceGroup': str(resource_group_name),
-            'tenantId': profile.get_subscription(subscription=client.config.subscription_id)['tenantId'],
-            'subscriptionId': client.config.subscription_id,
+            'tenantId': profile.get_subscription(subscription=client._config.subscription_id)['tenantId'],
+            'subscriptionId': client._config.subscription_id,
             'serviceName': resource_name
         }
 


### PR DESCRIPTION

Fixes Azure/azure-cli#26037

While running the CLI command `az bot show -n botnaem -g rsourcegroupname --msbot` we get the below error:

```
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/init.py", line 697, in _run_job
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/init.py", line 333, in call
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 363, in handler
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/arm.py", line 429, in show_exception_handler
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/command_operation.py", line 361, in handler
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/botservice/custom.py", line 179, in get_bot
File "D:\a_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/botservice/bot_json_formatter.py", line 94, in create_bot_json
AttributeError: 'AzureBotService' object has no attribute 'config'
```

THis PR has the fix for the above error.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
