### PR TITLE
{Telemetry} Shorten default push interval from 24h to 6h

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -74,9 +74,9 @@ class RecordsCollection:
 
     def _get_push_interval_config(self):
         config = CLIConfig(config_dir=self._config_dir)
-        threshold = config.getint('telemetry', 'push_interval_in_hours', fallback=24)
-        # the threshold for push telemetry can't be less than 1 hour, default value is 24 hours
-        return threshold if threshold >= 1 else 24
+        threshold = config.getint('telemetry', 'push_interval_in_hours', fallback=6)
+        # the threshold for push telemetry can't be less than 1 hour, default value is 6 hours
+        return threshold if threshold >= 1 else 6
 
     def _read_file(self, path):
         """ Read content of a telemetry cache file and parse them into records. """

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
@@ -42,11 +42,11 @@ class TestRecordsCollection(unittest.TestCase):
         self.assertEqual(1758, len([r for r in collection]))
 
     def test_create_records_collection_with_last_send(self):
-        last_send = datetime.datetime.now() - datetime.timedelta(hours=6)
+        last_send = datetime.datetime.now() - datetime.timedelta(hours=2)
         collection = RecordsCollection(last_send, self.work_dir)
         collection.snapshot_and_read()
 
-        # the threshold for pushing 'cache' file is 24, so 'cache' file should not be moved
+        # the threshold for pushing 'cache' file is 6, so 'cache' file should not be moved
         self.assert_cache_files_count(1)
         # no new records since last_send
         self.assertEqual(0, len([r for r in collection]))


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We decide to drop CLI telemetry local cache because of
- CLI telemetry local cache strategy has introduced a lot of troubles
- Learning from PSH and VSCode, we know that they don't have any local cache
- Carl from devdiv data team has confirmed that the application insight's quota is highly customizable.

We don't want to drop local cache by one night so things need to change step by step:
1. Shorten the cache push interval from 24 hours to 6 hours
2. Wait for few CLI versions until the usage of 6hours interval grows up to 50% and see if there's any risks
3. Shorten the cache push interval from 6 hours to 1 hour
4. Repeat step 2
5. Totally remove local cache

This PR is for step 1

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
