### PR TITLE
{AKS} Fix aks install cli test 0407 (#26073)

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -645,10 +645,10 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = os.path.realpath(tempfile.mkdtemp())  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'kubelogin')
-            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
+            # 2 warnings, 1st for download result, 2nd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 2)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 
@@ -659,7 +659,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
-            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertTrue(os.path.exists(test_location))
         finally:
             shutil.rmtree(temp_dir)
@@ -688,7 +688,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
             test_ver = '1.2.6'
             test_source_url = 'http://url2'
-            k8s_install_kubelogin(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url)
+            k8s_install_kubelogin(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url, arch="amd64")
             mock_url_retrieve.assert_called_with(mockUrlretrieveUrlValidator(test_source_url, test_ver), mock.ANY)
         finally:
             shutil.rmtree(temp_dir)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -629,10 +629,10 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = os.path.realpath(tempfile.mkdtemp())  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'kubelogin')
-            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 3 warnings, 1st for arch, 2nd for download result, 3rd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
+            # 2 warnings, 1st for download result, 2nd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 
@@ -643,7 +643,7 @@ class AcsCustomCommandTest(unittest.TestCase):
         try:
             temp_dir = tempfile.mkdtemp()  # tempfile.TemporaryDirectory() is no available on 2.7
             test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
-            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location)
+            k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertTrue(os.path.exists(test_location))
         finally:
             shutil.rmtree(temp_dir)
@@ -672,7 +672,7 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'foo', 'kubelogin')
             test_ver = '1.2.6'
             test_source_url = 'http://url2'
-            k8s_install_kubelogin(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url)
+            k8s_install_kubelogin(mock.MagicMock(), client_version=test_ver, install_location=test_location, source_url=test_source_url, arch="amd64")
             mock_url_retrieve.assert_called_with(MockUrlretrieveUrlValidator(test_source_url, test_ver), mock.ANY)
         finally:
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
Alternative PR #26072 for testing batch CI

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks install-cli`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In PR [#26035](https://github.com/Azure/azure-cli/pull/26035), the command `az aks install-cli` starts to support the distinction between arm64 and amd64 architectures, but in some test cases, the mock binary is hardcoded with amd64 arch.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
