### PR TITLE
[Dms] `az dms project tack create`: Add support for database schema migration

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -191,7 +191,7 @@ long-summary: |
     -) source -> target :: task type
     1) SQL -> SQLDB :: OfflineMigration
     2) PostgreSQL -> AzureDbForPostgreSql :: OnlineMigration
-    3) MySQL -> AzureDbForMySQL :: OfflineMigration
+    3) MySQL -> AzureDbForMySQL :: OfflineMigration, OnlineMigration, ReplicateChanges
 parameters:
   - name: --task-type
     type: string
@@ -288,7 +288,7 @@ parameters:
                     'selected_events': [
                         'sourceSchema1.nightly_maintenance'
                     ],
-                    // Optional. If true, the database will be selected for schema migration.
+                    // Optional. If true, DMS will migrate the source database schema to the target.
                     "select_database_for_schema_migration": "true|false"
                 },
                 ...n

--- a/src/azure-cli/azure/cli/command_modules/dms/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/_help.py
@@ -287,7 +287,9 @@ parameters:
                     // optional, migrates the enumerated events
                     'selected_events': [
                         'sourceSchema1.nightly_maintenance'
-                    ]
+                    ],
+                    // Optional. If true, the database will be selected for schema migration.
+                    "select_database_for_schema_migration": "true|false"
                 },
                 ...n
             ],

--- a/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
@@ -189,6 +189,7 @@ def create_db_input(database, has_schema_migration_options):
         set_optional(db_properties, 'selectedTriggers', database, 'selected_triggers', throw_if_not_list)
         set_optional(db_properties, 'selectedRoutines', database, 'selected_routines', throw_if_not_list)
         set_optional(db_properties, 'selectedEvents', database, 'selected_events', throw_if_not_list)
+        set_optional(db_properties, 'selectDatabaseForSchemaMigration', database, 'select_database_for_schema_migration')
 
         if len(db_properties) > 0:
             db_input.additional_properties = db_properties

--- a/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
+++ b/src/azure-cli/azure/cli/command_modules/dms/scenario_inputs.py
@@ -189,7 +189,10 @@ def create_db_input(database, has_schema_migration_options):
         set_optional(db_properties, 'selectedTriggers', database, 'selected_triggers', throw_if_not_list)
         set_optional(db_properties, 'selectedRoutines', database, 'selected_routines', throw_if_not_list)
         set_optional(db_properties, 'selectedEvents', database, 'selected_events', throw_if_not_list)
-        set_optional(db_properties, 'selectDatabaseForSchemaMigration', database, 'select_database_for_schema_migration')
+        set_optional(db_properties,
+                     'selectDatabaseForSchemaMigration',
+                     database,
+                     'select_database_for_schema_migration')
 
         if len(db_properties) > 0:
             db_input.additional_properties = db_properties


### PR DESCRIPTION
**Related command**
az dms project task create

**Description**<!--Mandatory-->
This change enables database schema migration for MySQL migrations.

**Testing Guide**
<!--Example commands with explanations.-->



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
