### PR TITLE
{EventHub} `az eventhubs cluster create/update` Add breaking change message for --tags parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -142,7 +142,7 @@ def cli_cluster_create(cmd, client, resource_group_name, cluster_name, location=
             ehparam.supports_scaling = supports_scaling
         logger.warning('Instead of key1=val1, the tags parameter should be used as "{key1:val1}".'
                        'If more than one value is present, the format will be "{key1:val1,key2:val2}".'
-                       '')
+                       'Use --tags key1=null to delete the unused key1 tags')
         ehparam.tags = tags
 
         cluster_result = client.begin_create_or_update(

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -140,7 +140,9 @@ def cli_cluster_create(cmd, client, resource_group_name, cluster_name, location=
 
         if supports_scaling is not None:
             ehparam.supports_scaling = supports_scaling
-
+        logger.warning('Instead of key1=val1, the tags parameter should be used as "{key1:val1}".'
+                       'If more than one value is present, the format will be "{key1:val1,key2:val2}".'
+                       '')
         ehparam.tags = tags
 
         cluster_result = client.begin_create_or_update(


### PR DESCRIPTION
**Related command**
`az eventhubs cluster create/update`

**Description**<!--Mandatory-->
Instead of key1=val1, the tags parameter should be used as "{key1:val1}". If more than one value is present, the format will be "{key1:val1,key2:val2}". Use --tags key1=null to delete the unused key1 tags

**Testing Guide**
**Current Command:**
`az eventhubs cluster update --resource-group {rg} --name {clustername} --tags tag2=value2 `

**Future Release**
`az eventhubs cluster update --resource-group {rg} --name {clustername} --tags "{tag2:value2}" `

Similar for create command too.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
