### PR TITLE
{EventHub} Add Breaking change message for `az eventhubs namespace network-rule` cmdlets.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
@@ -177,9 +177,9 @@ def load_arguments_eh(self, _):
     for scope in ['eventhubs namespace network-rule add', 'eventhubs namespace network-rule remove']:
         with self.argument_context(scope, resource_type=ResourceType.MGMT_EVENTHUB, min_api='2017-04-01') as c:
             c.argument('subnet', arg_group='Virtual Network Rule', options_list=['--subnet'], help='Name or ID of subnet. If name is supplied, `--vnet-name` must be supplied.')
-            c.argument('ip_mask', arg_group='IP Address Rule', options_list=['--ip-address'], help='IPv4 address or CIDR range - 10.6.0.0/24')
+            c.argument('ip_mask', arg_group='IP Address Rule', options_list=['--ip-address'], help='IPv4 address or CIDR range - 10.6.0.0/24', deprecate_info=c.deprecate(redirect='--ip-rule', expiration='2.50.0'))
             c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of the Namespace')
-            c.extra('vnet_name', arg_group='Virtual Network Rule', options_list=['--vnet-name'], help='Name of the Virtual Network')
+            c.extra('vnet_name', arg_group='Virtual Network Rule', options_list=['--vnet-name'], help='Name of the Virtual Network', deprecate_info=c.deprecate(expiration='2.50.0'))
 
     with self.argument_context('eventhubs namespace network-rule update', resource_type=ResourceType.MGMT_EVENTHUB, min_api='2017-04-01') as c:
         c.argument('public_network_access', options_list=['--public-network-access', '--public-network'], arg_type=get_enum_type(['Enabled', 'Disabled']), help='This determines if traffic is allowed over public network. By default it is enabled. If value is SecuredByPerimeter then Inbound and Outbound communication is controlled by the network security perimeter and profile\' access rules.')

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
@@ -179,7 +179,7 @@ def load_arguments_eh(self, _):
             c.argument('subnet', arg_group='Virtual Network Rule', options_list=['--subnet'], help='Name or ID of subnet. If name is supplied, `--vnet-name` must be supplied.')
             c.argument('ip_mask', arg_group='IP Address Rule', options_list=['--ip-address'], help='IPv4 address or CIDR range - 10.6.0.0/24', deprecate_info=c.deprecate(redirect='--ip-rule', expiration='2.49.0'))
             c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of the Namespace')
-            c.extra('vnet_name', arg_group='Virtual Network Rule', options_list=['--vnet-name'], help='Name of the Virtual Network', deprecate_info=c.deprecate(expiration='2.50.0'))
+            c.extra('vnet_name', arg_group='Virtual Network Rule', options_list=['--vnet-name'], help='Name of the Virtual Network', deprecate_info=c.deprecate(expiration='2.49.0'))
 
     with self.argument_context('eventhubs namespace network-rule update', resource_type=ResourceType.MGMT_EVENTHUB, min_api='2017-04-01') as c:
         c.argument('public_network_access', options_list=['--public-network-access', '--public-network'], arg_type=get_enum_type(['Enabled', 'Disabled']), help='This determines if traffic is allowed over public network. By default it is enabled. If value is SecuredByPerimeter then Inbound and Outbound communication is controlled by the network security perimeter and profile\' access rules.')

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/_params.py
@@ -177,7 +177,7 @@ def load_arguments_eh(self, _):
     for scope in ['eventhubs namespace network-rule add', 'eventhubs namespace network-rule remove']:
         with self.argument_context(scope, resource_type=ResourceType.MGMT_EVENTHUB, min_api='2017-04-01') as c:
             c.argument('subnet', arg_group='Virtual Network Rule', options_list=['--subnet'], help='Name or ID of subnet. If name is supplied, `--vnet-name` must be supplied.')
-            c.argument('ip_mask', arg_group='IP Address Rule', options_list=['--ip-address'], help='IPv4 address or CIDR range - 10.6.0.0/24', deprecate_info=c.deprecate(redirect='--ip-rule', expiration='2.50.0'))
+            c.argument('ip_mask', arg_group='IP Address Rule', options_list=['--ip-address'], help='IPv4 address or CIDR range - 10.6.0.0/24', deprecate_info=c.deprecate(redirect='--ip-rule', expiration='2.49.0'))
             c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of the Namespace')
             c.extra('vnet_name', arg_group='Virtual Network Rule', options_list=['--vnet-name'], help='Name of the Virtual Network', deprecate_info=c.deprecate(expiration='2.50.0'))
 

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
@@ -129,7 +129,7 @@ def load_command_table(self, _):
         g.command('keys list', 'list_keys')
 
 # NetwrokRuleSet Region
-    with self.command_group('eventhubs namespace network-rule', eh_namespace_util, min_api='2021-06-01-preview', resource_type=ResourceType.MGMT_EVENTHUB, client_factory=namespaces_mgmt_client_factory) as g:
+    with self.command_group('eventhubs namespace network-rule', eh_namespace_util, deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule add'), min_api='2021-06-01-preview', resource_type=ResourceType.MGMT_EVENTHUB, client_factory=namespaces_mgmt_client_factory) as g:
         g.custom_command('add', 'cli_networkrule_createupdate', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule add'), validator=validate_subnet)
         g.show_command('list', 'get_network_rule_set', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set list'))
         g.custom_command('remove', 'cli_networkrule_delete', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule remove'), validator=validate_subnet)

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
@@ -130,24 +130,11 @@ def load_command_table(self, _):
 
 # NetwrokRuleSet Region
     with self.command_group('eventhubs namespace network-rule', eh_namespace_util, min_api='2021-06-01-preview', resource_type=ResourceType.MGMT_EVENTHUB, client_factory=namespaces_mgmt_client_factory) as g:
-        g.custom_command('add', 'cli_networkrule_createupdate', validator=validate_subnet)
-        g.show_command('list', 'get_network_rule_set')
-        g.custom_command('remove', 'cli_networkrule_delete', validator=validate_subnet)
-        g.custom_command('update', 'cli_networkrule_update')
+        g.custom_command('add', 'cli_networkrule_createupdate', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule add'), validator=validate_subnet)
+        g.show_command('list', 'get_network_rule_set', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set list'))
+        g.custom_command('remove', 'cli_networkrule_delete', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule remove'), validator=validate_subnet)
+        g.custom_command('update', 'cli_networkrule_update', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set update'))
 
-    with self.command_group('eventhubs namespace network-rule', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set', hide=True)) as g:
-        g.show_command('list', 'get_network_rule_set')
-        g.custom_command('update', 'cli_networkrule_update')
-
-    with self.command_group('eventhubs namespace network-rule') as g:
-        g.command('add', deprecate_info=g.deprecate(redirect='eventhubs namespace network-rule-set ip-rule add' 'eventhubs namespace network-rule-set virtual-network-rule add'))
-
-    with self.command_group('eventhubs namespace network-rule', test_sdk) as g:
-        g.command('remove', deprecate_info=g.deprecate(redirect='eventhubs namespace network-rule-set ip-rule remove' 'eventhubs namespace network-rule-set virtual-network-rule remove'))
-
-    with self.argument_context('eventhubs namespace network-rule add') as c:
-        c.argument('vnet_name', help='We no longer want to support.', deprecate_info = c.deprecate())
-        
 # Identity Region
     with self.command_group('eventhubs namespace identity', custom_command_type=eh_namespace_custom,
                             is_preview=True) as g:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
@@ -135,6 +135,19 @@ def load_command_table(self, _):
         g.custom_command('remove', 'cli_networkrule_delete', validator=validate_subnet)
         g.custom_command('update', 'cli_networkrule_update')
 
+    with self.command_group('eventhubs namespace network-rule', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set', hide=True)) as g:
+        g.show_command('list', 'get_network_rule_set')
+        g.custom_command('update', 'cli_networkrule_update')
+
+    with self.command_group('eventhubs namespace network-rule') as g:
+        g.command('add', deprecate_info=g.deprecate(redirect='eventhubs namespace network-rule-set ip-rule add' 'eventhubs namespace network-rule-set virtual-network-rule add'))
+
+    with self.command_group('eventhubs namespace network-rule', test_sdk) as g:
+        g.command('remove', deprecate_info=g.deprecate(redirect='eventhubs namespace network-rule-set ip-rule remove' 'eventhubs namespace network-rule-set virtual-network-rule remove'))
+
+    with self.argument_context('eventhubs namespace network-rule add') as c:
+        c.argument('vnet_name', help='We no longer want to support.', deprecate_info = c.deprecate())
+        
 # Identity Region
     with self.command_group('eventhubs namespace identity', custom_command_type=eh_namespace_custom,
                             is_preview=True) as g:

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/commands.py
@@ -129,7 +129,7 @@ def load_command_table(self, _):
         g.command('keys list', 'list_keys')
 
 # NetwrokRuleSet Region
-    with self.command_group('eventhubs namespace network-rule', eh_namespace_util, deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule add'), min_api='2021-06-01-preview', resource_type=ResourceType.MGMT_EVENTHUB, client_factory=namespaces_mgmt_client_factory) as g:
+    with self.command_group('eventhubs namespace network-rule', eh_namespace_util, deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set'), min_api='2021-06-01-preview', resource_type=ResourceType.MGMT_EVENTHUB, client_factory=namespaces_mgmt_client_factory) as g:
         g.custom_command('add', 'cli_networkrule_createupdate', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule add'), validator=validate_subnet)
         g.show_command('list', 'get_network_rule_set', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set list'))
         g.custom_command('remove', 'cli_networkrule_delete', deprecate_info=self.deprecate(redirect='eventhubs namespace network-rule-set ip-rule/virtual-network-rule remove'), validator=validate_subnet)

--- a/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/eventhubs/custom.py
@@ -305,7 +305,7 @@ def cli_networkrule_createupdate(cmd, client, resource_group_name, namespace_nam
     NWRuleSetIpRules = cmd.get_models('NWRuleSetIpRules', resource_type=ResourceType.MGMT_EVENTHUB)
 
     netwrokruleset = client.get_network_rule_set(resource_group_name, namespace_name)
-
+    logger.warning('This version will be depracated & latest version will release in breaking change release.')
     if cmd.supported_api_version(resource_type=ResourceType.MGMT_EVENTHUB, min_api='2017-04-01'):
         if netwrokruleset.virtual_network_rules is None:
             netwrokruleset.virtual_network_rules = [NWRuleSetVirtualNetworkRules]

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -229,7 +229,6 @@ def cli_networkrule_createupdate(cmd, client, resource_group_name, namespace_nam
     NWRuleSetIpRules = cmd.get_models('NWRuleSetIpRules', resource_type=ResourceType.MGMT_SERVICEBUS)
     netwrokruleset = client.get_network_rule_set(resource_group_name, namespace_name)
 
-    logger.warning('This version will be depracated & latest version will release in breaking change release.')
     if netwrokruleset.virtual_network_rules is None:
         netwrokruleset.virtual_network_rules = []
 

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -229,6 +229,7 @@ def cli_networkrule_createupdate(cmd, client, resource_group_name, namespace_nam
     NWRuleSetIpRules = cmd.get_models('NWRuleSetIpRules', resource_type=ResourceType.MGMT_SERVICEBUS)
     netwrokruleset = client.get_network_rule_set(resource_group_name, namespace_name)
 
+    logger.warning('This version will be depracated & latest version will release in breaking change release.')
     if netwrokruleset.virtual_network_rules is None:
         netwrokruleset.virtual_network_rules = []
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
We will change the format of this command in Future release. the parameter `vnet-name` will be deprecated in future.
We will offer simultaneous addition and removal of multiple IP rules and subnet rules with the new future release cmdlets.
We are targeting these breaking change in this May breaking change cycle.

We will Replace the following command.
1. `az eventhubs namespace network-rule` with `az eventhubs namespace network-rule-set`
2. `az eventhubs namespace network-rule add` with `az eventhubs namespace network-rule-set ip-rule add`, `az eventhubs namespace network-rule-set virtual-network-rule add`
3. `az eventhubs namespace network-rule remove` with `az eventhubs namespace network-rule-set ip-rule remove`, `az eventhubs namespace network-rule-set virtual-network-rule remove`
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
