### PR TITLE
[AppService] `az functionapp`: Remove workarounds from Centauri Private Preview

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3789,12 +3789,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         managed_environment = get_managed_environment(cmd, resource_group_name, environment)
         location = managed_environment.location
         functionapp_def.location = location
-
-        functionapp_def.enable_additional_properties_sending()
-        existing_properties = functionapp_def.serialize()["properties"]
-        functionapp_def.additional_properties["properties"] = existing_properties
-        functionapp_def.additional_properties["properties"]["name"] = name
-        functionapp_def.additional_properties["properties"]["managedEnvironmentId"] = managed_environment.id
+        functionapp_def.managed_environment_id = managed_environment.id
 
     # temporary workaround for dotnet-isolated linux consumption apps
     if is_linux and consumption_plan_location is not None and runtime == 'dotnet-isolated':

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3799,9 +3799,10 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
     for app_setting, value in app_settings_dict.items():
         site_config.app_settings.append(NameValuePair(name=app_setting, value=value))
 
-    site_config.app_settings.append(NameValuePair(name='FUNCTIONS_EXTENSION_VERSION',
-                                                  value=_get_extension_version_functionapp(functions_version)))
-    site_config.app_settings.append(NameValuePair(name='AzureWebJobsStorage', value=con_string))
+    if environment is None:
+        site_config.app_settings.append(NameValuePair(name='FUNCTIONS_EXTENSION_VERSION',
+                                                    value=_get_extension_version_functionapp(functions_version)))
+        site_config.app_settings.append(NameValuePair(name='AzureWebJobsStorage', value=con_string))
 
     # If plan is not consumption or elastic premium, we need to set always on
     if consumption_plan_location is None and plan_info is not None and not is_plan_elastic_premium(cmd, plan_info):

--- a/src/azure-cli/azure/cli/command_modules/appservice/utils.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/utils.py
@@ -161,19 +161,10 @@ def _get_location_from_resource_group(cli_ctx, resource_group_name):
     return group.location
 
 
-def show_raw_functionapp(cmd, resource_group_name, name):
-    client = web_client_factory(cmd.cli_ctx)
-    site_url_base = 'subscriptions/{}/resourceGroups/{}/providers/Microsoft.Web/sites/{}?api-version={}'
-    subscription_id = get_subscription_id(cmd.cli_ctx)
-    site_url = site_url_base.format(subscription_id, resource_group_name, name, client.DEFAULT_API_VERSION)
-    request_url = cmd.cli_ctx.cloud.endpoints.resource_manager + site_url
-    response = send_raw_request(cmd.cli_ctx, "GET", request_url)
-    return response.json()
-
-
 def is_centauri_functionapp(cmd, resource_group, name):
-    function_app = show_raw_functionapp(cmd, resource_group, name)
-    return function_app.get("properties", {}).get("managedEnvironmentId", None) is not None
+    client = web_client_factory(cmd.cli_ctx)
+    functionapp = client.web_apps.get(resource_group, name)
+    return functionapp.managed_environment_id is not None
 
 
 def _list_app(cli_ctx, resource_group_name=None):


### PR DESCRIPTION
**Related command**
Any command that checks whether the function app is related, or that updates the site configs or application settings.

**Description**<!--Mandatory-->
In Centauri Private Preview, we did the following workarounds (which we are removing with this PR):
- sending the managed environment ID attribute in the PUT request when creating a function app
- using send_raw_request to fetch the managed environment ID attribute in the GET function app request
- writing our own polling logic to update the site configs since PUT requests for Centauri function apps return a 202
- writing our own polling logic to update the application settings since PUT requests for Centauri function apps return a 202

**Testing Guide**
1. Create a Centauri function app: `az functionapp create`
2. See that the managed environment ID attribute is not None: `az functionapp show`
3. Updating the site configs or application settings: `az functionapp config appsettings set`
4. Check that commands are blocked for Centauri function apps: `az functionapp vnet-integration list`

**History Notes**

For Private Preview, we were given an exception to use the workarounds listed above but we want to have those removed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
