### PR TITLE
[Storage] `az storage copy`: Stop granting `stat.S_IWUSR` permission for azcopy installation dir

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/azcopy/util.py
@@ -53,10 +53,13 @@ class AzCopy:
         else:
             raise CLIError('Azcopy ({}) does not exist.'.format(self.system))
         try:
-            os.chmod(install_dir, os.stat(install_dir).st_mode | stat.S_IWUSR)
             _urlretrieve(file_url, install_location)
             os.chmod(install_location,
                      os.stat(install_location).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        except PermissionError as err:
+            raise CLIError(f'Permission error while attempting to download azcopy to {install_dir}. '
+                           f'You could install the specified azcopy version {AZCOPY_VERSION} manually or '
+                           f'grant write permission and retry. ({err})')
         except IOError as err:
             raise CLIError('Connection error while attempting to download azcopy {}. You could also install the '
                            'specified azcopy version to {} manually. ({})'.format(AZCOPY_VERSION, install_dir, err))


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage copy/remove`
`az storage blob sync`
`az storage fs directory upload/download`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We won't automatically add `stat.S_IWUSER` permission to azcopy installation directory any more. Customers have to make sure they have write permission by themselves



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
