### PR TITLE
[Core] `aaz`: Support argument prompt input

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/__init__.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/__init__.py
@@ -12,7 +12,7 @@ Atomic commands can be generated from rest api by using aaz-dev tool.
 from ._arg import AAZArgumentsSchema, AAZArgEnum, AAZStrArg, AAZIntArg, AAZObjectArg, AAZDictArg, \
     AAZFreeFormDictArg, AAZFloatArg, AAZBaseArg, AAZBoolArg, AAZListArg, AAZResourceGroupNameArg, \
     AAZResourceLocationArg, AAZResourceIdArg, AAZSubscriptionIdArg, AAZUuidArg, AAZDateArg, AAZTimeArg, \
-    AAZDateTimeArg, AAZDurationArg, AAZFileArg
+    AAZDateTimeArg, AAZDurationArg, AAZFileArg, AAZPasswordArg
 from ._arg_fmt import AAZStrArgFormat, AAZIntArgFormat, AAZFloatArgFormat, AAZBoolArgFormat, AAZObjectArgFormat, \
     AAZDictArgFormat, AAZFreeFormDictArgFormat, AAZListArgFormat, AAZResourceLocationArgFormat, \
     AAZResourceIdArgFormat, AAZSubscriptionIdArgFormat, AAZUuidFormat, AAZDateFormat, AAZTimeFormat, \
@@ -24,4 +24,5 @@ from ._field_type import AAZIntType, AAZFloatType, AAZStrType, AAZBoolType, AAZD
     AAZListType, AAZObjectType
 from ._operation import AAZHttpOperation, AAZJsonInstanceUpdateOperation, AAZGenericInstanceUpdateOperation, \
     AAZJsonInstanceDeleteOperation, AAZJsonInstanceCreateOperation
+from ._prompt import AAZPromptInput, AAZPromptPasswordInput
 from ._selector import AAZJsonSelector

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -21,6 +21,7 @@ from ._arg_fmt import AAZObjectArgFormat, AAZListArgFormat, AAZDictArgFormat, AA
     AAZSubscriptionIdArgFormat, AAZResourceLocationArgFormat, AAZResourceIdArgFormat, AAZUuidFormat, AAZDateFormat, \
     AAZTimeFormat, AAZDateTimeFormat, AAZDurationFormat, AAZFileArgTextFormat
 from .exceptions import AAZUnregisteredArg
+from ._prompt import AAZPromptInput
 
 # pylint: disable=redefined-builtin, protected-access, too-few-public-methods
 
@@ -134,6 +135,12 @@ class AAZBaseArg(AAZBaseType):  # pylint: disable=too-many-instance-attributes
 
         if self._blank != AAZUndefined:
             arg.nargs = '?'
+            if isinstance(self._blank, AAZPromptInput):
+                short_summary = arg.type.settings.get('help', None) or ''
+                if short_summary:
+                    short_summary += '  '
+                short_summary += self._blank.help_message
+                arg.help = short_summary
 
         cli_ctx = kwargs.get('cli_ctx', None)
         if cli_ctx is None:

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg.py
@@ -270,6 +270,13 @@ class AAZUuidArg(AAZStrArg):
         return "GUID/UUID"
 
 
+class AAZPasswordArg(AAZStrArg):
+
+    @property
+    def _type_in_help(self):
+        return "Password"
+
+
 class AAZIntArg(AAZSimpleTypeArg, AAZIntType):
 
     @property

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -125,7 +125,7 @@ class AAZSimpleTypeArgAction(AAZArgAction):
         if data == AAZBlankArgValue:
             if cls._schema._blank == AAZUndefined:
                 raise AAZInvalidValueError("argument value cannot be blank")
-            elif isinstance(cls._schema._blank, AAZPromptInput):
+            if isinstance(cls._schema._blank, AAZPromptInput):
                 try:
                     data = cls._schema._blank()
                 except NoTTYException:

--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access, too-few-public-methods
 
 import copy
 import os
@@ -148,8 +148,7 @@ class AAZSimpleTypeArgAction(AAZArgAction):
                 # Postpone the prompt input when apply the operation.
                 # In order not to break the logic of displaying help or validating other parameters.
                 return AAZPromptInputOperation(prompt=cls._schema._blank, action_cls=cls)
-            else:
-                data = copy.deepcopy(cls._schema._blank)
+            data = copy.deepcopy(cls._schema._blank)
 
         if isinstance(data, str):
             # transfer string into correct data

--- a/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
@@ -15,6 +15,10 @@ class AAZPromptInput:
     def __call__(self, *args, **kwargs):
         return prompt(msg=self._msg, help_string=self._help_string)
 
+    @property
+    def help_message(self):
+        return "If value is blank it's asked from the tty."
+
 
 class AAZPromptPasswordInput(AAZPromptInput):
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
@@ -1,0 +1,25 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+from knack.prompting import prompt, prompt_pass
+
+
+class AAZPromptInput:
+
+    def __init__(self, msg, help_string=None):
+        self._msg = msg
+        self._help_string = help_string
+
+    def __call__(self, *args, **kwargs):
+        return prompt(msg=self._msg, help_string=self._help_string)
+
+
+class AAZPromptPasswordInput(AAZPromptInput):
+
+    def __init__(self, msg, confirm=False, help_string=None):
+        super().__init__(msg=msg, help_string=help_string)
+        self._confirm = confirm
+
+    def __call__(self, *args, **kwargs):
+        return prompt_pass(msg=self._msg, confirm=self._confirm, help_string=self._help_string)

--- a/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_prompt.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+# pylint: disable=too-few-public-methods
 from knack.prompting import prompt, prompt_pass
 
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
@@ -146,7 +146,7 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
-        my_password = '7ndBkS3zKQazD5N3zzstubZq'
+        my_password = '123'
         with mock.patch('getpass.getpass', return_value=my_password):
             action.setup_operations(dest_ops, None)
         dest_ops.apply(v, "password")
@@ -175,14 +175,14 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
-        my_password = '7ndBkS3zKQazD5N3zzstubZq'
+        my_password = '123'
         with mock.patch('getpass.getpass', side_effect=[my_password, my_password]):
             action.setup_operations(dest_ops, None)
         dest_ops.apply(v, "password")
         self.assertEqual(v.password, my_password)
 
-        my_password1 = '7ndBkS3zKQazD5N3zzstubZq'
-        my_password2 = 'LTQ9haNMCSGp8p2uQHw2K9xf'
+        my_password1 = '111'
+        my_password2 = '123'
         with self.assertRaises(StopIteration):
             with mock.patch('getpass.getpass', side_effect=[my_password1, my_password2]):
                 action.setup_operations(dest_ops, None)

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
@@ -1,0 +1,188 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import base64
+import json
+import random
+
+import unittest
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from azure.cli.core import azclierror
+from azure.cli.core.aaz import exceptions as aazerror
+from azure.cli.core.aaz._command_ctx import AAZCommandCtx
+from azure.cli.core.aaz import AAZArgumentsSchema
+from azure.cli.core.mock import DummyCli
+from azure.cli.core.aaz._prompt import AAZPromptInput, AAZPromptPasswordInput
+
+
+class TestAAZPromptInput(unittest.TestCase):
+
+    # @mock.patch('sys.stdin.isatty', return_value=False)
+    # def test_no_tty_should_raise_exception(self, _):
+    #     pass
+
+    @mock.patch('sys.stdin.isatty', return_value=True)
+    def test_prompt_input(self, _):
+        from azure.cli.core.aaz._arg import AAZStrArg, AAZArgumentsSchema
+        from azure.cli.core.aaz._arg_action import AAZArgActionOperations
+        from azure.cli.core.aaz import has_value
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.prompt_arg = AAZStrArg(
+            options=["--prompt-arg"],
+            enum={
+                "1": "Monday",
+                "2": "Tuesday",
+                "3": "Wednesday",
+                "4": "Thursday",
+                "5": "Friday",
+                "6": "Saturday",
+                "7": "Sunday",
+                "Mon": "Monday",
+                "Tue": "Tuesday",
+                "Wed": "Wednesday",
+                "Thu": "Thursday",
+                "Fri": "Friday",
+                "Sat": "Saturday",
+                "Sun": "Sunday",
+            },
+            required=True,
+            blank=AAZPromptInput(msg="Your input value for --prompt-arg:")
+        )
+
+        self.assertFalse(has_value(v.prompt_arg))
+
+        arg = schema.prompt_arg.to_cmd_arg("prompt_arg")
+        self.assertEqual(len(arg.choices), 14)
+        action = arg.type.settings["action"]
+
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+
+        expected_result = '1'
+
+        with mock.patch('knack.prompting._input', return_value=expected_result):
+            action.setup_operations(dest_ops, None)
+        dest_ops.apply(v, "prompt_arg")
+        self.assertEqual(v.prompt_arg, "Monday")
+
+        expected_result = '100'
+        with self.assertRaisesRegex(azclierror.InvalidArgumentValueError, f"unrecognized value '{expected_result}' from choices"):
+            with mock.patch('knack.prompting._input', return_value=expected_result):
+                action.setup_operations(dest_ops, None)
+
+
+    @mock.patch('sys.stdin.isatty', return_value=False)
+    def test_no_tty_prompt_input(self, _):
+        from azure.cli.core.aaz._arg import AAZStrArg, AAZArgumentsSchema
+        from azure.cli.core.aaz._arg_action import AAZArgActionOperations
+        from azure.cli.core.aaz import has_value
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.prompt_arg = AAZStrArg(
+            options=["--prompt-arg"],
+            enum={
+                "1": "Monday",
+                "2": "Tuesday",
+                "3": "Wednesday",
+                "4": "Thursday",
+                "5": "Friday",
+                "6": "Saturday",
+                "7": "Sunday",
+                "Mon": "Monday",
+                "Tue": "Tuesday",
+                "Wed": "Wednesday",
+                "Thu": "Thursday",
+                "Fri": "Friday",
+                "Sat": "Saturday",
+                "Sun": "Sunday",
+            },
+            required=True,
+            blank=AAZPromptInput(msg="Your input value for --prompt-arg:")
+        )
+
+        self.assertFalse(has_value(v.prompt_arg))
+
+        arg = schema.prompt_arg.to_cmd_arg("prompt_arg")
+        self.assertEqual(len(arg.choices), 14)
+        action = arg.type.settings["action"]
+
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+
+        expected_result = '1'
+
+        with self.assertRaisesRegex(aazerror.AAZInvalidValueError, f"argument value cannot be blank in non-interactive mode."):
+            with mock.patch('knack.prompting._input', return_value=expected_result):
+                action.setup_operations(dest_ops, None)
+
+    @mock.patch('sys.stdin.isatty', return_value=True)
+    def test_pass_prompt_input(self, _):
+        from azure.cli.core.aaz._arg import AAZPasswordArg, AAZArgumentsSchema
+        from azure.cli.core.aaz._arg_action import AAZArgActionOperations
+        from azure.cli.core.aaz._arg_fmt import AAZStrArgFormat
+        from azure.cli.core.aaz import has_value
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.password = AAZPasswordArg(
+            options=["--password"],
+            required=True,
+            blank=AAZPromptPasswordInput(msg="Your input value for --password:")
+        )
+
+        self.assertFalse(has_value(v.password))
+
+        arg = schema.password.to_cmd_arg("password")
+        action = arg.type.settings["action"]
+
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+
+        my_password = '7ndBkS3zKQazD5N3zzstubZq'
+        with mock.patch('getpass.getpass', return_value=my_password):
+            action.setup_operations(dest_ops, None)
+        dest_ops.apply(v, "password")
+        self.assertEqual(v.password, my_password)
+
+    @mock.patch('sys.stdin.isatty', return_value=True)
+    def test_pass_prompt_input_confirm(self, _):
+        from azure.cli.core.aaz._arg import AAZPasswordArg, AAZArgumentsSchema
+        from azure.cli.core.aaz._arg_action import AAZArgActionOperations
+        from azure.cli.core.aaz._arg_fmt import AAZStrArgFormat
+        from azure.cli.core.aaz import has_value
+        schema = AAZArgumentsSchema()
+        v = schema()
+
+        schema.password = AAZPasswordArg(
+            options=["--password"],
+            required=True,
+            blank=AAZPromptPasswordInput(msg="Your input value for --password:", confirm=True)
+        )
+
+        self.assertFalse(has_value(v.password))
+
+        arg = schema.password.to_cmd_arg("password")
+        action = arg.type.settings["action"]
+
+        dest_ops = AAZArgActionOperations()
+        self.assertEqual(len(dest_ops._ops), 0)
+
+        my_password = '7ndBkS3zKQazD5N3zzstubZq'
+        with mock.patch('getpass.getpass', side_effect=[my_password, my_password]):
+            action.setup_operations(dest_ops, None)
+        dest_ops.apply(v, "password")
+        self.assertEqual(v.password, my_password)
+
+        my_password1 = '7ndBkS3zKQazD5N3zzstubZq'
+        my_password2 = 'LTQ9haNMCSGp8p2uQHw2K9xf'
+        with self.assertRaises(StopIteration):
+            with mock.patch('getpass.getpass', side_effect=[my_password1, my_password2]):
+                action.setup_operations(dest_ops, None)

--- a/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_aaz_prompt.py
@@ -22,10 +22,6 @@ from azure.cli.core.aaz._prompt import AAZPromptInput, AAZPromptPasswordInput
 
 class TestAAZPromptInput(unittest.TestCase):
 
-    # @mock.patch('sys.stdin.isatty', return_value=False)
-    # def test_no_tty_should_raise_exception(self, _):
-    #     pass
-
     @mock.patch('sys.stdin.isatty', return_value=True)
     def test_prompt_input(self, _):
         from azure.cli.core.aaz._arg import AAZStrArg, AAZArgumentsSchema
@@ -65,18 +61,17 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
-        expected_result = '1'
+        action.setup_operations(dest_ops, None)
 
+        expected_result = '1'
         with mock.patch('knack.prompting._input', return_value=expected_result):
-            action.setup_operations(dest_ops, None)
-        dest_ops.apply(v, "prompt_arg")
+            dest_ops.apply(v, "prompt_arg")
         self.assertEqual(v.prompt_arg, "Monday")
 
         expected_result = '100'
         with self.assertRaisesRegex(azclierror.InvalidArgumentValueError, f"unrecognized value '{expected_result}' from choices"):
             with mock.patch('knack.prompting._input', return_value=expected_result):
-                action.setup_operations(dest_ops, None)
-
+                dest_ops.apply(v, "prompt_arg")
 
     @mock.patch('sys.stdin.isatty', return_value=False)
     def test_no_tty_prompt_input(self, _):
@@ -117,11 +112,12 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
-        expected_result = '1'
+        action.setup_operations(dest_ops, None)
 
+        expected_result = '1'
         with self.assertRaisesRegex(aazerror.AAZInvalidValueError, f"argument value cannot be blank in non-interactive mode."):
             with mock.patch('knack.prompting._input', return_value=expected_result):
-                action.setup_operations(dest_ops, None)
+                dest_ops.apply(v, "prompt_arg")
 
     @mock.patch('sys.stdin.isatty', return_value=True)
     def test_pass_prompt_input(self, _):
@@ -146,10 +142,11 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
+        action.setup_operations(dest_ops, None)
+
         my_password = '123'
         with mock.patch('getpass.getpass', return_value=my_password):
-            action.setup_operations(dest_ops, None)
-        dest_ops.apply(v, "password")
+            dest_ops.apply(v, "password")
         self.assertEqual(v.password, my_password)
 
     @mock.patch('sys.stdin.isatty', return_value=True)
@@ -175,14 +172,15 @@ class TestAAZPromptInput(unittest.TestCase):
         dest_ops = AAZArgActionOperations()
         self.assertEqual(len(dest_ops._ops), 0)
 
+        action.setup_operations(dest_ops, None)
+
         my_password = '123'
         with mock.patch('getpass.getpass', side_effect=[my_password, my_password]):
-            action.setup_operations(dest_ops, None)
-        dest_ops.apply(v, "password")
+            dest_ops.apply(v, "password")
         self.assertEqual(v.password, my_password)
 
         my_password1 = '111'
         my_password2 = '123'
         with self.assertRaises(StopIteration):
             with mock.patch('getpass.getpass', side_effect=[my_password1, my_password2]):
-                action.setup_operations(dest_ops, None)
+                dest_ops.apply(v, "password")


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Support argument prompt input for AAZCommand args when the value is blank.

Below is the current usage for a command without prompt input for secure arguments like `--password`
![image](https://user-images.githubusercontent.com/69238381/232708069-1e3a62ca-5dd1-4781-b0c7-4b2e5f5dfe12.png)

Now we can support prompt input for those secure arguments like this way
![image](https://user-images.githubusercontent.com/69238381/232708801-5577c27f-7402-4b9d-a371-e643bee910ce.png)
The password is not appeared in TTY.

For those arguments which supports prompt input, you can see the following message added in their short summary:
![image](https://user-images.githubusercontent.com/69238381/232709694-cfe1859c-bd0d-46ff-b8e2-290694593f9d.png)
Which means if the value of those arguments is blank, the prompt input will be triggered in TTY. 

The there are two prompt input classes: 
- AAZPromptInput: Used for regular arguments. The input will be display in TTY.
- AAZPromptPasswordInput: Used for password kind of arguments. The input will be hidden. And support input confirmation.

![image](https://user-images.githubusercontent.com/69238381/232711162-3760931d-f6cf-468d-8d59-7f8fe1403e6f.png)
The first prompt input is for `--name` which use `AAZPromptInput`. The last two prompt input is for `--password` which use `AAZPromptPasswordInput` with confirmation.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Core] `aaz`: Support `AAZPasswordArg`
[Core] `aaz`: Support argument prompt input for simple type args

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
