### PR TITLE
{Core} Move clouds.config to config dir

### DIFF
--- a/src/azure-cli-core/azure/cli/core/cloud.py
+++ b/src/azure-cli-core/azure/cli/core/cloud.py
@@ -594,8 +594,6 @@ def set_cloud_subscription(cli_ctx, cloud_name, subscription):
             config.remove_option(cloud_name, 'subscription')
         except configparser.NoSectionError:
             pass
-    if not os.path.isdir(GLOBAL_CONFIG_DIR):
-        os.makedirs(GLOBAL_CONFIG_DIR)
     with open(get_cloud_config_file(cli_ctx), 'w') as configfile:
         config.write(configfile)
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_profile.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_profile.py
@@ -282,7 +282,7 @@ class TestProfile(unittest.TestCase):
                                   create_subscription_client_mock):
         login_with_auth_code_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -304,7 +304,7 @@ class TestProfile(unittest.TestCase):
                                     create_subscription_client_mock):
         login_with_device_code_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -324,7 +324,7 @@ class TestProfile(unittest.TestCase):
                                                create_subscription_client_mock):
         login_with_device_code_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -345,7 +345,7 @@ class TestProfile(unittest.TestCase):
                                                      create_subscription_client_mock):
         login_with_username_password_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -364,7 +364,7 @@ class TestProfile(unittest.TestCase):
     def test_login_with_service_principal(self, login_with_service_principal_mock,
                                           get_service_principal_credential_mock,
                                           create_subscription_client_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -396,7 +396,7 @@ class TestProfile(unittest.TestCase):
     def test_login_in_cloud_shell(self, msi_auth_mock, create_subscription_client_mock):
         msi_auth_mock.return_value = MSRestAzureAuthStub()
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
@@ -425,7 +425,7 @@ class TestProfile(unittest.TestCase):
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
         create_subscription_client_mock.return_value = mock_subscription_client
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -458,7 +458,7 @@ class TestProfile(unittest.TestCase):
         mock_subscription_client.subscriptions.list.return_value = []
         create_subscription_client_mock.return_value = mock_subscription_client
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -493,7 +493,7 @@ class TestProfile(unittest.TestCase):
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
         create_subscription_client_mock.return_value = mock_subscription_client
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -548,7 +548,7 @@ class TestProfile(unittest.TestCase):
                     raise AzureResponseError('Failed to connect to MSI. Please make sure MSI is configured correctly.\n'
                                              'Get Token request returned http error: 400, reason: Bad Request')
 
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
 
         mock_msi_auth.side_effect = AuthStub
         test_object_id = '54826b22-38d6-4fb2-bad9-b7b93a3e9999'
@@ -569,7 +569,7 @@ class TestProfile(unittest.TestCase):
         mock_subscription_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
         create_subscription_client_mock.return_value = mock_subscription_client
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -602,7 +602,7 @@ class TestProfile(unittest.TestCase):
                                    create_subscription_client_mock):
         login_with_auth_code_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
         mock_subscription_client.subscriptions.list.return_value = []
@@ -628,7 +628,7 @@ class TestProfile(unittest.TestCase):
                              create_subscription_client_mock):
         login_with_auth_code_mock.return_value = self.user_identity_mock
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_subscription_client = mock.MagicMock()
         mock_subscription_client.tenants.list.return_value = []
         mock_subscription_client.subscriptions.list.return_value = []
@@ -647,7 +647,7 @@ class TestProfile(unittest.TestCase):
     def test_login_with_auth_code_adfs(self, can_launch_browser_mock,
                                        login_with_auth_code_mock, get_user_credential_mock,
                                        create_subscription_client_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         TEST_ADFS_AUTH_URL = 'https://adfs.local.azurestack.external/adfs'
 
         def login_with_auth_code_mock_side_effect(identity_self, *args, **kwargs):
@@ -675,7 +675,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(self.subscription1_output, subs)
 
     def test_normalize(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
         consolidated = profile._normalize_properties(self.user1, [self.subscription1], False)
@@ -685,7 +685,7 @@ class TestProfile(unittest.TestCase):
         self.assertIsNotNone(json.dumps(consolidated[0]))
 
     def test_normalize_v2016_06_01(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
         from azure.mgmt.resource.subscriptions.v2016_06_01.models import Subscription \
@@ -716,7 +716,7 @@ class TestProfile(unittest.TestCase):
         self.assertIsNotNone(json.dumps(consolidated[0]))
 
     def test_update_add_two_different_subscriptions(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -750,7 +750,7 @@ class TestProfile(unittest.TestCase):
         self.assertFalse(storage_mock['subscriptions'][0]['isDefault'])
 
     def test_update_with_same_subscription_added_twice(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -773,7 +773,7 @@ class TestProfile(unittest.TestCase):
         self.assertTrue(storage_mock['subscriptions'][0]['isDefault'])
 
     def test_set_active_subscription(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -794,7 +794,7 @@ class TestProfile(unittest.TestCase):
         self.assertTrue(storage_mock['subscriptions'][0]['isDefault'])
 
     def test_default_active_subscription_to_non_disabled_one(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -808,7 +808,7 @@ class TestProfile(unittest.TestCase):
         self.assertTrue(storage_mock['subscriptions'][1]['isDefault'])
 
     def test_get_subscription(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
 
@@ -828,7 +828,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.profiles.get_api_version', autospec=True)
     def test_subscription_finder_constructor(self, get_api_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         get_api_mock.return_value = '2019-11-01'
         cli.cloud.endpoints.resource_manager = 'http://foo_arm'
         finder = SubscriptionFinder(cli)
@@ -836,7 +836,7 @@ class TestProfile(unittest.TestCase):
         self.assertEqual(result._client._base_url, 'http://foo_arm')
 
     def test_get_current_account_user(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
 
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -850,7 +850,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', return_value=credential_mock)
     def test_get_login_credentials(self, get_user_credential_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -874,7 +874,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', return_value=credential_mock)
     def test_get_login_credentials_aux_subscriptions(self, get_user_credential_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
 
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -903,7 +903,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', return_value=credential_mock)
     def test_get_login_credentials_aux_tenants(self, get_user_credential_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
 
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -941,7 +941,7 @@ class TestProfile(unittest.TestCase):
     def test_get_login_credentials_msi_system_assigned(self):
 
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_user = 'systemAssignedIdentity'
@@ -964,7 +964,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper', MSRestAzureAuthStub)
     def test_get_login_credentials_msi_user_assigned_with_client_id(self):
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_user = 'userAssignedIdentity'
@@ -988,7 +988,7 @@ class TestProfile(unittest.TestCase):
     def test_get_login_credentials_msi_user_assigned_with_object_id(self):
 
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_object_id = '12345678-38d6-4fb2-bad9-b7b93a3e9999'
         msi_subscription = SubscriptionStub('/subscriptions/12345678-1bf0-4dda-aec3-cb9272f09590',
@@ -1011,7 +1011,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper', MSRestAzureAuthStub)
     def test_get_login_credentials_msi_user_assigned_with_res_id(self):
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_res_id = ('/subscriptions/{}/resourceGroups/r1/providers/Microsoft.ManagedIdentity/'
                        'userAssignedIdentities/id1').format(test_subscription_id)
@@ -1036,7 +1036,7 @@ class TestProfile(unittest.TestCase):
     def test_get_raw_token(self, get_user_credential_mock):
         credential_mock_temp = CredentialMock()
         get_user_credential_mock.return_value = credential_mock_temp
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -1083,7 +1083,7 @@ class TestProfile(unittest.TestCase):
     def test_get_raw_token_for_sp(self, get_service_principal_credential_mock):
         credential_mock_temp = CredentialMock()
         get_service_principal_credential_mock.return_value = credential_mock_temp
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         # setup
         storage_mock = {'subscriptions': None}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -1122,7 +1122,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('azure.cli.core.auth.adal_authentication.MSIAuthenticationWrapper', autospec=True)
     def test_get_raw_token_msi_system_assigned(self, mock_msi_auth):
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         test_user = 'systemAssignedIdentity'
@@ -1169,7 +1169,7 @@ class TestProfile(unittest.TestCase):
         mock_in_cloud_console.return_value = True
 
         # setup an existing msi subscription
-        profile = Profile(cli_ctx=DummyCli(), storage={'subscriptions': None})
+        profile = Profile(cli_ctx=DummyCli(random_config_dir=True), storage={'subscriptions': None})
         test_subscription_id = '12345678-1bf0-4dda-aec3-cb9272f09590'
         test_tenant_id = '12345678-38d6-4fb2-bad9-b7b93a3e1234'
         msi_subscription = SubscriptionStub('/subscriptions/' + test_subscription_id,
@@ -1212,7 +1212,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.auth.identity.Identity.logout_user')
     def test_logout(self, logout_user_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
 
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -1230,7 +1230,7 @@ class TestProfile(unittest.TestCase):
 
     @mock.patch('azure.cli.core.auth.identity.Identity.logout_all_users')
     def test_logout_all(self, logout_all_users_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         # setup
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -1258,7 +1258,7 @@ class TestProfile(unittest.TestCase):
         mock_arm_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
         create_subscription_client_mock.return_value = mock_arm_client
 
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False, None, None)
@@ -1288,7 +1288,7 @@ class TestProfile(unittest.TestCase):
     def test_refresh_accounts_one_user_account_one_sp_account(self, get_user_credential_mock,
                                                               get_service_principal_credential_mock,
                                                               create_subscription_client_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         sp_id = '44fee498-c798-4ebb-a41f-7bb523bed8d8'
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
@@ -1323,7 +1323,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
     def test_refresh_accounts_with_nothing(self, get_user_credential_mock, create_subscription_client_mock):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False, None, None)
@@ -1344,7 +1344,7 @@ class TestProfile(unittest.TestCase):
     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
     def test_login_common_tenant_mfa_warning(self, get_user_credential_mock, create_subscription_client_mock):
         # Assume 2 tenants. Home tenant tenant1 doesn't require MFA, but tenant2 does
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         mock_arm_client = mock.MagicMock()
         tenant2_mfa_id = 'tenant2-0000-0000-0000-000000000000'
         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id), TenantStub(tenant2_mfa_id)]
@@ -1384,7 +1384,7 @@ class TestProfile(unittest.TestCase):
         # With pytest, use -o log_cli=True to manually check the log
 
     def test_get_auth_info_for_newly_created_service_principal(self):
-        cli = DummyCli()
+        cli = DummyCli(random_config_dir=True)
         storage_mock = {'subscriptions': []}
         profile = Profile(cli_ctx=cli, storage=storage_mock)
         consolidated = profile._normalize_properties(self.user1, [self.subscription1], False)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
At present, `CLOUD_CONFIG_FILE` is always `~/.azure/clouds.config`.

`TestProfile` consists of different login test. When run `az login`, cloud config file is updated by `login`->`_set_subscriptions` -> `set_cloud_subscription`.
https://github.com/Azure/azure-cli/blob/acd8f2c3db4be03e7dfd50b2d105cd91df0008e6/src/azure-cli-core/azure/cli/core/cloud.py#L581-L598

Simultaneous writing may lead to file interruption.

This PR fixes this bug by enabling `random_config_dir` in these test and move cloud config to `cli_ctx.config.config_dir`.

```
2023-04-13T04:49:15.7092388Z [gw0] [ 78%] FAILED tests/test_profile.py::TestProfile::test_refresh_accounts_one_user_account 
2023-04-13T04:49:15.7092660Z 
2023-04-13T04:49:15.7093062Z =================================== FAILURES ===================================
2023-04-13T04:49:15.7093394Z ______________ TestProfile.test_refresh_accounts_one_user_account ______________
2023-04-13T04:49:15.7093901Z [gw0] linux -- Python 3.10.10 /opt/az/bin/python3
2023-04-13T04:49:15.7094189Z self = <core.tests.test_profile.TestProfile testMethod=test_refresh_accounts_one_user_account>
2023-04-13T04:49:15.7094508Z get_user_credential_mock = <function get_user_credential at 0xffff9d0968c0>
2023-04-13T04:49:15.7094818Z create_subscription_client_mock = <function _create_subscription_client at 0xffff9d0944c0>
2023-04-13T04:49:15.7094960Z 
2023-04-13T04:49:15.7095334Z     @mock.patch('azure.cli.core._profile.SubscriptionFinder._create_subscription_client', autospec=True)
2023-04-13T04:49:15.7095771Z     @mock.patch('azure.cli.core.auth.identity.Identity.get_user_credential', autospec=True)
2023-04-13T04:49:15.7096119Z     def test_refresh_accounts_one_user_account(self, get_user_credential_mock, create_subscription_client_mock):
2023-04-13T04:49:15.7096401Z         mock_arm_client = mock.MagicMock()
2023-04-13T04:49:15.7096990Z         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
2023-04-13T04:49:15.7097312Z         mock_arm_client.subscriptions.list.return_value = [deepcopy(self.subscription1_raw)]
2023-04-13T04:49:15.7097617Z         create_subscription_client_mock.return_value = mock_arm_client
2023-04-13T04:49:15.7097828Z     
2023-04-13T04:49:15.7097988Z         cli = DummyCli()
2023-04-13T04:49:15.7098264Z         storage_mock = {'subscriptions': []}
2023-04-13T04:49:15.7098518Z         profile = Profile(cli_ctx=cli, storage=storage_mock)
2023-04-13T04:49:15.7098838Z         consolidated = profile._normalize_properties(self.user1, deepcopy([self.subscription1]), False, None, None)
2023-04-13T04:49:15.7099145Z         profile._set_subscriptions(consolidated)
2023-04-13T04:49:15.7099353Z     
2023-04-13T04:49:15.7099596Z         mock_arm_client.tenants.list.return_value = [TenantStub(self.tenant_id)]
2023-04-13T04:49:15.7099948Z         mock_arm_client.subscriptions.list.return_value = deepcopy([self.subscription1_raw, self.subscription2_raw])
2023-04-13T04:49:15.7100206Z     
2023-04-13T04:49:15.7100377Z >       profile.refresh_accounts()
2023-04-13T04:49:15.7100471Z 
2023-04-13T04:49:15.7100805Z /opt/az/lib/python3.10/site-packages/azure/cli/core/tests/test_profile.py:1270: 
2023-04-13T04:49:15.7101244Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-04-13T04:49:15.7101628Z /opt/az/lib/python3.10/site-packages/azure/cli/core/_profile.py:640: in refresh_accounts
2023-04-13T04:49:15.7101917Z     self._set_subscriptions(result, merge=False)
2023-04-13T04:49:15.7102284Z /opt/az/lib/python3.10/site-packages/azure/cli/core/_profile.py:496: in _set_subscriptions
2023-04-13T04:49:15.7102591Z     set_cloud_subscription(self.cli_ctx, active_cloud.name, default_sub_id)
2023-04-13T04:49:15.7102976Z /opt/az/lib/python3.10/site-packages/azure/cli/core/cloud.py:576: in set_cloud_subscription
2023-04-13T04:49:15.7103254Z     if not _get_cloud(cli_ctx, cloud_name):
2023-04-13T04:49:15.7103604Z /opt/az/lib/python3.10/site-packages/azure/cli/core/cloud.py:491: in _get_cloud
2023-04-13T04:49:15.7103896Z     return next((x for x in get_clouds(cli_ctx) if x.name == cloud_name), None)
2023-04-13T04:49:15.7104268Z /opt/az/lib/python3.10/site-packages/azure/cli/core/cloud.py:514: in get_clouds
2023-04-13T04:49:15.7104518Z     config.read(CLOUD_CONFIG_FILE)
2023-04-13T04:49:15.7104753Z /opt/az/lib/python3.10/configparser.py:699: in read
2023-04-13T04:49:15.7104980Z     self._read(fp, filename)
2023-04-13T04:49:15.7105200Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2023-04-13T04:49:15.7105304Z 
2023-04-13T04:49:15.7105507Z self = <configparser.ConfigParser object at 0xffff9d0d9180>
2023-04-13T04:49:15.7105874Z fp = <_io.TextIOWrapper name='/root/.azure/clouds.config' mode='r' encoding='UTF-8'>
2023-04-13T04:49:15.7106179Z fpname = '/root/.azure/clouds.config'
2023-04-13T04:49:15.7106280Z 
2023-04-13T04:49:15.7106452Z     def _read(self, fp, fpname):
2023-04-13T04:49:15.7106666Z         """Parse a sectioned configuration file.
2023-04-13T04:49:15.7106856Z     
2023-04-13T04:49:15.7107070Z         Each section in a configuration file contains a header, indicated by
2023-04-13T04:49:15.7107349Z         a name in square brackets (`[]`), plus key/value options, indicated by
2023-04-13T04:49:15.7107609Z         `name` and `value` delimited with a specific substring (`=` or `:` by
2023-04-13T04:49:15.7107825Z         default).
2023-04-13T04:49:15.7107989Z     
2023-04-13T04:49:15.7108217Z         Values can span multiple lines, as long as they are indented deeper
2023-04-13T04:49:15.7108614Z         than the first line of the value. Depending on the parser's mode, blank
2023-04-13T04:49:15.7108897Z         lines may be treated as parts of multiline values or ignored.
2023-04-13T04:49:15.7109117Z     
2023-04-13T04:49:15.7109371Z         Configuration files may include comments, prefixed by specific
2023-04-13T04:49:15.7109797Z         characters (`#` and `;` by default). Comments may appear on their own
2023-04-13T04:49:15.7110090Z         in an otherwise empty line or may be entered in lines holding values or
2023-04-13T04:49:15.7110392Z         section names. Please note that comments get stripped off when reading configuration files.
2023-04-13T04:49:15.7110657Z         """
2023-04-13T04:49:15.7110857Z         elements_added = set()
2023-04-13T04:49:15.7111100Z         cursect = None                        # None, or a dictionary
2023-04-13T04:49:15.7111313Z         sectname = None
2023-04-13T04:49:15.7111511Z         optname = None
2023-04-13T04:49:15.7111708Z         lineno = 0
2023-04-13T04:49:15.7111913Z         indent_level = 0
2023-04-13T04:49:15.7112140Z         e = None                              # None, or an exception
2023-04-13T04:49:15.7112356Z         for lineno, line in enumerate(fp, start=1):
2023-04-13T04:49:15.7112686Z             comment_start = sys.maxsize
2023-04-13T04:49:15.7112890Z             # strip inline comments
2023-04-13T04:49:15.7113236Z             inline_prefixes = {p: -1 for p in self._inline_comment_prefixes}
2023-04-13T04:49:15.7113508Z             while comment_start == sys.maxsize and inline_prefixes:
2023-04-13T04:49:15.7113731Z                 next_prefixes = {}
2023-04-13T04:49:15.7114059Z                 for prefix, index in inline_prefixes.items():
2023-04-13T04:49:15.7114292Z                     index = line.find(prefix, index+1)
2023-04-13T04:49:15.7114494Z                     if index == -1:
2023-04-13T04:49:15.7114672Z                         continue
2023-04-13T04:49:15.7114866Z                     next_prefixes[prefix] = index
2023-04-13T04:49:15.7115182Z                     if index == 0 or (index > 0 and line[index-1].isspace()):
2023-04-13T04:49:15.7115430Z                         comment_start = min(comment_start, index)
2023-04-13T04:49:15.7115652Z                 inline_prefixes = next_prefixes
2023-04-13T04:49:15.7115858Z             # strip full line comments
2023-04-13T04:49:15.7116065Z             for prefix in self._comment_prefixes:
2023-04-13T04:49:15.7116291Z                 if line.strip().startswith(prefix):
2023-04-13T04:49:15.7116494Z                     comment_start = 0
2023-04-13T04:49:15.7116670Z                     break
2023-04-13T04:49:15.7116865Z             if comment_start == sys.maxsize:
2023-04-13T04:49:15.7117059Z                 comment_start = None
2023-04-13T04:49:15.7117282Z             value = line[:comment_start].strip()
2023-04-13T04:49:15.7117490Z             if not value:
2023-04-13T04:49:15.7117693Z                 if self._empty_lines_in_values:
2023-04-13T04:49:15.7117924Z                     # add empty line to the value, but only if there was no
2023-04-13T04:49:15.7118135Z                     # comment on the line
2023-04-13T04:49:15.7118336Z                     if (comment_start is None and
2023-04-13T04:49:15.7118541Z                         cursect is not None and
2023-04-13T04:49:15.7118727Z                         optname and
2023-04-13T04:49:15.7118919Z                         cursect[optname] is not None):
2023-04-13T04:49:15.7119230Z                         cursect[optname].append('') # newlines added at join
2023-04-13T04:49:15.7119438Z                 else:
2023-04-13T04:49:15.7119628Z                     # empty line marks end of value
2023-04-13T04:49:15.7119839Z                     indent_level = sys.maxsize
2023-04-13T04:49:15.7120018Z                 continue
2023-04-13T04:49:15.7120516Z             # continuation line?
2023-04-13T04:49:15.7120741Z             first_nonspace = self.NONSPACECRE.search(line)
2023-04-13T04:49:15.7121026Z             cur_indent_level = first_nonspace.start() if first_nonspace else 0
2023-04-13T04:49:15.7121274Z             if (cursect is not None and optname and
2023-04-13T04:49:15.7121485Z                 cur_indent_level > indent_level):
2023-04-13T04:49:15.7121698Z                 cursect[optname].append(value)
2023-04-13T04:49:15.7121913Z             # a section header or option header?
2023-04-13T04:49:15.7122297Z             else:
2023-04-13T04:49:15.7122485Z                 indent_level = cur_indent_level
2023-04-13T04:49:15.7122690Z                 # is it a section header?
2023-04-13T04:49:15.7122894Z                 mo = self.SECTCRE.match(value)
2023-04-13T04:49:15.7123088Z                 if mo:
2023-04-13T04:49:15.7123368Z                     sectname = mo.group('header')
2023-04-13T04:49:15.7123577Z                     if sectname in self._sections:
2023-04-13T04:49:15.7123806Z                         if self._strict and sectname in elements_added:
2023-04-13T04:49:15.7124058Z                             raise DuplicateSectionError(sectname, fpname,
2023-04-13T04:49:15.7124275Z                                                         lineno)
2023-04-13T04:49:15.7124485Z                         cursect = self._sections[sectname]
2023-04-13T04:49:15.7124713Z                         elements_added.add(sectname)
2023-04-13T04:49:15.7124936Z                     elif sectname == self.default_section:
2023-04-13T04:49:15.7125155Z                         cursect = self._defaults
2023-04-13T04:49:15.7125339Z                     else:
2023-04-13T04:49:15.7125516Z                         cursect = self._dict()
2023-04-13T04:49:15.7125724Z                         self._sections[sectname] = cursect
2023-04-13T04:49:15.7126119Z                         self._proxies[sectname] = SectionProxy(self, sectname)
2023-04-13T04:49:15.7126358Z                         elements_added.add(sectname)
2023-04-13T04:49:15.7126681Z                     # So sections can't start with a continuation line
2023-04-13T04:49:15.7126890Z                     optname = None
2023-04-13T04:49:15.7127088Z                 # no section header in the file?
2023-04-13T04:49:15.7127288Z                 elif cursect is None:
2023-04-13T04:49:15.7127513Z                     raise MissingSectionHeaderError(fpname, lineno, line)
2023-04-13T04:49:15.7127732Z                 # an option line?
2023-04-13T04:49:15.7127899Z                 else:
2023-04-13T04:49:15.7128096Z                     mo = self._optcre.match(value)
2023-04-13T04:49:15.7128288Z                     if mo:
2023-04-13T04:49:15.7128587Z                         optname, vi, optval = mo.group('option', 'vi', 'value')
2023-04-13T04:49:15.7128812Z                         if not optname:
2023-04-13T04:49:15.7129022Z                             e = self._handle_error(e, fpname, lineno, line)
2023-04-13T04:49:15.7129266Z                         optname = self.optionxform(optname.rstrip())
2023-04-13T04:49:15.7129486Z                         if (self._strict and
2023-04-13T04:49:15.7129699Z                             (sectname, optname) in elements_added):
2023-04-13T04:49:15.7129932Z                             raise DuplicateOptionError(sectname, optname,
2023-04-13T04:49:15.7130172Z                                                        fpname, lineno)
2023-04-13T04:49:15.7130388Z                         elements_added.add((sectname, optname))
2023-04-13T04:49:15.7130629Z                         # This check is fine because the OPTCRE cannot
2023-04-13T04:49:15.7130861Z                         # match if it would set optval to None
2023-04-13T04:49:15.7131064Z                         if optval is not None:
2023-04-13T04:49:15.7131280Z                             optval = optval.strip()
2023-04-13T04:49:15.7131489Z                             cursect[optname] = [optval]
2023-04-13T04:49:15.7131676Z                         else:
2023-04-13T04:49:15.7131870Z                             # valueless option handling
2023-04-13T04:49:15.7132067Z                             cursect[optname] = None
2023-04-13T04:49:15.7132254Z                     else:
2023-04-13T04:49:15.7132538Z                         # a non-fatal parsing error occurred. set up the
2023-04-13T04:49:15.7132786Z                         # exception but keep going. the exception will be
2023-04-13T04:49:15.7133028Z                         # raised at the end of the file and will contain a
2023-04-13T04:49:15.7133396Z                         # list of all bogus lines
2023-04-13T04:49:15.7133624Z                         e = self._handle_error(e, fpname, lineno, line)
2023-04-13T04:49:15.7133851Z         self._join_multiline_values()
2023-04-13T04:49:15.7134078Z         # if any parsing errors occurred, raise an exception
2023-04-13T04:49:15.7134286Z         if e:
2023-04-13T04:49:15.7134444Z >           raise e
2023-04-13T04:49:15.7134813Z E           configparser.ParsingError: Source contains parsing errors: '/root/.azure/clouds.config'
2023-04-13T04:49:15.7135148Z E           	[line  4]: 'rosoft.com\n'
2023-04-13T04:49:15.7135232Z 
2023-04-13T04:49:15.7135457Z /opt/az/lib/python3.10/configparser.py:1118: ParsingError
2023-04-13T04:49:15.7135826Z -------- generated xml file: /azure_cli_test_result/azure-cli-core.xml ---------
```

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
