### PR TITLE
[AppService] `az functionapp create`: Support minReplicas for Centauri function apps

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -334,6 +334,7 @@ subscription than the app service environment, please use the resource ID for --
             c.argument('net_framework_version', help="The version used to run your web app if using .NET Framework, e.g., 'v4.0' for .NET 4.6 and 'v3.0' for .NET 3.5")
             c.argument('linux_fx_version', help="The runtime stack used for your linux-based webapp, e.g., \"RUBY|2.5.5\", \"NODE|12LTS\", \"PHP|7.2\", \"DOTNETCORE|2.1\". See https://aka.ms/linux-stacks for more info.")
             c.argument('windows_fx_version', help="A docker image name used for your windows container web app, e.g., microsoft/nanoserver:ltsc2016")
+            c.ignore('min_replicas')
             if scope == 'functionapp':
                 c.ignore('windows_fx_version')
             c.argument('pre_warmed_instance_count', options_list=['--prewarmed-instance-count'],
@@ -367,7 +368,6 @@ subscription than the app service environment, please use the resource ID for --
                        help="config file for multicontainer apps")
             c.argument('show_multicontainer_config', action='store_true',
                        help='shows decoded config if a multicontainer config is set')
-
         with self.argument_context(scope + ' deployment container config') as c:
             c.argument('enable', options_list=['--enable-cd', '-e'], help='enable/disable continuous deployment',
                        arg_type=get_three_state_flag(return_label=True))
@@ -381,6 +381,7 @@ subscription than the app service environment, please use the resource ID for --
                    help='the container registry server username')
         c.argument('docker_registry_server_password', options_list=['--docker-registry-server-password', '-p'],
                    help='the container registry server password')
+        c.ignore('min_replicas')
 
     with self.argument_context('functionapp config container') as c:
         c.argument('registry_server', options_list=['--registry-server', '-r', c.deprecate(target='--docker-registry-server-url', redirect='--registry-server')],

--- a/src/azure-cli/azure/cli/command_modules/appservice/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/_params.py
@@ -391,6 +391,7 @@ subscription than the app service environment, please use the resource ID for --
                    help='the container registry server username')
         c.argument('registry_password', options_list=['--registry-password', '-p', c.deprecate(target='--docker-registry-server-password', redirect='--registry-password')],
                    help='the container registry server password')
+        c.argument('min_replicas', options_list=['--min-replicas'], help='The minimum number of replicas.', is_preview=True)
 
     with self.argument_context('webapp config connection-string list') as c:
         c.argument('name', arg_type=webapp_name_arg_type, id_part=None)
@@ -722,6 +723,7 @@ subscription than the app service environment, please use the resource ID for --
         c.argument('vnet', options_list=['--vnet'], help="Name or resource ID of the regional virtual network. If there are multiple vnets of the same name across different resource groups, use vnet resource id to specify which vnet to use. If vnet name is used, by default, the vnet in the same resource group as the webapp will be used. Must be used with --subnet argument.")
         c.argument('subnet', options_list=['--subnet'], help="Name or resource ID of the pre-existing subnet to have the webapp join. The --vnet is argument also needed if specifying subnet by name.")
         c.argument('environment', help="Name of the container app environment.", is_preview=True)
+        c.argument('min_replicas', options_list=['--min-replicas'], help="The minimum number of replicas", is_preview=True)
         c.argument('image', options_list=['--image', '-i', c.deprecate(target='--deployment-container-image-name', redirect='--image')],
                    help='Container image, e.g. publisher/image-name:tag')
         c.argument('registry_username', options_list=['--registry-username', '-d', c.deprecate(target='--docker-registry-server-user', redirect='--registry-username')], help='The container registry server username.')

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3813,7 +3813,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         setattr(site_config, snake_case_prop, value)
 
     if environment is not None:
-        functionapp_def.kind = 'functionapp,linux,container,azurecontainerapps'
+        functionapp_def.kind = 'functionapp'
         functionapp_def.reserved = None
         functionapp_def.name = name
         functionapp_def.https_only = None
@@ -3839,7 +3839,8 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         functionapp_def.additional_properties["properties"] = existing_properties
         functionapp_def.additional_properties["properties"]["name"] = name
         functionapp_def.additional_properties["properties"]["managedEnvironmentId"] = managed_environment.id
-        functionapp_def.additional_properties["properties"]["minReplicas"] = int(min_replicas)
+        if min_replicas:
+            functionapp_def.additional_properties["properties"]["minReplicas"] = int(min_replicas)
 
     # temporary workaround for dotnet-isolated linux consumption apps
     if is_linux and consumption_plan_location is not None and runtime == 'dotnet-isolated':

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -3802,7 +3802,7 @@ def create_functionapp(cmd, resource_group_name, name, storage_account, plan=Non
         setattr(site_config, snake_case_prop, value)
 
     if environment is not None:
-        functionapp_def.kind = 'functionapp'
+        functionapp_def.kind = 'functionapp,linux,container,azurecontainerapps'
         functionapp_def.reserved = None
         functionapp_def.name = name
         functionapp_def.https_only = None


### PR DESCRIPTION
**Related command**
`az functionapp create`
`az functionapp config container set`

**Description**<!--Mandatory-->
For Public Preview, we want to support minReplicas for Centauri function apps since container apps support it. In this PR, we have made changes to pass this attribute in the PUT request when creating Centauri function apps and in the PATCH request when updating the site configs for Centauri function apps (we are assuming that minReplicas will be considered a site config).

**Testing Guide**
`az functionapp create -g <resourceGroupName> -n <functionAppName> -s <storageAccountName> --functions-version 4 --environment <containerAppEnvName> --min-replicas 4`
`az functionapp config container set -g <resourceGroupName> -n <functionAppName> --min-replicas 4`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
