### PR TITLE
{Servicebus} Add Breaking change message for `az servicebus georecovery-alias fail-over` cmdlets

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicebus/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_help.py
@@ -72,7 +72,7 @@ type: command
 short-summary: Invokes Service Bus Geo-Disaster Recovery Configuration Alias failover and re-configure the alias to point to the secondary namespace
 examples:
   - name: Invokes Geo-Disaster Recovery Configuration Alias failover and reconfigure the alias to point to the secondary namespace
-    text: az servicebus georecovery-alias fail-over --resource-group myresourcegroup --namespace-name secondarynamespace --alias myaliasname
+    text: az servicebus georecovery-alias fail-over --resource-group myresourcegroup --namespace-name secondarynamespace --alias myaliasname --parameters {FailoverProperties}
 """
 
 helps['servicebus georecovery-alias set'] = """

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_help.py
@@ -72,7 +72,7 @@ type: command
 short-summary: Invokes Service Bus Geo-Disaster Recovery Configuration Alias failover and re-configure the alias to point to the secondary namespace
 examples:
   - name: Invokes Geo-Disaster Recovery Configuration Alias failover and reconfigure the alias to point to the secondary namespace
-    text: az servicebus georecovery-alias fail-over --resource-group myresourcegroup --namespace-name secondarynamespace --alias myaliasname --parameters {FailoverProperties}
+    text: az servicebus georecovery-alias fail-over --resource-group myresourcegroup --namespace-name secondarynamespace --alias myaliasname
 """
 
 helps['servicebus georecovery-alias set'] = """

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -208,6 +208,9 @@ def load_arguments_sb(self, _):
     with self.argument_context('servicebus georecovery-alias list') as c:
         c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of Namespace')
 
+    with self.argument_context('servicebus georecovery-alias fail-over') as c:
+        c.argument('parameters', options_list=['--parameters'], deprecate_info=c.deprecate(expiration='2.49.0'), help='Parameters required to create an Alias(Disaster Recovery configuration). Is either a FailoverProperties type or a IO type. Default value is None.')
+
     with self.argument_context('servicebus georecovery-alias authorization-rule list') as c:
         c.argument('alias', options_list=['--alias', '-a'], help='Name of Geo-Disaster Recovery Configuration Alias')
         c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of Namespace')

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -217,7 +217,9 @@ def load_arguments_sb(self, _):
         c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of Namespace')
         c.argument('authorization_rule_name', arg_type=name_type, help='Name of Namespace AuthorizationRule')
 
-    # Standard to Premium Migration: Region
+    with self.argument_context('servicebus georecovery-alias fail-over') as c:
+        c.extra('parameters', options_list=['--parameters'], deprecate_info=c.deprecate(expiration='2.50.0'))
+# Standard to Premium Migration: Region
 
     with self.argument_context('servicebus migration start') as c:
         c.ignore('config_name')

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -217,8 +217,6 @@ def load_arguments_sb(self, _):
         c.argument('namespace_name', options_list=['--namespace-name'], id_part=None, help='Name of Namespace')
         c.argument('authorization_rule_name', arg_type=name_type, help='Name of Namespace AuthorizationRule')
 
-    with self.argument_context('servicebus georecovery-alias fail-over') as c:
-        c.extra('parameters', options_list=['--parameters'], deprecate_info=c.deprecate(hide=True, expiration='2.50.0'))
 # Standard to Premium Migration: Region
 
     with self.argument_context('servicebus migration start') as c:

--- a/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/_params.py
@@ -218,7 +218,7 @@ def load_arguments_sb(self, _):
         c.argument('authorization_rule_name', arg_type=name_type, help='Name of Namespace AuthorizationRule')
 
     with self.argument_context('servicebus georecovery-alias fail-over') as c:
-        c.extra('parameters', options_list=['--parameters'], deprecate_info=c.deprecate(expiration='2.50.0'))
+        c.extra('parameters', options_list=['--parameters'], deprecate_info=c.deprecate(hide=True, expiration='2.50.0'))
 # Standard to Premium Migration: Region
 
     with self.argument_context('servicebus migration start') as c:

--- a/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/servicebus/custom.py
@@ -105,6 +105,8 @@ def cli_georecovery_alias_create(cmd, client, resource_group_name, namespace_nam
             'partner_namespace': partner_namespace,
             'alternate_name': alternate_name,
         }
+        logger.warning(
+            'the argument parameters from georecovery-alias fail-over cmdlets will be remove in future release.')
         return client.create_or_update(resource_group_name=resource_group_name, namespace_name=namespace_name,
                                        alias=alias, parameters=parameters)
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
`parameters` argument will be removed from `az servicebus georecovery-alias fail-over` cmdlets in future release.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
