### PR TITLE
{Packaging} Optimize Linux package and docker image by trimming SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY . /azure-cli
 
 # 1. Build packages and store in tmp dir
 # 2. Install the cli and the other command modules that weren't included
-RUN ./scripts/install_full.sh \
+RUN ./scripts/install_full.sh && python ./scripts/trim_sdk.py \
  && cat /azure-cli/az.completion > ~/.bashrc \
  && runDeps="$( \
     scanelf --needed --nobanner --recursive /usr/local \

--- a/scripts/release/debian/build.sh
+++ b/scripts/release/debian/build.sh
@@ -52,6 +52,7 @@ export PATH=$PATH:$WORKDIR/python_env/bin
 
 find ${WORKDIR}/src/ -name setup.py -type f | xargs -I {} dirname {} | grep -v azure-cli-testsdk | xargs pip3 install --no-deps
 pip3 install -r ${WORKDIR}/src/azure-cli/requirements.py3.$(uname).txt
+$WORKDIR/python_env/bin/python3 ${WORKDIR}/scripts/trim_sdk.py
 
 # Create create directory for debian build
 mkdir -p $WORKDIR/debian

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -48,12 +48,11 @@ A great cloud needs great tools; we're excited to introduce Azure CLI,
 source %{buildroot}%{cli_lib_dir}/bin/activate
 %{python_cmd} -m pip install --upgrade pip setuptools
 source %{repo_path}/scripts/install_full.sh
+# Remove unused SDK version
+%{python_cmd} %{repo_path}/scripts/trim_sdk.py
 
 # cffi 1.15.0 doesn't work with RPM: https://foss.heptapod.net/pypy/cffi/-/issues/513
 %{python_cmd} -m pip install cffi==1.14.6
-
-# Remove unused SDK version
-%{python_cmd} %{repo_path}/scripts/trim_sdk.py
 
 deactivate
 

--- a/scripts/release/rpm/azure-cli.spec
+++ b/scripts/release/rpm/azure-cli.spec
@@ -52,6 +52,9 @@ source %{repo_path}/scripts/install_full.sh
 # cffi 1.15.0 doesn't work with RPM: https://foss.heptapod.net/pypy/cffi/-/issues/513
 %{python_cmd} -m pip install cffi==1.14.6
 
+# Remove unused SDK version
+%{python_cmd} %{repo_path}/scripts/trim_sdk.py
+
 deactivate
 
 # Fix up %{buildroot} appearing in some files...


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We have used `trim_sdk.py` and only keep pyc file on Windows. Apply them on Linux and docker to reduce package size.

This is the first part, use trim_sdk on Linux.
Using pyc is https://github.com/Azure/azure-cli/pull/25801

Result:
Ubuntu 22.04 installed size: 965MB -> 576 MB, become 60% of original size. 
RHEL 9 installed size 771MB -> 403 MB, become 52% of original size. 
Docker  1328MB -> 952MB,  become 72% of original size. 

**Testing Guide**
<!--Example commands with explanations.--> 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
