### PR TITLE
{CI} Use serial test in azure-cli-core, iot, resource

### DIFF
--- a/scripts/release/debian/test_deb_package.py
+++ b/scripts/release/debian/test_deb_package.py
@@ -12,7 +12,7 @@ mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path
 
 pytest_base_cmd = '/opt/az/bin/python3 -m pytest -x -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
-serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
+serial_test_modules = ['botservice', 'network', 'cloud', 'appservice', 'iot', 'resource']
 
 for mod_name in mod_list:
     cmd = '{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(
@@ -24,5 +24,5 @@ for mod_name in mod_list:
     elif exit_code != 0:
         sys.exit(exit_code)
 
-exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/azure-cli-core.xml --pyargs azure.cli.core'.format(pytest_parallel_cmd)], shell=True)
+exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/azure-cli-core.xml --pyargs azure.cli.core'.format(pytest_base_cmd)], shell=True)
 sys.exit(exit_code)

--- a/scripts/release/rpm/test_rpm_package.py
+++ b/scripts/release/rpm/test_rpm_package.py
@@ -13,7 +13,7 @@ mod_list = [mod for mod in sorted(os.listdir(root_dir)) if os.path.isdir(os.path
 
 pytest_base_cmd = f'PYTHONPATH=/usr/lib64/az/lib/{python_version}/site-packages python -m pytest -x -v --forked -p no:warnings --log-level=WARN'
 pytest_parallel_cmd = '{} -n auto'.format(pytest_base_cmd)
-serial_test_modules = ['botservice', 'network', 'cloud', 'appservice']
+serial_test_modules = ['botservice', 'network', 'cloud', 'appservice', 'iot', 'resource']
 
 for mod_name in mod_list:
     cmd = '{} --junit-xml /azure_cli_test_result/{}.xml --pyargs azure.cli.command_modules.{}'.format(
@@ -25,5 +25,5 @@ for mod_name in mod_list:
     elif exit_code != 0:
         sys.exit(exit_code)
 
-exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/azure-cli-core.xml --pyargs azure.cli.core'.format(pytest_parallel_cmd)], shell=True)
+exit_code = subprocess.call(['{} --junit-xml /azure_cli_test_result/azure-cli-core.xml --pyargs azure.cli.core'.format(pytest_base_cmd)], shell=True)
 sys.exit(exit_code)


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Add those module to `serial_test_modules` to prevent failure in ARM64 Test because of high concurrency.

### core
It hardcode `cloud.config` path. See https://github.com/Azure/azure-cli/pull/26138
### iot
It does not use `random_config_dir`, so the error occurs when write to same config file.
https://github.com/Azure/azure-cli/blob/7a087b14d59296832cbbabe496bef2e0a2557e28/src/azure-cli/azure/cli/command_modules/iot/__init__.py#L14-L29
### resource
It consists of tests that install & uninstall same bicep binary file.
`azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py`


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
