### PR TITLE
{RDBMS} Postgres Flexible server - Fix az cli issue for PG public access server for Network object with recent M-train changes

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/flexible_server_custom_postgres.py
@@ -145,7 +145,7 @@ def flexible_server_create(cmd, client,
     version = server_result.version
     sku = server_result.sku.name
     host = server_result.fully_qualified_domain_name
-    subnet_id = network.delegated_subnet_resource_id
+    subnet_id = None if network is None else network.delegated_subnet_resource_id
 
     logger.warning('Make a note of your password. If you forget, you would have to '
                    'reset your password with "az postgres flexible-server update -n %s -g %s -p <new-password>".',
@@ -760,9 +760,10 @@ def flexible_server_provision_network_resource(cmd, resource_group_name, server_
                                                vnet=None, subnet=None, vnet_address_prefix=None, subnet_address_prefix=None, yes=False):
     start_ip = -1
     end_ip = -1
-    network = postgresql_flexibleservers.models.Network()
+    network = None
 
     if subnet is not None or vnet is not None:
+        network = postgresql_flexibleservers.models.Network()
         subnet_id = prepare_private_network(cmd,
                                             resource_group_name,
                                             server_name,


### PR DESCRIPTION
Fix az cli issue for PG public access server for sending empty Network properties in Network object for public access server instead of sending Network object as null

**Related command**
az postgres flexible-server create -g <resource_group_name> -n <server_name> -l <location_name>

**Description**<!--Mandatory-->
In recent M-train we added a String.IsNullOrEmpty check for one of the Network properties PrivateDnsZoneArmResourceId. This resulted into the cli command breaking for public access servers. This is because the CLI was sending Network object instantiated with empty properties "network": {"delegatedSubnetResourceId": "", "privateDnsZoneArmResourceId": ""}.

The fix here is to send the Network object as null in case of public access servers.

**Testing Guide**
Verified public access server creation with this change.


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [X ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [X ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
