### PR TITLE
[Core] `extension`: Install extensions without prompt as default behavior when it's not in a tty

### DIFF
--- a/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
+++ b/src/azure-cli-core/azure/cli/core/extension/dynamic_install.py
@@ -121,7 +121,14 @@ def try_install_extension(parser, args):
 
 
 def _get_extension_use_dynamic_install_config(cli_ctx):
-    default_value = 'yes_prompt'
+    from knack.prompting import verify_is_a_tty, NoTTYException
+    try:
+        verify_is_a_tty()
+        # prompt when it's in tty
+        default_value = 'yes_prompt'
+    except NoTTYException:
+        # without prompt when it's not in tty
+        default_value = 'yes_without_prompt'
     use_dynamic_install = cli_ctx.config.get(
         'extension', 'use_dynamic_install', default_value).lower() if cli_ctx else default_value
     if use_dynamic_install not in ['no', 'yes_prompt', 'yes_without_prompt']:

--- a/src/azure-cli-core/azure/cli/core/tests/test_extension.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extension.py
@@ -230,6 +230,16 @@ class TestExtensions(TestExtensionsBase):
             self.assertFalse(is_compatible)
             self.assertEqual(min_ext_required, expected_min_ext_required)
 
+    @mock.patch('sys.stdin.isatty', return_value=True)
+    def test_ext_dynamic_install_config_tty(self, _):
+        from azure.cli.core.extension.dynamic_install import _get_extension_use_dynamic_install_config
+        self.assertEqual(_get_extension_use_dynamic_install_config(None), 'yes_prompt')
+
+    @mock.patch('sys.stdin.isatty', return_value=False)
+    def test_ext_dynamic_install_config_tty(self, _):
+        from azure.cli.core.extension.dynamic_install import _get_extension_use_dynamic_install_config
+        self.assertEqual(_get_extension_use_dynamic_install_config(None), 'yes_without_prompt')
+
 
 class TestWheelExtension(TestExtensionsBase):
 

--- a/src/azure-cli-core/azure/cli/core/tests/test_extension.py
+++ b/src/azure-cli-core/azure/cli/core/tests/test_extension.py
@@ -236,7 +236,7 @@ class TestExtensions(TestExtensionsBase):
         self.assertEqual(_get_extension_use_dynamic_install_config(None), 'yes_prompt')
 
     @mock.patch('sys.stdin.isatty', return_value=False)
-    def test_ext_dynamic_install_config_tty(self, _):
+    def test_ext_dynamic_install_config_no_tty(self, _):
         from azure.cli.core.extension.dynamic_install import _get_extension_use_dynamic_install_config
         self.assertEqual(_get_extension_use_dynamic_install_config(None), 'yes_without_prompt')
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

When we run a command in an extension which is not installed, it will show a prompt like this
![image](https://user-images.githubusercontent.com/69238381/236151420-f72111eb-ddf1-4e78-9238-0325fc34198a.png)

This will block the script in no-tty environment. This PR use the `yes_without_prompt` mode as default for no-tty environment, so that the missing commands will be installed automatically.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
