### PR TITLE
[AKS] BREAKING CHANGE: `az aks create`: Raise error when specifying `--pod-cidr` with `--network-plugin azure` without overlay

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -2181,12 +2181,10 @@ class AKSManagedClusterContext(BaseAKSContext):
             network_plugin_mode = self._get_network_plugin_mode(enable_validation=False)
             if network_plugin:
                 if network_plugin == "azure" and pod_cidr and network_plugin_mode != "overlay":
-                    logger.warning(
-                        'The provided pod CIDR "%s" will be overwritten with the node subnet CIDR. '
-                        'To use a pod CIDR, please specify network plugin mode `overlay` or '
-                        'use network plugin `kubenet`. For more information about Azure CNI '
-                        'Overlay please see https://aka.ms/aks/azure-cni-overlay. This warning '
-                        'will become an error in the Build sprint release.', pod_cidr
+                    raise InvalidArgumentValueError(
+                        "Please specify network plugin mode `overlay` when using --pod-cidr or "
+                        "use network plugin `kubenet`. For more information about Azure CNI "
+                        "Overlay please see https://aka.ms/aks/azure-cni-overlay"
                     )
             else:
                 if (

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -1783,8 +1783,9 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             self.models,
             DecoratorMode.CREATE,
         )
-        # overwrite warning
-        self.assertEqual(ctx_3.get_network_plugin(), "azure")
+
+        with self.assertRaises(InvalidArgumentValueError):
+            self.assertEqual(ctx_3.get_network_plugin(), "azure")
 
     def test_mc_get_network_dataplane(self):
         # Default, not set.


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az aks create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Raise an error instead of logging a warning when using `--pod-cidr` with `--network-plugin azure` without `--network-plugin-mode overlay`

**Testing Guide**
<!--Example commands with explanations.-->
azdev test acs.test_get_network_plugin

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] BREAKING CHANGE: `az aks create`: Specifying `--pod-cidr` with Azure CNI will return an error instead of logging a warning when not use `overlay` mode

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
