### PR TITLE
[RDBMS] BREAKING CHANGE: `az mysql/postgres flexible-server create/update`: Deprecate `Enabled` for `--high-availability` argument

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/_params.py
@@ -16,8 +16,7 @@ from azure.cli.core.commands.parameters import (
     get_three_state_flag)
 from azure.cli.command_modules.rdbms.validators import configuration_value_validator, validate_subnet, \
     tls_validator, public_access_validator, maintenance_window_validator, ip_address_validator, \
-    retention_validator, firewall_rule_name_validator, validate_identity, validate_byok_identity, validate_identities, \
-    high_availability_validator
+    retention_validator, firewall_rule_name_validator, validate_identity, validate_byok_identity, validate_identities
 from azure.cli.core.local_context import LocalContextAttribute, LocalContextAction
 
 from .randomname.generate import generate_username
@@ -384,10 +383,9 @@ def load_arguments(self, _):    # pylint: disable=too-many-statements, too-many-
         )
 
         high_availability_arg_type = CLIArgumentType(
-            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled', 'Enabled']),
+            arg_type=get_enum_type(['ZoneRedundant', 'SameZone', 'Disabled']),
             options_list=['--high-availability'],
-            help='Enable (ZoneRedundant or SameZone) or disable high availability feature.',
-            validator=high_availability_validator
+            help='Enable (ZoneRedundant or SameZone) or disable high availability feature.'
         )
 
         mysql_version_upgrade_arg_type = CLIArgumentType(

--- a/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/validators.py
@@ -651,10 +651,3 @@ def validate_byok_identity(cmd, namespace):
 def validate_identities(cmd, namespace):
     if namespace.identities:
         namespace.identities = [_validate_identity(cmd, namespace, identity) for identity in namespace.identities]
-
-
-def high_availability_validator(namespace):
-    if namespace.high_availability and namespace.high_availability == 'Enabled':
-        logger.warning("'Enabled' value for high availability parameter will be deprecated by April 2023. "
-                       "Please use 'ZoneRedundant' or 'SameZone' instead.")
-        namespace.high_availability = 'ZoneRedundant'


### PR DESCRIPTION
**Related command**
`az mysql/postgres flexible-server create/update`

**Description**<!--Mandatory-->
`Enabled` value for `--high-availability` argument in commands `az mysql/postgres flexible-server create/update` will be deprecated. The possible values for that argument will be only `ZoneRedundant`, `SameZone` and `Disabled`, the value `Enabled` was the same as `ZoneRedundant`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
