### PR TITLE
{APIM} public network access parameter values should be Enabled or Disabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/apim/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/_params.py
@@ -68,8 +68,9 @@ def load_arguments(self, _):
         c.argument('sku_capacity', type=int, help='The number of deployed units of the SKU.')
         c.argument('enable_managed_identity', arg_type=get_three_state_flag(),
                    help='Create a managed identity for the API Management service to access other Azure resources. Only meant to be used for Consumption SKU Service.')
-        c.argument('public_network_access', arg_type=get_three_state_flag(),
-                   help='Whether or not public endpoint access is allowed for this API Management service. If set to true, private endpoints are the exclusive access method.')
+        c.argument('public_network_access',
+                   help='Whether or not public endpoint access is allowed for this API Management service. If set to Disabled, private endpoints are the exclusive access method.',
+                   choices=['Enabled', 'Disabled'])
         c.argument('disable_gateway', arg_type=get_three_state_flag(),
                    help='Disable gateway in the master region. Only valid for an Api Management service deployed in multiple locations.')
 
@@ -87,8 +88,9 @@ def load_arguments(self, _):
         c.argument('sku_capacity', type=int, help='The number of deployed units of the SKU.')
         c.argument('enable_managed_identity', arg_type=get_three_state_flag(),
                    help='Create a managed identity for the API Management service to access other Azure resources. Only meant to be used for Consumption SKU Service.')
-        c.argument('public_network_access', arg_type=get_three_state_flag(),
-                   help='Whether or not public endpoint access is allowed for this API Management service. If set to true, private endpoints are the exclusive access method.')
+        c.argument('public_network_access',
+                   help='Whether or not public endpoint access is allowed for this API Management service. If set to Disabled, private endpoints are the exclusive access method.',
+                   choices=['Enabled', 'Disabled'])
         c.argument('disable_gateway', arg_type=get_three_state_flag(),
                    help='Disable gateway in the master region. Only valid for an Api Management service deployed in multiple locations.')
 


### PR DESCRIPTION
fixes Azure/azure-rest-api-specs#23683

[This](https://learn.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-management-service/create-or-update) REST API where it clearly talks about the `--public-network-access` accepting the values `Enabled or Disabled`.

Seeing the [REST API Specs swagger](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2021-12-01-preview/apimdeployment.json#L1323), I see the accepted values are `Enabled` or `Disabled`.

However in Azure CLI, `apim update` and `apim create` is expecting true or false. This is causing an unexpected behavior with the apim creation and updating the `--public-network-access` setting.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
