### PR TITLE
{Core} `aaz`: Fix importlib deadlocks while loading `requests.models` in multi threads

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_poller.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_poller.py
@@ -14,8 +14,7 @@ from azure.core.tracing.common import with_current_context
 from azure.core.tracing.decorator import distributed_trace
 # import LROPoller in main thread to resolve import deadlock between threads in python 3.10.10
 # reference https://github.com/psf/requests/issues/2925 and https://github.com/Azure/azure-cli/issues/26272
-from msrest.polling.poller import LROPoller  # pylint: disable=unused-import
-
+import requests
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_poller.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_poller.py
@@ -12,7 +12,7 @@ from azure.core.polling import NoPolling
 from azure.core.polling.base_polling import LROBasePolling
 from azure.core.tracing.common import with_current_context
 from azure.core.tracing.decorator import distributed_trace
-# import LROPoller in main thread to resolve import deadlock between threads in python 3.10.10
+# import requests in main thread to resolve import deadlock between threads in python
 # reference https://github.com/psf/requests/issues/2925 and https://github.com/Azure/azure-cli/issues/26272
 import requests  # pylint: disable=unused-import
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_poller.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_poller.py
@@ -12,6 +12,10 @@ from azure.core.polling import NoPolling
 from azure.core.polling.base_polling import LROBasePolling
 from azure.core.tracing.common import with_current_context
 from azure.core.tracing.decorator import distributed_trace
+# import LROPoller in main thread to resolve import deadlock between threads in python 3.10.10
+# reference https://github.com/psf/requests/issues/2925 and https://github.com/Azure/azure-cli/issues/26272
+from msrest.polling.poller import LROPoller  # pylint: disable=unused-import
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/azure-cli-core/azure/cli/core/aaz/_poller.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_poller.py
@@ -14,7 +14,7 @@ from azure.core.tracing.common import with_current_context
 from azure.core.tracing.decorator import distributed_trace
 # import LROPoller in main thread to resolve import deadlock between threads in python 3.10.10
 # reference https://github.com/psf/requests/issues/2925 and https://github.com/Azure/azure-cli/issues/26272
-import requests
+import requests  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
closed: #26272
closed: #26297

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

In python 3.10.10, we encountered import deadlocks in `aaz` LRO which try to load the `requests.models` in two different threads. It's a known issue https://github.com/psf/requests/issues/2925

In this PR, we provide a workaround by importing these modules in the main thread before spawning child threads.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
