### PR TITLE
{IoT} Fix recorder and poller issues

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/iot/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/custom.py
@@ -585,7 +585,7 @@ def iot_hub_create(cmd, client, hub_name, resource_group_name, location=None,
         except CloudError as e:
             raise e
 
-    create = client.iot_hub_resource.begin_create_or_update(resource_group_name, hub_name, hub_description, polling=True)
+    create = client.iot_hub_resource.begin_create_or_update(resource_group_name, hub_name, hub_description)
     if identity_role and identity_scopes:
         create.add_done_callback(identity_assignment)
     return create
@@ -704,12 +704,12 @@ def update_iot_hub_custom(instance,
 
 def iot_hub_update(client, hub_name, parameters, resource_group_name=None):
     resource_group_name = _ensure_hub_resource_group_name(client, resource_group_name, hub_name)
-    return client.iot_hub_resource.begin_create_or_update(resource_group_name, hub_name, parameters, {'IF-MATCH': parameters.etag}, polling=True)
+    return client.iot_hub_resource.begin_create_or_update(resource_group_name, hub_name, parameters, {'IF-MATCH': parameters.etag})
 
 
 def iot_hub_delete(client, hub_name, resource_group_name=None):
     resource_group_name = _ensure_hub_resource_group_name(client, resource_group_name, hub_name)
-    return client.iot_hub_resource.begin_delete(resource_group_name, hub_name, polling=True)
+    return client.iot_hub_resource.begin_delete(resource_group_name, hub_name)
 
 
 # pylint: disable=inconsistent-return-statements

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recording_processors.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/recording_processors.py
@@ -34,7 +34,7 @@ class KeyReplacer(RecordingProcessor):
                          .format(MOCK_KEY), val, flags=re.IGNORECASE)
         if any(['SharedAccessKey=' in val, 'sharedaccesskey=' in val]):
             # Replaces live key with `mock_key` in `SharedAccessKey=live_key` or `sharedaccesskey=live_key` string response
-            val = re.sub(r'[S|s]hared[A|a]ccess[K|k]ey=([^\*].+=);?', 'SharedAccessKey={};'
+            val = re.sub(r'[S|s]hared[A|a]ccess[K|k]ey=([^\*=]+=);?', 'SharedAccessKey={};'
                          .format(MOCK_KEY), val, flags=re.IGNORECASE)
         return val
 
@@ -49,6 +49,6 @@ class KeyReplacer(RecordingProcessor):
                          .format(MOCK_KEY).encode(), val, flags=re.IGNORECASE)
         if any([b'SharedAccessKey=' in val, b'sharedaccesskey=' in val]):
             # Replaces live key with `mock_key` in `SharedAccessKey=live_key` or `sharedaccesskey=live_key` byte response
-            val = re.sub(br'[S|s]hared[A|a]ccess[K|k]ey=([^\*].+=);?', 'SharedAccessKey={};'
+            val = re.sub(br'[S|s]hared[A|a]ccess[K|k]ey=([^\*=]+=);?', 'SharedAccessKey={};'
                          .format(MOCK_KEY).encode(), val, flags=re.IGNORECASE)
         return val

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -252,7 +252,7 @@ class IoTHubTest(ScenarioTest):
         storage_batch_frequency = 100
         storage_file_name_format = '{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}'
         # Test 'az iot hub routing-endpoint create'
-        self.cmd('iot hub routing-endpoint create --hub-name {0} -g {1} -n {2} -t {3} -r {4} -s {5} -c "{6}"'
+        x = self.cmd('iot hub routing-endpoint create --hub-name {0} -g {1} -n {2} -t {3} -r {4} -s {5} -c "{6}"'
                  .format(hub, rg, endpoint_name, endpoint_type, rg, subscription_id, ehConnectionString),
                  checks=[self.check('length(eventHubs[*])', 1),
                          self.check('eventHubs[0].resourceGroup', rg),

--- a/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/iot/tests/latest/test_iot_commands.py
@@ -252,7 +252,7 @@ class IoTHubTest(ScenarioTest):
         storage_batch_frequency = 100
         storage_file_name_format = '{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}'
         # Test 'az iot hub routing-endpoint create'
-        x = self.cmd('iot hub routing-endpoint create --hub-name {0} -g {1} -n {2} -t {3} -r {4} -s {5} -c "{6}"'
+        self.cmd('iot hub routing-endpoint create --hub-name {0} -g {1} -n {2} -t {3} -r {4} -s {5} -c "{6}"'
                  .format(hub, rg, endpoint_name, endpoint_type, rg, subscription_id, ehConnectionString),
                  checks=[self.check('length(eventHubs[*])', 1),
                          self.check('eventHubs[0].resourceGroup', rg),


### PR DESCRIPTION
**Related command**
`az iot hub create`
`az iot hub update`
`az iot hub delete`

**Description**<!--Mandatory-->
For the following commands:
`az iot hub create`
`az iot hub update`
`az iot hub delete`
followed the instructions [here](https://github.com/Azure/azure-cli/issues/25479) and removed polling=True so a separate thread is not created.

Also fixed the recorder so that it replaces the SharedAccessKey correctly. Before, we had to manually fix the recording after rerecording tests.

**Testing Guide**
azdev test test_iot_hub

Ran the test live and then reran it using the recording and both pass.

**History Notes**
[IoT] Fix poller issues for `az iot hub create`, `az iot hub update`, `az iot hub delete`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
