### PR TITLE
az vm create optional parameter update.

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_help.py
@@ -3815,3 +3815,6 @@ helps['restore-point collection wait'] = """
         text: |-
                az restore-point collection wait --resource-group "myResourceGroup" --collection-name "rpcName" --deleted
 """
+
+--public-ip-address
+Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None ('""' in Azure CLI using PowerShell or --% operator). For Azure CLI using powershell core edition 7.3.4, specify '' or "" (--public-ip-address '' or --public-ip-address "")


### PR DESCRIPTION
--public-ip-address
Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None ('""' in Azure CLI using PowerShell or --% operator).

**Description**
We have tested with different versions of OS and PowerShell core version 7.3.4 to test the public-ip-address parameter behavior and below is our findings when we have to create VM without public IP:

For PowerShell core version 7.2.* & below === --public-ip-address '""'
For PowerShell core version 7.3.4 ===== --public-ip-address ‘’ or --public-ip-address “” ---------------------------------------- Here we just have to use single field i.e., either single inverted comma (‘’) or just double inverted comma (“”). 

Since, cloud shell also uses PowerShell core edition so here also we saw the same behavior in past. This not specific to any OS version as such, we just need to do slight modification in command while using PowerShell core version 7.3.4.

**Testing Guide**

az vm create --name newvm --resource-group testazcli --image Win2022Datacenter --admin-username sinhamanisha --admin-password Manishasinha*10 --subnet /subscriptions/6b26da86-6cfd-4198-afde-fb754b11c54e/resourceGroups/testazcli/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet --location southindia --size Standard_E32s_v3 **--public-ip-address ''**

OR

az vm create --name newvm --resource-group testazcli --image Win2022Datacenter --admin-username sinhamanisha --admin-password Manishasinha*10 --subnet /subscriptions/6b26da86-6cfd-4198-afde-fb754b11c54e/resourceGroups/testazcli/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet --location southindia --size Standard_E32s_v3 --public-ip-address ""

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
