### PR TITLE
[AKS] `az aks install-cli`: Add validation for installation path and update help message for parameters `--install-location` and `--kubelogin-install-location`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -391,10 +391,10 @@ def load_arguments(self, _):
 
     with self.argument_context('aks install-cli') as c:
         c.argument('client_version', validator=validate_kubectl_version, help='Version of kubectl to install.')
-        c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl.')
+        c.argument('install_location', default=_get_default_install_location('kubectl'), help='Path at which to install kubectl. Note: the path should contain the binary filename.')
         c.argument('base_src_url', help='Base download source URL for kubectl releases.')
         c.argument('kubelogin_version', validator=validate_kubelogin_version, help='Version of kubelogin to install.')
-        c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin.')
+        c.argument('kubelogin_install_location', default=_get_default_install_location('kubelogin'), help='Path at which to install kubelogin. Note: the path should contain the binary filename.')
         c.argument('kubelogin_base_src_url', options_list=['--kubelogin-base-src-url', '-l'], help='Base download source URL for kubelogin releases.')
 
     with self.argument_context('aks update-credentials', arg_group='Service Principal') as c:

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1488,9 +1488,9 @@ def get_arch_for_cli_binary():
             )
         )
     logger.warning(
-        "The detected architecture is '%s', which will be regarded as '%s' and "
-        "the corresponding binary will be downloaded. "
-        "If there is any problem, please download the appropriate binary by yourself.",
+        'The detected architecture of current device is "%s", and the binary for "%s" '
+        'will be downloaded. If the detectiton is wrong, please download and install '
+        'the binary corresponding to the appropriate architecture.',
         arch,
         formatted_arch,
     )
@@ -1574,6 +1574,17 @@ def log_windows_post_installation_manual_steps_warning(install_dir, binary_name)
     )
 
 
+def validate_install_location(install_location: str, exe_name: str) -> None:
+    if os.path.isdir(install_location):
+        from azure.cli.command_modules.acs._params import _get_default_install_location
+        raise InvalidArgumentValueError(
+            'The installation location "{}" is a directory. Please specify a path '
+            'including the binary filename e.g. "{}".'.format(
+                install_location, _get_default_install_location(exe_name)
+            )
+        )
+
+
 # install kubectl
 def k8s_install_kubectl(cmd, client_version='latest', install_location=None, source_url=None, arch=None):
     """
@@ -1587,8 +1598,9 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
             source_url = 'https://mirror.azure.cn/kubernetes/kubectl'
 
     if client_version == 'latest':
-        context = _ssl_context()
-        version = urlopen(source_url + '/stable.txt', context=context).read()
+        latest_version_url = source_url + '/stable.txt'
+        logger.warning('No version specified, will get the latest version of kubectl from "%s"', latest_version_url)
+        version = urlopen(source_url + '/stable.txt', context=_ssl_context()).read()
         client_version = version.decode('UTF-8').strip()
     else:
         client_version = "v%s" % client_version
@@ -1600,6 +1612,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
     base_url = source_url + f"/{{}}/bin/{{}}/{arch}/{{}}"
 
     # ensure installation directory exists
+    validate_install_location(install_location, "kubectl")
     install_dir, cli = os.path.dirname(
         install_location), os.path.basename(install_location)
     if not os.path.exists(install_dir):
@@ -1614,8 +1627,7 @@ def k8s_install_kubectl(cmd, client_version='latest', install_location=None, sou
     else:
         raise UnknownError("Unsupported system '{}'.".format(system))
 
-    logger.warning('Downloading client to "%s" from "%s"',
-                   install_location, file_url)
+    logger.warning('Downloading client to "%s" from "%s"', install_location, file_url)
     try:
         _urlretrieve(file_url, install_location)
         os.chmod(install_location,
@@ -1645,11 +1657,11 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
             source_url = 'https://mirror.azure.cn/kubernetes/kubelogin'
 
     if client_version == 'latest':
-        context = _ssl_context()
         latest_release_url = 'https://api.github.com/repos/Azure/kubelogin/releases/latest'
         if cloud_name.lower() == 'azurechinacloud':
             latest_release_url = 'https://mirror.azure.cn/kubernetes/kubelogin/latest'
-        latest_release = urlopen(latest_release_url, context=context).read()
+        logger.warning('No version specified, will get the latest version of kubelogin from "%s"', latest_release_url)
+        latest_release = urlopen(latest_release_url, context=_ssl_context()).read()
         client_version = json.loads(latest_release)['tag_name'].strip()
     else:
         client_version = "v%s" % client_version
@@ -1658,6 +1670,7 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
     file_url = base_url.format(client_version)
 
     # ensure installation directory exists
+    validate_install_location(install_location, "kubelogin")
     install_dir, cli = os.path.dirname(
         install_location), os.path.basename(install_location)
     if not os.path.exists(install_dir):
@@ -1686,6 +1699,7 @@ def k8s_install_kubelogin(cmd, client_version='latest', install_location=None, s
                 'Connection error while attempting to download client ({})'.format(ex))
         _unzip(download_path, tmp_dir)
         download_path = os.path.join(tmp_dir, 'bin', sub_dir, binary_name)
+        logger.warning('Moving binary to "%s" from "%s"', install_location, download_path)
         shutil.move(download_path, install_location)
     os.chmod(install_location, os.stat(install_location).st_mode |
              stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/hybrid_2020_09_01/test_custom.py
@@ -647,8 +647,8 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubelogin')
             k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result, 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 3 warnings, one for download result
+            # 3 warnings, 1st for download result, 2nd for moving file, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_custom.py
@@ -631,8 +631,8 @@ class AcsCustomCommandTest(unittest.TestCase):
             test_location = os.path.join(temp_dir, 'kubelogin')
             k8s_install_kubelogin(mock.MagicMock(), client_version='0.0.4', install_location=test_location, arch="amd64")
             self.assertEqual(mock_url_retrieve.call_count, 1)
-            # 2 warnings, 1st for download result, 2nd for updating PATH
-            self.assertEqual(logger_mock.warning.call_count, 2)  # 2 warnings, one for download result
+            # 3 warnings, 1st for download result, 2nd for moving file, 3rd for updating PATH
+            self.assertEqual(logger_mock.warning.call_count, 3)  # 3 warnings, one for download result
         finally:
             shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
**Related command**
`az aks install-cli`

**Description**<!--Mandatory-->
- In the case that the user does not specify the installation version, the user is prompted by a **warning message**, which URL the cli tries to obtain the latest version number from.
  > No version specified, will get the latest version of kubectl from "https://storage.googleapis.com/kubernetes-release/release/stable.txt"
  > No version specified, will get the latest version of kubelogin from "https://api.github.com/repos/Azure/kubelogin/releases/latest"
- After downloading kubelogin and decompressing the installation package, the user is prompted by a **warning message**, where the cli will install the binary.
  > Moving binary to "/home/fumingzhang/tmp/kubelogin" from "/tmp/tmpi1d4nrng/bin/linux_amd64/kubelogin"
- Add validation for installation path
  - Make sure the installation path contains a binary filename, not a directory, otherwise an **exception** is thrown.
    > The installation location "/home/fumingzhang/tmp" is a directory. Please specify a path including the binary filename e.g. "/usr/local/bin/kubectl".
  - Prompt the user with an **error message** when the user-specified installation path contains a binary with a name that does not match the current platform (for windows, should be kubectl.exe or kubelogin.exe; for linux/darwin, should be kubectl or kubelogin).
    > The binary filename "abc" in install location does not match the expected binary name "kubectl".
- Update help information for options `--install-location` and `--kubelogin-install-location`.
  > --install-location           : Path at which to install kubectl. Note: the path should contain
                                   the binary filename.  Default: /usr/local/bin/kubectl.
  > --kubelogin-install-location : Path at which to install kubelogin. Note: the path should contain
                                   the binary filename.  Default: /usr/local/bin/kubelogin.
- Update architecture detection warning message.
  > The detected architecture of current device is "x86_64", and the binary for "amd64" will be downloaded. If the detectiton is wrong, please download and install the binary corresponding to the appropriate architecture.

![image](https://user-images.githubusercontent.com/81607949/236602972-35da1f9f-4cdb-48fc-9b28-8e88fe911dcc.png)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
