### PR TITLE
[ARM] `az bicep publish`: Check for bicep installation

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3775,6 +3775,7 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
 
 
 def publish_bicep_file(cmd, file, target, documentationUri=None):
+    ensure_bicep_installation(cmd.cli_ctx)
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["publish", file, "--target", target]


### PR DESCRIPTION
**Related command**
`az bicep`

**Description**
Running `az bicep publish` will now check if bicep is installed and install bicep if needed. Experience should be consistent with `az bicep format`

Closes #26256 

**Testing Guide**
```
# make sure bicep is not installed
az bicep uninstall

az bicep publish --file module.bicep --target "br:<registry>/module:1"
# bicep is installed
```

**History Notes**
[ARM] `az bicep publish`: Check for bicep installation

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
