### PR TITLE
[ARM] Fix #26352: `az ts create`: Fix for the TypeError `string indices must be integers`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -137,7 +137,7 @@ def _get_deployment_resource_objects(cmd, template_obj, includeNested=False):
     if 'resources' in template_obj:
         resources = template_obj['resources']
         for resource in resources:
-            if (str(resource['type']) == 'Microsoft.Resources/deployments') is True:
+            if 'type' in resource and resource['type'] == 'Microsoft.Resources/deployments':
                 immediate_deployment_resources.append(resource)
     results = []
     for deployment_resource_obj in immediate_deployment_resources:

--- a/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/_packing_engine.py
@@ -136,6 +136,8 @@ def _get_deployment_resource_objects(cmd, template_obj, includeNested=False):
 
     if 'resources' in template_obj:
         resources = template_obj['resources']
+        if isinstance(resources, dict):  # Check if resources is an object
+            resources = list(resources.values())  # Convert object to array
         for resource in resources:
             if 'type' in resource and resource['type'] == 'Microsoft.Resources/deployments':
                 immediate_deployment_resources.append(resource)


### PR DESCRIPTION
fix for the TypeError in az ts create CLi command 

fixes Azure/azure-cli#26352

While running the `az ts create` cli command we get the below error:


```
  File "/home/sverrir/.local/lib/python3.10/site-packages/azure/cli/command_modules/resource/_packing_engine.py", line 155, in _get_template_links_to_artifacts
    deployment_resource_objs = _get_deployment_resource_objects(cmd, template_obj, includeNested)
  File "/home/sverrir/.local/lib/python3.10/site-packages/azure/cli/command_modules/resource/_packing_engine.py", line 140, in _get_deployment_resource_objects
    if (str(resource['type']) == 'Microsoft.Resources/deployments') is True:
TypeError: string indices must be integers
```

This PR has the fix for this issue.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
