### PR TITLE
[AKS] Fix #26353: `az aks install-cli`: Fix incorrect architecture detection on Darwin/arm64

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -1477,7 +1477,7 @@ def get_arch_for_cli_binary():
     arch = platform.machine().lower()
     if "amd64" in arch or "x86_64" in arch:
         formatted_arch = "amd64"
-    elif "armv8" in arch or "aarch64" in arch:
+    elif "armv8" in arch or "aarch64" in arch or "arm64" in arch:
         formatted_arch = "arm64"
     else:
         raise CLIInternalError(


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az aks install-cli`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

Fix issue #26353, fix incorrect architecture detection on Darwin/arm64, should regard the return value (by `platform.machine()`) `arm64` as `arm64` as well.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
