### PR TITLE
[ARM] Fix #26256: `az bicep publish/restore/generate-params`: Fix version checks without bicep installed

### DIFF
--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -217,14 +217,21 @@ class LocalContextScenarioTest(ScenarioTest):
 @live_only()
 class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
 
-    def __init__(self, method_name):
+    def __init__(self, method_name, random_config_dir=False):
         super(LiveScenarioTest, self).__init__(method_name)
-        self.cli_ctx = get_dummy_cli()
+        self.cli_ctx = get_dummy_cli(random_config_dir=random_config_dir)
+        self.random_config_dir = random_config_dir
         self.kwargs = {}
         self.test_resources_count = 0
 
     def setUp(self):
         patch_main_exception_handler(self)
+
+    def tearDown(self):
+        if self.random_config_dir:
+            from azure.cli.core.util import rmtree_with_retry
+            rmtree_with_retry(self.cli_ctx.config.config_dir)
+        super(LiveScenarioTest, self).tearDown()
 
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)

--- a/src/azure-cli-testsdk/azure/cli/testsdk/base.py
+++ b/src/azure-cli-testsdk/azure/cli/testsdk/base.py
@@ -217,21 +217,14 @@ class LocalContextScenarioTest(ScenarioTest):
 @live_only()
 class LiveScenarioTest(IntegrationTestBase, CheckerMixin, unittest.TestCase):
 
-    def __init__(self, method_name, random_config_dir=False):
+    def __init__(self, method_name):
         super(LiveScenarioTest, self).__init__(method_name)
-        self.cli_ctx = get_dummy_cli(random_config_dir=random_config_dir)
-        self.random_config_dir = random_config_dir
+        self.cli_ctx = get_dummy_cli()
         self.kwargs = {}
         self.test_resources_count = 0
 
     def setUp(self):
         patch_main_exception_handler(self)
-
-    def tearDown(self):
-        if self.random_config_dir:
-            from azure.cli.core.util import rmtree_with_retry
-            rmtree_with_retry(self.cli_ctx.config.config_dir)
-        super(LiveScenarioTest, self).tearDown()
 
     def cmd(self, command, checks=None, expect_failure=False):
         command = self._apply_kwargs(command)

--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -3775,6 +3775,8 @@ def format_bicep_file(cmd, file, stdout=None, outdir=None, outfile=None, newline
 
 
 def publish_bicep_file(cmd, file, target, documentationUri=None):
+    ensure_bicep_installation(cmd.cli_ctx)
+
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["publish", file, "--target", target]
@@ -3790,6 +3792,8 @@ def publish_bicep_file(cmd, file, target, documentationUri=None):
 
 
 def restore_bicep_file(cmd, file, force=None):
+    ensure_bicep_installation(cmd.cli_ctx)
+
     minimum_supported_version = "0.4.1008"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["restore", file]
@@ -3816,6 +3820,8 @@ def list_bicep_cli_versions(cmd):
 
 
 def generate_params_file(cmd, file, no_restore=None, outdir=None, outfile=None, stdout=None):
+    ensure_bicep_installation(cmd.cli_ctx)
+
     minimum_supported_version = "0.7.4"
     if bicep_version_greater_than_or_equal_to(minimum_supported_version):
         args = ["generate-params", file]

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -4017,9 +4017,6 @@ class BicepScenarioTest(ScenarioTest):
 # Because don't want to record bicep cli binary
 class BicepBuildTest(LiveScenarioTest):
 
-    def __init__(self, *arg, **kwargs):
-        super().__init__(*arg, random_config_dir=True, **kwargs)
-
     def setup(self):
         super().setup()
         self.cmd('az bicep uninstall')
@@ -4049,9 +4046,6 @@ class BicepBuildTest(LiveScenarioTest):
             os.remove(decompile_path)
 
 class BicepGenerateParamsTest(LiveScenarioTest):
-
-    def __init__(self, *arg, **kwargs):
-        super().__init__(*arg, random_config_dir=True, **kwargs)
 
     def setup(self):
         super().setup()
@@ -4108,9 +4102,6 @@ class BicepInstallationTest(LiveScenarioTest):
 
 class BicepRestoreTest(LiveScenarioTest):
 
-    def __init__(self, *arg, **kwargs):
-        super().__init__(*arg, random_config_dir=True, **kwargs)
-
     def setup(self):
         super().setup()
         self.cmd('az bicep uninstall')
@@ -4138,9 +4129,6 @@ class BicepRestoreTest(LiveScenarioTest):
 
 class BicepFormatTest(LiveScenarioTest):
 
-    def __init__(self, *arg, **kwargs):
-        super().__init__(*arg, random_config_dir=True, **kwargs)
-
     def setup(self):
         super().setup()
         self.cmd('az bicep uninstall')
@@ -4165,8 +4153,6 @@ class BicepFormatTest(LiveScenarioTest):
 
 
 class DeploymentWithBicepScenarioTest(LiveScenarioTest):
-    def __init__(self, *arg, **kwargs):
-        super().__init__(*arg, random_config_dir=True, **kwargs)
 
     def setup(self):
         super.setup()

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource.py
@@ -4016,7 +4016,18 @@ class BicepScenarioTest(ScenarioTest):
 
 # Because don't want to record bicep cli binary
 class BicepBuildTest(LiveScenarioTest):
-    
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
+    def setup(self):
+        super().setup()
+        self.cmd('az bicep uninstall')
+
+    def tearDown(self):
+        super().tearDown()
+        self.cmd('az bicep uninstall')
+
     def test_bicep_build_decompile(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         tf = os.path.join(curr_dir, 'storage_account_deploy.bicep').replace('\\', '\\\\')
@@ -4038,6 +4049,17 @@ class BicepBuildTest(LiveScenarioTest):
             os.remove(decompile_path)
 
 class BicepGenerateParamsTest(LiveScenarioTest):
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
+    def setup(self):
+        super().setup()
+        self.cmd('az bicep uninstall')
+
+    def tearDown(self):
+        super().tearDown()
+        self.cmd('az bicep uninstall')
 
     def test_bicep_generate_params(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
@@ -4085,6 +4107,18 @@ class BicepInstallationTest(LiveScenarioTest):
 
 
 class BicepRestoreTest(LiveScenarioTest):
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
+    def setup(self):
+        super().setup()
+        self.cmd('az bicep uninstall')
+
+    def tearDown(self):
+        super().tearDown()
+        self.cmd('az bicep uninstall')
+
     def test_restore(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         bf = os.path.join(curr_dir, 'data', 'external_modules.bicep').replace('\\', '\\\\')
@@ -4103,6 +4137,18 @@ class BicepRestoreTest(LiveScenarioTest):
 
 
 class BicepFormatTest(LiveScenarioTest):
+
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
+    def setup(self):
+        super().setup()
+        self.cmd('az bicep uninstall')
+
+    def tearDown(self):
+        super().tearDown()
+        self.cmd('az bicep uninstall')
+
     def test_format(self):
         curr_dir = os.path.dirname(os.path.realpath(__file__))
         bf = os.path.join(curr_dir, 'storage_account_deploy.bicep').replace('\\', '\\\\')
@@ -4119,6 +4165,9 @@ class BicepFormatTest(LiveScenarioTest):
 
 
 class DeploymentWithBicepScenarioTest(LiveScenarioTest):
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, random_config_dir=True, **kwargs)
+
     def setup(self):
         super.setup()
         self.cmd('az bicep uninstall')

--- a/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/tests/latest/test_resource_bicep.py
@@ -194,5 +194,3 @@ class TestBicep(unittest.TestCase):
     def _remove_bicep_version_check_file(self):
         with contextlib.suppress(FileNotFoundError):
             os.remove(_bicep_version_check_file_path)
-
-    


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
```sh
az bicep publish
az bicep restore
az bicep generate-params
```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Some commands require a specific version of `bicep` to function and when trying to check the current version of `bicep` installed, if the `bicep` CLI is not present, the commands fail.

The workaround is to ensure the `bicep` CLI is already installed. This PR ensures it is installed if it is already not before running the checks.

Additionally, to improve test coverage, this extends the `random_config_dir` property introduced in #25796 for `LiveScenarioTest`s as well. @bebound FYI

resolves #26256

**Testing Guide**
<!--Example commands with explanations.-->
```sh
az bicep publish
az bicep restore
az bicep generate-params
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
