### PR TITLE
{APIM} public network access parameter values should be Enabled or Disabled

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/apim/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/apim/custom.py
@@ -97,6 +97,12 @@ def apim_create(client, resource_group_name, name, publisher_email, sku_name=Sku
     if parameters.sku.name == SkuType.consumption.value:
         parameters.sku.capacity = 0
 
+    if parameters.public_network_access is not None:
+        if parameters.public_network_access:
+            parameters.public_network_access = "Enabled"
+        else:
+            parameters.public_network_access = "Disabled"
+
     return sdk_no_wait(no_wait, client.api_management_service.begin_create_or_update,
                        resource_group_name=resource_group_name,
                        service_name=name, parameters=parameters)


### PR DESCRIPTION
fixes https://github.com/Azure/azure-rest-api-specs/issues/23683

[This](https://learn.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-management-service/create-or-update) REST API where it clearly talks about the --public-network-access accepting the values Enabled or Disabled.

Seeing the [REST API Specs swagger](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/apimanagement/resource-manager/Microsoft.ApiManagement/preview/2021-12-01-preview/apimdeployment.json#L1323), I see the accepted values are Enabled or Disabled.

However in Azure CLI, apim update and apim create is expecting true or false. This is causing an unexpected behavior with the apim creation and updating the --public-network-access setting.

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).


