### PR TITLE
[Network] Fix #26318: `az network vnet subnet create`: `--nsg` and `--route-table` cannot be used as name from Azure Stack

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/2017_03_09_profile/operations/vnet.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/2017_03_09_profile/operations/vnet.py
@@ -88,6 +88,22 @@ class VNetUpdate(_VNet.Update):
 _VNetSubNet = import_aaz_by_profile("network.vnet.subnet")
 
 
+class VNetSubnetCreate(_VNetSubNet.Create):
+    @classmethod
+    def _build_arguments_schema(cls, *args, **kwargs):
+        from azure.cli.core.aaz import AAZResourceIdArgFormat
+        args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.network_security_group._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/networkSecurityGroups/{}",
+        )
+        args_schema.route_table._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/routeTables/{}",
+        )
+        return args_schema
+
+
 class VNetSubnetUpdate(_VNetSubNet.Update):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):

--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/2018_03_01_hybrid/operations/vnet.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/2018_03_01_hybrid/operations/vnet.py
@@ -110,7 +110,7 @@ _VNetSubNet = import_aaz_by_profile("network.vnet.subnet")
 class VNetSubnetCreate(_VNetSubNet.Create):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
-        from azure.cli.core.aaz import AAZListArg, AAZStrArg
+        from azure.cli.core.aaz import AAZListArg, AAZStrArg, AAZResourceIdArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
         args_schema.delegations = AAZListArg(
             options=["--delegations"],
@@ -124,6 +124,14 @@ class VNetSubnetCreate(_VNetSubNet.Create):
                  "Values from: az network vnet list-endpoint-services.",
         )
         args_schema.service_endpoints.Element = AAZStrArg()
+        args_schema.network_security_group._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/networkSecurityGroups/{}",
+        )
+        args_schema.route_table._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/routeTables/{}",
+        )
         # filter arguments
         args_schema.endpoints._registered = False
         return args_schema
@@ -232,7 +240,11 @@ _VNetPeering = import_aaz_by_profile("network.vnet.peering")
 class VNetPeeringCreate(_VNetPeering.Create):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
+        from azure.cli.core.aaz import AAZResourceIdArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.remote_vnet._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network/virtualNetworks/{}",
+        )
         return args_schema
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/2019_03_01_hybrid/operations/vnet.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/2019_03_01_hybrid/operations/vnet.py
@@ -110,7 +110,7 @@ _VNetSubNet = import_aaz_by_profile("network.vnet.subnet")
 class VNetSubnetCreate(_VNetSubNet.Create):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
-        from azure.cli.core.aaz import AAZListArg, AAZStrArg
+        from azure.cli.core.aaz import AAZListArg, AAZStrArg, AAZResourceIdArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
         args_schema.delegations = AAZListArg(
             options=["--delegations"],
@@ -124,6 +124,14 @@ class VNetSubnetCreate(_VNetSubNet.Create):
                  "Values from: az network vnet list-endpoint-services.",
         )
         args_schema.service_endpoints.Element = AAZStrArg()
+        args_schema.network_security_group._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/networkSecurityGroups/{}",
+        )
+        args_schema.route_table._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/routeTables/{}",
+        )
         # filter arguments
         args_schema.endpoints._registered = False
         return args_schema
@@ -233,7 +241,11 @@ _VNetPeering = import_aaz_by_profile("network.vnet.peering")
 class VNetPeeringCreate(_VNetPeering.Create):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
+        from azure.cli.core.aaz import AAZResourceIdArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.remote_vnet._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network/virtualNetworks/{}",
+        )
         return args_schema
 
 

--- a/src/azure-cli/azure/cli/command_modules/network/azure_stack/2020_09_01_hybrid/operations/vnet.py
+++ b/src/azure-cli/azure/cli/command_modules/network/azure_stack/2020_09_01_hybrid/operations/vnet.py
@@ -44,6 +44,9 @@ class VNetCreate(_VNet.Create):
                          "/networkSecurityGroups/{}",
             ),
         )
+        args_schema.ddos_protection_plan._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network/ddosProtectionPlans/{}",
+        )
         # filter arguments
         return args_schema
 
@@ -157,6 +160,14 @@ class VNetSubnetCreate(_VNetSubNet.Create):
                 template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
                          "/serviceEndpointPolicies/{}",
             ),
+        )
+        args_schema.network_security_group._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/networkSecurityGroups/{}",
+        )
+        args_schema.route_table._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network"
+                     "/routeTables/{}",
         )
         # filter arguments
         args_schema.policies._registered = False
@@ -332,7 +343,11 @@ _VNetPeering = import_aaz_by_profile("network.vnet.peering")
 class VNetPeeringCreate(_VNetPeering.Create):
     @classmethod
     def _build_arguments_schema(cls, *args, **kwargs):
+        from azure.cli.core.aaz import AAZResourceIdArgFormat
         args_schema = super()._build_arguments_schema(*args, **kwargs)
+        args_schema.remote_vnet._fmt = AAZResourceIdArgFormat(
+            template="/subscriptions/{subscription}/resourceGroups/{resource_group}/providers/Microsoft.Network/virtualNetworks/{}",
+        )
         return args_schema
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix: https://github.com/Azure/azure-cli/issues/26318

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
