### PR TITLE
{CI} Exit immediately if install docker fails

### DIFF
--- a/scripts/ci/install_docker.sh
+++ b/scripts/ci/install_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ARM64 image does not have docker, install manually
-
+set -evx
 if [[ $(dpkg --print-architecture) == "amd64" ]]; then
     echo "Docker is already installed on AMD64"
     exit 0


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Sometimes, if the install docker script fails, it still continues running until the last line.
This PR make it exit faster.
```
W: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/dists/focal/InRelease  Connection failed [IP: 185.125.190.36 80]
W: Failed to fetch http://ports.ubuntu.com/ubuntu-ports/dists/focal-updates/InRelease  Cannot initiate the connection to ports.ubuntu.com:80 (2620:2d:4000:1::16). - connect (101: Network is unreachable) Cannot initiate the connection to ports.ubuntu.com:80 (2620:2d:4000:1::19). - connect (101: Network is unreachable) Could not connect to ports.ubuntu.com:80 (185.125.190.39), connection timed out Could not connect to ports.ubuntu.com:80 (185.125.190.36), connection timed out [IP: 185.125.190.36 80]
...
+ command -v selinuxenabled
+ exec rootlesskit --net=slirp4netns --mtu=65520 --slirp4netns-sandbox=auto --slirp4netns-seccomp=auto --disable-host-loopback --port-driver=builtin --copy-up=/etc --copy-up=/run --propagation=rslave /usr/bin/dockerd-rootless.sh
[rootlesskit:parent] error: failed to setup UID/GID map: newuidmap 6850 [0 1000 1 1 100000 65536] failed: : exec: "newuidmap": executable file not found in $PATH
context "rootless": context not found: open /home/cloudtest/.docker/contexts/meta/12b961af5feb3e9d39f93b2cefb9a1a944f18d02cca0cac2f04f5a982240605f/meta.json: no such file or directory
##[error]Bash exited with code '1'.
````


**Testing Guide**
<!--Example commands with explanations.-->


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
