### PR TITLE
{Core} Only apply `allow_broker` to `PublicClientApplication`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/identity.py
+++ b/src/azure-cli-core/azure/cli/core/auth/identity.py
@@ -85,7 +85,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
 
     @property
     def _msal_app_kwargs(self):
-        """kwargs for creating UserCredential or ServicePrincipalCredential.
+        """kwargs for creating ClientApplication (including its subclass ConfidentialClientApplication).
         MSAL token cache and HTTP cache are lazily created.
         """
         if not Identity._msal_token_cache:
@@ -98,10 +98,15 @@ class Identity:  # pylint: disable=too-many-instance-attributes
             "authority": self._msal_authority,
             "token_cache": Identity._msal_token_cache,
             "http_cache": Identity._msal_http_cache,
-            "allow_broker": self._allow_broker,
             # CP1 means we can handle claims challenges (CAE)
             "client_capabilities": None if "AZURE_IDENTITY_DISABLE_CP1" in os.environ else ["CP1"]
         }
+
+    @property
+    def _msal_public_app_kwargs(self):
+        """kwargs for creating PublicClientApplication."""
+        # allow_broker can only be used on PublicClientApplication.
+        return {**self._msal_app_kwargs, "allow_broker": self._allow_broker}
 
     @property
     def _msal_app(self):
@@ -109,7 +114,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         The instance is lazily created.
         """
         if not self._msal_app_instance:
-            self._msal_app_instance = PublicClientApplication(self.client_id, **self._msal_app_kwargs)
+            self._msal_app_instance = PublicClientApplication(self.client_id, **self._msal_public_app_kwargs)
         return self._msal_app_instance
 
     def _load_msal_token_cache(self):
@@ -222,7 +227,7 @@ class Identity:  # pylint: disable=too-many-instance-attributes
         return accounts
 
     def get_user_credential(self, username):
-        return UserCredential(self.client_id, username, **self._msal_app_kwargs)
+        return UserCredential(self.client_id, username, **self._msal_public_app_kwargs)
 
     def get_service_principal_credential(self, client_id):
         entry = self._service_principal_store.load_entry(client_id, self.tenant_id)


### PR DESCRIPTION
**Related command**
 `az login`

**Description**<!--Mandatory-->
Close #26052

Turn on WAM with

```
az config set core.allow_broker=true
```

Then use service principal to login with `az login --service-principal -u {} -p {} -t {}`. The command fails with `ValueError: allow_broker=True is only supported in PublicClientApplication`.

This is because WAM doesn't support service principal. This issue has also been reported to the MSAL repo: https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/544

This PR changes the behavior by only applying `allow_broker` to `PublicClientApplication`, not to `ConfidentialClientApplication`.

**Testing Guide**
```
az config set core.allow_broker=true
az login --service-principal -u {} -p {} -t {}
```

Observe the `az login` command succeed without raising any exception.