### PR TITLE
{Compute} `az vm create`: Breaking change warning to image alias that will be deprecated

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_alias.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_alias.py
@@ -95,6 +95,13 @@ alias_json = """
             "version": "latest",
             "architecture": "x64"
           },
+          "SuseSles15SP3": {
+            "publisher": "SUSE",
+            "offer": "sles-15-sp3",
+            "sku": "gen2",
+            "version": "latest",
+            "architecture": "x64"
+          },
           "UbuntuLTS": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -927,7 +927,8 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
                            'The "UbuntuLTS" will be removed with the breaking change release of Fall 2023.')
         if image in ["RHEL", "Debian", "CentOS", "Flatcar"]:
             logger.warning('Consider using the image alias including the version of the distribution you want to use. '
-                           'For example: please use Debian11 instead of Debian')
+                           'For example: please use Debian11 instead of Debian. In October 2023, '
+                           'the aliases `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, and `RHEL` will be removed.')
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
     if os_disk_encryption_set is not None and not is_valid_resource_id(os_disk_encryption_set):
@@ -3158,7 +3159,8 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
                            'The "UbuntuLTS" will be removed with the breaking change release of Fall 2023.')
         if image in ["RHEL", "Debian", "CentOS", "Flatcar"]:
             logger.warning('Consider using the image alias including the version of the distribution you want to use. '
-                           'For example: please use Debian11 instead of Debian')
+                           'For example: please use Debian11 instead of Debian. In October 2023, '
+                           'the aliases `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, and `RHEL` will be removed.')
 
     # The default load balancer will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,

--- a/src/azure-cli/azure/cli/command_modules/vm/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/custom.py
@@ -925,10 +925,11 @@ def create_vm(cmd, vm_name, resource_group_name, image=None, size='Standard_DS1_
             logger.warning('Consider using the "Ubuntu2204" alias. On April 30, 2023,'
                            'the image deployed by the "UbuntuLTS" alias reaches its end of life. '
                            'The "UbuntuLTS" will be removed with the breaking change release of Fall 2023.')
-        if image in ["RHEL", "Debian", "CentOS", "Flatcar"]:
+        if image in ["RHEL", "Debian", "CentOS", "Flatcar", "SLES", "openSUSE-Leap"]:
             logger.warning('Consider using the image alias including the version of the distribution you want to use. '
-                           'For example: please use Debian11 instead of Debian. In October 2023, '
-                           'the aliases `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, and `RHEL` will be removed.')
+                           'For example: please use Debian11 instead of Debian.\nIn Ignite (November) 2023, '
+                           'the aliases without version suffix (such as: `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, '
+                           '`SLES`, `openSUSE-Leap` and `RHEL`) will be removed.')
 
     subscription_id = get_subscription_id(cmd.cli_ctx)
     if os_disk_encryption_set is not None and not is_valid_resource_id(os_disk_encryption_set):
@@ -3157,10 +3158,11 @@ def create_vmss(cmd, vmss_name, resource_group_name, image=None,
             logger.warning('Consider using the "Ubuntu2204" alias. On April 30, 2023,'
                            'the image deployed by the "UbuntuLTS" alias reaches its end of life. '
                            'The "UbuntuLTS" will be removed with the breaking change release of Fall 2023.')
-        if image in ["RHEL", "Debian", "CentOS", "Flatcar"]:
+        if image in ["RHEL", "Debian", "CentOS", "Flatcar", "SLES", "openSUSE-Leap"]:
             logger.warning('Consider using the image alias including the version of the distribution you want to use. '
-                           'For example: please use Debian11 instead of Debian. In October 2023, '
-                           'the aliases `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, and `RHEL` will be removed.')
+                           'For example: please use Debian11 instead of Debian.\nIn Ignite (November) 2023, '
+                           'the aliases without version suffix (such as: `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, '
+                           '`SLES`, `openSUSE-Leap` and `RHEL`) will be removed.')
 
     # The default load balancer will be expected to be changed from Basic to Standard.
     # In order to avoid breaking change which has a big impact to users,


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az vm image alias
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
[Add] Breaking change warning to show image aliases will be removed in October 2023: `UbuntuLTS`, `CentOS`, `Debian`, `Flatcar`, `SLES`, `openSUSE-Leap` and `RHEL`
**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
