### PR TITLE
[Network] `az network dns zone import`: Fix alias records cannot be imported

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -2710,7 +2710,10 @@ def import_zone(cmd, resource_group_name, zone_name, file_name):
         rs_name = rs_name[:-(len(origin) + 1)] if rs_name != origin else '@'
         try:
             record_count = len(rs[_type_to_property_name(rs_type)[0]])
-        except TypeError:
+        except (TypeError, KeyError):
+            # There is some bug with `alias records` being mapped from `AZURE ALIAS A` to `ARecords`,
+            # but `rs` does not contain `a_records`.  We could fix it, but this is just logging, so
+            # lets not fail the whole import and hope someone refactors this method
             record_count = 1
         total_records += record_count
     cum_records = 0
@@ -2729,7 +2732,7 @@ def import_zone(cmd, resource_group_name, zone_name, file_name):
 
         try:
             record_count = len(rs[_type_to_property_name(rs_type)[0]])
-        except TypeError:
+        except (TypeError, KeyError):
             record_count = 1
         if rs_name == '@' and rs_type == 'soa':
             root_soa = client.record_sets.get(resource_group_name, zone_name, '@', 'SOA')


### PR DESCRIPTION
**Related command**
`az network dns zone import --name … --resource-group … --subscription … --file-name …`

**Description**<!--Mandatory-->
I'm importing a very small zone, but it fails due to the APEX being an (Azure)Alias record?  The zone is generated using `zone export` command and all records are generated by Azure Portal.

Relevant traceback:
```
cli.azure.cli.core.azclierror: The command failed with an unexpected error. Here is the traceback:
az_command_data_logger: The command failed with an unexpected error. Here is the traceback:
cli.azure.cli.core.azclierror: 'a_records'
Traceback (most recent call last):
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
    raise ex
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/network/custom.py", line 2787, in import_zone
    record_count = len(rs[_type_to_property_name(rs_type)[0]])
KeyError: 'a_records'
az_command_data_logger: 'a_records'
Traceback (most recent call last):
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/knack/cli.py", line 233, in invoke
    cmd_result = self.invocation.execute(args)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 663, in execute
    raise ex
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 726, in _run_jobs_serially
    results.append(self._run_job(expanded_arg, cmd_copy))
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 697, in _run_job
    result = cmd_copy(params)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/__init__.py", line 333, in __call__
    return self.handler(*args, **kwargs)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/core/commands/command_operation.py", line 121, in handler
    return op(**command_args)
  File "/Users/…/brew/Cellar/azure-cli/2.48.1/libexec/lib/python3.10/site-packages/azure/cli/command_modules/network/custom.py", line 2787, in import_zone
    record_count = len(rs[_type_to_property_name(rs_type)[0]])
KeyError: 'a_records'
To check existing issues, please visit: https://github.com/Azure/azure-cli/issues
To open a new issue, please run `az feedback`
cli.knack.cli: Event: Cli.PostExecute [<function AzCliLogging.deinit_cmd_metadata_logging at 0x1096d8a60>]
az_command_data_logger: exit code: 1
```

The code is very convoluted, so I think this is a tiny patch, but the proper solution is to rewrite some of it (tests would also help!)

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
