### PR TITLE
{App Service} Allow Azure Functions Create to accept Python 3.11 parameters

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/resources/WebappRuntimeStacks.json
+++ b/src/azure-cli/azure/cli/command_modules/appservice/resources/WebappRuntimeStacks.json
@@ -486,6 +486,15 @@
             }
         },
         {
+            "displayName": "PYTHON|3.11",
+            "configs": {
+                "linux_fx_version": "PYTHON|3.11"
+            },
+            "github_actions_properties": {
+                "github_actions_version": "3.11"
+            }
+        },
+        {
             "displayName": "RUBY|2.7",
             "configs": {
                 "linux_fx_version": "RUBY|2.7"


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Azure Functions team is going to support Python 3.11 in beginning of June, we need to allow customers to create Python 3.11 function app in azure-cli before the Python 3.11 announcement.

This is NOT an official Azure Functions Python 3.11 release.

**Testing Guide**
Customer should be able to create Python 3.11

On Linux Consumption with az functionapp create -g <resource_group> -n <app_name> -c <consumption_plan_location> -s <storage_account> --os-type linux --runtime python --runtime-version 3.11 --functions-version 4
On Linux Dedicated/Premium with az functionapp create -g <resource_group> -n <app_name> -p <dedicated_plan_name> -s <storage_account> --os-type linux --runtime python --runtime-version 3.11 --functions-version 4

**History Notes**
{App Service} Take '--runtime-version 3.11' as Azure Functions v4 az functionapp create parameter

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
