### PR TITLE
{Telemetry} Reduce default pushing interval for local telemetry cache to 1h

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -74,9 +74,9 @@ class RecordsCollection:
 
     def _get_push_interval_config(self):
         config = CLIConfig(config_dir=self._config_dir)
-        threshold = config.getint('telemetry', 'push_interval_in_hours', fallback=6)
-        # the threshold for push telemetry can't be less than 1 hour, default value is 6 hours
-        return threshold if threshold >= 1 else 6
+        threshold = config.getint('telemetry', 'push_interval_in_hours', fallback=1)
+        # the threshold for push telemetry can't be less than 1 hour, default value is 1 hour
+        return threshold if threshold >= 1 else 1
 
     def _read_file(self, path):
         """ Read content of a telemetry cache file and parse them into records. """

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
@@ -42,11 +42,11 @@ class TestRecordsCollection(unittest.TestCase):
         self.assertEqual(1758, len([r for r in collection]))
 
     def test_create_records_collection_with_last_send(self):
-        last_send = datetime.datetime.now() - datetime.timedelta(hours=2)
+        last_send = datetime.datetime.now() - datetime.timedelta(minutes=20)
         collection = RecordsCollection(last_send, self.work_dir)
         collection.snapshot_and_read()
 
-        # the threshold for pushing 'cache' file is 6, so 'cache' file should not be moved
+        # the threshold for pushing 'cache' file is 1 hour, so 'cache' file should not be moved
         self.assert_cache_files_count(1)
         # no new records since last_send
         self.assertEqual(0, len([r for r in collection]))


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
As we planned in #26065, this is the third step to shorten the cache push interval from 6 hours to 1 hour



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
