### PR TITLE
{CDN} `az cdn endpoint purge/load`: Describe how to pass multiple content-paths

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/cdn/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/_help.py
@@ -147,7 +147,7 @@ short-summary: Pre-load content for a CDN endpoint.
 parameters:
   - name: --content-paths
     type: string
-    short-summary: Space-separated values. The path to the content to be loaded. 
+    short-summary: Space-separated values. The path to the content to be loaded.
                    Path should be a relative file URL of the origin.
 examples:
   - name: Pre-load Javascript and CSS content for an endpoint.
@@ -162,7 +162,7 @@ short-summary: Purge pre-loaded content for a CDN endpoint.
 parameters:
   - name: --content-paths
     type: string
-    short-summary: Space-separated values. The path to the content to be purged. 
+    short-summary: Space-separated values. The path to the content to be purged.
                    Can describe a file path or a wildcard directory.
 examples:
   - name: Purge pre-loaded Javascript and CSS content.

--- a/src/azure-cli/azure/cli/command_modules/cdn/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/cdn/_help.py
@@ -147,8 +147,8 @@ short-summary: Pre-load content for a CDN endpoint.
 parameters:
   - name: --content-paths
     type: string
-    short-summary: The path to the content to be loaded. Path should be a relative
-                   file URL of the origin.
+    short-summary: Space-separated values. The path to the content to be loaded. 
+                   Path should be a relative file URL of the origin.
 examples:
   - name: Pre-load Javascript and CSS content for an endpoint.
     text: >
@@ -162,8 +162,8 @@ short-summary: Purge pre-loaded content for a CDN endpoint.
 parameters:
   - name: --content-paths
     type: string
-    short-summary: The path to the content to be purged. Can describe a file path or a
-                   wildcard directory.
+    short-summary: Space-separated values. The path to the content to be purged. 
+                   Can describe a file path or a wildcard directory.
 examples:
   - name: Purge pre-loaded Javascript and CSS content.
     text: >


### PR DESCRIPTION
**Related command**
az cdn endpoint purge --content-paths '/a' '/b'
az cdn endpoint load --content-paths '/a' '/b'

**Description**<!--Mandatory-->
Explicitly describe how to pass multiple values. Otherwise one would have to extract this from the examples.
Aligned with az ad app update --identifier-uris, the same is done over there.

**Testing Guide**
pass multiple values in content-paths:
az cdn endpoint purge --content-paths '/a' '/b'
az cdn endpoint load --content-paths '/a' '/b'

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
