### PR TITLE
{packaging} Remove urllib3 secure extra

### DIFF
--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -149,7 +149,7 @@ DEPENDENCIES = [
     'semver==2.13.0',
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
-    'urllib3[secure]',
+    'urllib3',
     'websocket-client~=1.3.1',
     'xmltodict~=0.12'
 ]


### PR DESCRIPTION
**Related command**
N/A

**Description**<!--Mandatory-->
The `secure` extra package from urllib3 was deprecated a long time ago and many Linux distributions, including Fedora, no longer include it in their packages.

**Testing Guide**
No testing changes needed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
