### PR TITLE
{App Service} Remove usages of deprecated `inject_into_urllib3`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -2794,13 +2794,6 @@ def get_scm_site_headers(cli_ctx, name, resource_group_name, slot=None, addition
 
 
 def _get_log(url, headers, log_file=None):
-    import urllib3
-    try:
-        import urllib3.contrib.pyopenssl
-        urllib3.contrib.pyopenssl.inject_into_urllib3()
-    except ImportError:
-        pass
-
     http = get_pool_manager(url)
     r = http.request(
         'GET',

--- a/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/tunnel.py
@@ -75,13 +75,6 @@ class TunnelServer:
 
     def is_webapp_up(self):
         import urllib3
-
-        try:
-            import urllib3.contrib.pyopenssl
-            urllib3.contrib.pyopenssl.inject_into_urllib3()
-        except ImportError:
-            pass
-
         headers = urllib3.util.make_headers()
         headers["authorization"] = self.auth_string
         url = 'https://{}{}'.format(self.remote_addr, '/AppServiceTunnel/Tunnel.ashx?GetStatus&GetStatusAPIVer=2')


### PR DESCRIPTION
**Description**<!--Mandatory-->
A supplementary PR for #23494

According to https://urllib3.readthedocs.io/en/stable/reference/contrib/pyopenssl.html

> This module was relevant before the standard library ssl module supported SNI, but now that we’ve dropped support for Python 2.7 all relevant Python versions support SNI so this module is no longer recommended.

Since we have dropped support for Python 2 (https://github.com/Azure/azure-cli/pull/11363), we should remove usages of deprecated `inject_into_urllib3`. Otherwise, in the future, `urllib3` v2.1.0 will raise an exception when `inject_into_urllib3` is called (https://github.com/urllib3/urllib3/issues/2680).
