### PR TITLE
{Keyvault} Remove useless AAD endpoint and honor user input `--subscription` to support cross sub operations

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_client_factory.py
@@ -289,7 +289,7 @@ def data_plane_azure_keyvault_secret_client(cli_ctx, command_args):
 def _prepare_data_plane_azure_keyvault_client(cli_ctx, command_args, resource_type):
     version = str(get_api_version(cli_ctx, resource_type))
     profile = Profile(cli_ctx=cli_ctx)
-    credential, _, _ = profile.get_login_credentials()
+    credential, _, _ = profile.get_login_credentials(subscription_id=cli_ctx.data.get('subscription_id'))
     vault_url = \
         command_args.get('hsm_name', None) or \
         command_args.get('vault_base_url', None) or \

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -408,7 +408,7 @@ def recover_hsm(cmd, client, hsm_name, resource_group_name, location, no_wait=Fa
 
     # tenantId and sku shouldn't be required
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data.get('subscription_id', None))[_TENANT_ID]
 
     # Use 'Recover' as 'create_mode' temporarily since it's a bug from service side making 'create_mode' case-sensitive
     # Will change it back to CreateMode.recover.value('recover') from SDK definition after service fix
@@ -435,7 +435,7 @@ def recover_vault(cmd, client, vault_name, resource_group_name, location, no_wai
     Sku = cmd.get_models('Sku', resource_type=ResourceType.MGMT_KEYVAULT)
     SkuName = cmd.get_models('SkuName', resource_type=ResourceType.MGMT_KEYVAULT)
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data.get('subscription_id', None))[_TENANT_ID]
 
     params = VaultCreateOrUpdateParameters(location=location,
                                            properties={'tenant_id': tenant_id,
@@ -604,7 +604,7 @@ def create_hsm(cmd, client,
     ManagedHsmSku = cmd.get_models('ManagedHsmSku', resource_type=ResourceType.MGMT_KEYVAULT)
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data.get('subscription_id', None))[_TENANT_ID]
 
     properties = ManagedHsmProperties(tenant_id=tenant_id,
                                       enable_purge_protection=enable_purge_protection,
@@ -669,7 +669,7 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
     graph_client = graph_client_factory(cmd.cli_ctx)
-    subscription = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])
+    subscription = profile.get_subscription(subscription=cmd.cli_ctx.data.get('subscription_id', None))
     tenant_id = subscription[_TENANT_ID]
 
     # if bypass or default_action was specified create a NetworkRuleSet

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -408,7 +408,7 @@ def recover_hsm(cmd, client, hsm_name, resource_group_name, location, no_wait=Fa
 
     # tenantId and sku shouldn't be required
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription()[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
 
     # Use 'Recover' as 'create_mode' temporarily since it's a bug from service side making 'create_mode' case-sensitive
     # Will change it back to CreateMode.recover.value('recover') from SDK definition after service fix
@@ -435,7 +435,7 @@ def recover_vault(cmd, client, vault_name, resource_group_name, location, no_wai
     Sku = cmd.get_models('Sku', resource_type=ResourceType.MGMT_KEYVAULT)
     SkuName = cmd.get_models('SkuName', resource_type=ResourceType.MGMT_KEYVAULT)
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription()[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
 
     params = VaultCreateOrUpdateParameters(location=location,
                                            properties={'tenant_id': tenant_id,
@@ -604,7 +604,7 @@ def create_hsm(cmd, client,
     ManagedHsmSku = cmd.get_models('ManagedHsmSku', resource_type=ResourceType.MGMT_KEYVAULT)
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    tenant_id = profile.get_subscription()[_TENANT_ID]
+    tenant_id = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])[_TENANT_ID]
 
     properties = ManagedHsmProperties(tenant_id=tenant_id,
                                       enable_purge_protection=enable_purge_protection,
@@ -669,7 +669,7 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
     graph_client = graph_client_factory(cmd.cli_ctx)
-    subscription = profile.get_subscription()
+    subscription = profile.get_subscription(subscription=cmd.cli_ctx.data['subscription_id'])
     tenant_id = subscription[_TENANT_ID]
 
     # if bypass or default_action was specified create a NetworkRuleSet

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -401,15 +401,14 @@ def recover_vault_or_hsm(cmd, client, resource_group_name=None, location=None, v
 
 
 def recover_hsm(cmd, client, hsm_name, resource_group_name, location, no_wait=False):
-    from azure.cli.core._profile import Profile
+    from azure.cli.core._profile import Profile, _TENANT_ID
 
     ManagedHsm = cmd.get_models('ManagedHsm', resource_type=ResourceType.MGMT_KEYVAULT)
     ManagedHsmSku = cmd.get_models('ManagedHsmSku', resource_type=ResourceType.MGMT_KEYVAULT)
 
     # tenantId and sku shouldn't be required
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    tenant_id = profile.get_subscription()[_TENANT_ID]
 
     # Use 'Recover' as 'create_mode' temporarily since it's a bug from service side making 'create_mode' case-sensitive
     # Will change it back to CreateMode.recover.value('recover') from SDK definition after service fix
@@ -426,7 +425,7 @@ def recover_hsm(cmd, client, hsm_name, resource_group_name, location, no_wait=Fa
 
 
 def recover_vault(cmd, client, vault_name, resource_group_name, location, no_wait=False):
-    from azure.cli.core._profile import Profile
+    from azure.cli.core._profile import Profile, _TENANT_ID
 
     VaultCreateOrUpdateParameters = cmd.get_models('VaultCreateOrUpdateParameters',
                                                    resource_type=ResourceType.MGMT_KEYVAULT)
@@ -436,8 +435,7 @@ def recover_vault(cmd, client, vault_name, resource_group_name, location, no_wai
     Sku = cmd.get_models('Sku', resource_type=ResourceType.MGMT_KEYVAULT)
     SkuName = cmd.get_models('SkuName', resource_type=ResourceType.MGMT_KEYVAULT)
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    tenant_id = profile.get_subscription()[_TENANT_ID]
 
     params = VaultCreateOrUpdateParameters(location=location,
                                            properties={'tenant_id': tenant_id,
@@ -596,7 +594,7 @@ def create_hsm(cmd, client,
 
     administrators = [admin.strip().replace('\r', '').replace('\n', '') for admin in administrators]
 
-    from azure.cli.core._profile import Profile
+    from azure.cli.core._profile import Profile, _TENANT_ID
 
     if not sku:
         sku = 'Standard_B1'
@@ -606,8 +604,7 @@ def create_hsm(cmd, client,
     ManagedHsmSku = cmd.get_models('ManagedHsmSku', resource_type=ResourceType.MGMT_KEYVAULT)
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
+    tenant_id = profile.get_subscription()[_TENANT_ID]
 
     properties = ManagedHsmProperties(tenant_id=tenant_id,
                                       enable_purge_protection=enable_purge_protection,
@@ -656,7 +653,7 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
         # if client.get raise exception, we can take it as no existing vault found
         # just continue the normal creation process
         pass
-    from azure.cli.core._profile import Profile
+    from azure.cli.core._profile import Profile, _TENANT_ID
     from azure.cli.command_modules.role import graph_client_factory, GraphError
 
     VaultCreateOrUpdateParameters = cmd.get_models('VaultCreateOrUpdateParameters',
@@ -671,11 +668,9 @@ def create_vault(cmd, client,  # pylint: disable=too-many-locals, too-many-state
     VaultProperties = cmd.get_models('VaultProperties', resource_type=ResourceType.MGMT_KEYVAULT)
 
     profile = Profile(cli_ctx=cmd.cli_ctx)
-    _, _, tenant_id = profile.get_login_credentials(
-        resource=cmd.cli_ctx.cloud.endpoints.active_directory_graph_resource_id)
-
     graph_client = graph_client_factory(cmd.cli_ctx)
     subscription = profile.get_subscription()
+    tenant_id = subscription[_TENANT_ID]
 
     # if bypass or default_action was specified create a NetworkRuleSet
     # if neither were specified we will parse it from parameter `--network-acls`


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
In #22432, we migrated AAD Graph to MS Graph. Some related code in Keyvault module was also modified from https://github.com/Azure/azure-cli/blob/1451bd570fd0fe54771cedaecdbd49cdb4b8d69c/src/azure-cli/azure/cli/command_modules/keyvault/custom.py#L681-L689 to https://github.com/Azure/azure-cli/blob/cac3f06cf483d8c81f93c9cd556116e27aff2182/src/azure-cli/azure/cli/command_modules/keyvault/custom.py#L679-L684

Before migration, we need to call `profile.get_login_credentials` to get `cred` and `tenant_id` info.
After migration, we don't need the `cred` anymore but didn't drop `profile.get_login_credentials` just to get `tenant_id` info.

But there's better way to get `tenant_id`, it's a waste to call `profile.get_login_credentials` just for tenant info. Besides, the existing `profile.get_login_credentials` is still passing `resource` with AAD Graph endpoint which is deprecated. This PR aims to clear these useless code.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
