### PR TITLE
[Network] Fix #26438: `az network vnet peering sync`: Doesn't work in cross-tenant scenario

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -5698,8 +5698,7 @@ def sync_vnet_peering(cmd, resource_group_name, virtual_network_name, virtual_ne
 
     class Create(_VNetPeeringCreate):
         def pre_operations(self):
-            # cross-tenant
-            self.ctx.update_aux_subscriptions(remote_subscription)
+            self.ctx.update_aux_subscriptions(remote_subscription)  # cross-tenant
 
     return Create(cli_ctx=cmd.cli_ctx)(command_args={
         "name": virtual_network_peering_name,

--- a/src/azure-cli/azure/cli/command_modules/network/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/network/custom.py
@@ -5693,18 +5693,11 @@ def sync_vnet_peering(cmd, resource_group_name, virtual_network_name, virtual_ne
         err_msg = f"Virtual network peering {virtual_network_name} doesn't exist."
         raise ResourceNotFoundError(err_msg)
 
-    remote_vnet_id = peering["remoteVirtualNetwork"].pop("id")
-    remote_subscription = parse_resource_id(remote_vnet_id)["subscription"]
-
-    class Create(_VNetPeeringCreate):
-        def pre_operations(self):
-            self.ctx.update_aux_subscriptions(remote_subscription)  # cross-tenant
-
-    return Create(cli_ctx=cmd.cli_ctx)(command_args={
+    return VNetPeeringCreate(cli_ctx=cmd.cli_ctx)(command_args={
         "name": virtual_network_peering_name,
         "resource_group": resource_group_name,
         "vnet_name": virtual_network_name,
-        "remote_vnet": remote_vnet_id,
+        "remote_vnet": peering["remoteVirtualNetwork"].pop("id", None),
         "allow_vnet_access": peering.pop("allowVirtualNetworkAccess", None),
         "allow_gateway_transit": peering.pop("allowGatewayTransit", None),
         "allow_forwarded_traffic": peering.pop("allowForwardedTraffic", None),


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix: https://github.com/Azure/azure-cli/issues/26438

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
