### PR TITLE
{Compute} `az vm create`: Update help message for `--public-ip-address`

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/vm/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/vm/_params.py
@@ -1053,7 +1053,7 @@ def load_arguments(self, _):
             c.argument('subnet_address_prefix', help='The subnet IP address prefix to use when creating a new VNet in CIDR format.')
             c.argument('nics', nargs='+', help='Names or IDs of existing NICs to attach to the VM. The first NIC will be designated as primary. If omitted, a new NIC will be created. If an existing NIC is specified, do not specify subnet, VNet, public IP or NSG.')
             c.argument('private_ip_address', help='Static private IP address (e.g. 10.0.0.5).')
-            c.argument('public_ip_address', help='Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None (\'""\' in Azure CLI using PowerShell or --% operator).')
+            c.argument('public_ip_address', help='Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None (\'""\' in Azure CLI using PowerShell or --% operator). For Azure CLI using powershell core edition 7.3.4, specify '' or "" (--public-ip-address '' or --public-ip-address "")')
             c.argument('public_ip_address_allocation', help=None, default=None, arg_type=get_enum_type(['dynamic', 'static']))
             c.argument('public_ip_address_dns_name', help='Globally unique DNS name for a newly created public IP.')
             if self.supported_api_version(min_api='2017-08-01', resource_type=ResourceType.MGMT_NETWORK):


### PR DESCRIPTION
Submitting request here as suggested in below pull request:

https://github.com/Azure/azure-cli/pull/26350#pullrequestreview-1440820818

**Related command**
--public-ip-address
Name of the public IP address when creating one (default) or referencing an existing one. Can also reference an existing public IP by ID or specify "" for None ('""' in Azure CLI using PowerShell or --% operator).

Description
We have tested with different versions of OS and PowerShell core version 7.3.4 to test the public-ip-address parameter behavior and below is our findings when we have to create VM without public IP:

For PowerShell core version 7.2.* & below === --public-ip-address '""'
For PowerShell core version 7.3.4 ===== --public-ip-address ‘’ or --public-ip-address “” ---------------------------------------- Here we just have to use single field i.e., either single inverted comma (‘’) or just double inverted comma (“”).

Since, cloud shell also uses PowerShell core edition so here also we saw the same behavior in past. This not specific to any OS version as such, we just need to do slight modification in command while using PowerShell core version 7.3.4.

Testing Guide

az vm create --name newvm --resource-group testazcli --image Win2022Datacenter --admin-username sinhamanisha --admin-password Manishasinha*10 --subnet /subscriptions/6b26da86-6cfd-4198-afde-fb754b11c54e/resourceGroups/testazcli/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet --location southindia --size Standard_E32s_v3 --public-ip-address ''

OR

az vm create --name newvm --resource-group testazcli --image Win2022Datacenter --admin-username sinhamanisha --admin-password Manishasinha*10 --subnet /subscriptions/6b26da86-6cfd-4198-afde-fb754b11c54e/resourceGroups/testazcli/providers/Microsoft.Network/virtualNetworks/testvnet/subnets/testsubnet --location southindia --size Standard_E32s_v3 --public-ip-address ""