### PR TITLE
[Role] `az ad sp create-for-rbac`: Add alias `--json-auth` for `--sdk-auth`

### DIFF
--- a/src/azure-cli-core/azure/cli/core/_profile.py
+++ b/src/azure-cli-core/azure/cli/core/_profile.py
@@ -640,8 +640,8 @@ class Profile:
         self._set_subscriptions(result, merge=False)
 
     def get_sp_auth_info(self, subscription_id=None, name=None, password=None, cert_file=None):
-        """Generate a JSON for --sdk-auth argument when used in:
-            - az ad sp create-for-rbac --sdk-auth
+        """Generate a JSON for --json-auth argument when used in:
+            - az ad sp create-for-rbac --json-auth
         """
         from collections import OrderedDict
         account = self.get_subscription(subscription_id)

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -181,8 +181,7 @@ def load_arguments(self, _):
                    deprecate_info=c.deprecate(target='--skip-assignment', hide=True), help='No-op.')
         c.argument('show_auth_in_json', options_list=['--sdk-auth', '--json-auth'],
                    deprecate_info=c.deprecate(target='--sdk-auth'),
-                   help='Output service principal credential along with cloud endpoints in JSON format. '
-                        'See https://learn.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli.',
+                   help='Output service principal credential along with cloud endpoints in JSON format. ',
                    arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -181,8 +181,9 @@ def load_arguments(self, _):
                    deprecate_info=c.deprecate(target='--skip-assignment', hide=True), help='No-op.')
         c.argument('show_auth_in_json', options_list=['--sdk-auth', '--json-auth'],
                    deprecate_info=c.deprecate(target='--sdk-auth'),
-                   help='Output result in the format compatible with some authentication scenarios requiring reading '
-                        'from a JSON dictionary.', arg_type=get_three_state_flag())
+                   help='Output service principal credential along with cloud endpoints in JSON format. '
+                        'See https://learn.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli.',
+                   arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id or the service principal')

--- a/src/azure-cli/azure/cli/command_modules/role/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/role/_params.py
@@ -179,8 +179,10 @@ def load_arguments(self, _):
                    help='Role of the service principal.')
         c.argument('skip_assignment', arg_type=get_three_state_flag(),
                    deprecate_info=c.deprecate(target='--skip-assignment', hide=True), help='No-op.')
-        c.argument('show_auth_for_sdk', options_list='--sdk-auth', deprecate_info=c.deprecate(target='--sdk-auth'),
-                   help='output result in compatible with Azure SDK auth file', arg_type=get_three_state_flag())
+        c.argument('show_auth_in_json', options_list=['--sdk-auth', '--json-auth'],
+                   deprecate_info=c.deprecate(target='--sdk-auth'),
+                   help='Output result in the format compatible with some authentication scenarios requiring reading '
+                        'from a JSON dictionary.', arg_type=get_three_state_flag())
 
     with self.argument_context('ad sp owner list') as c:
         c.argument('identifier', options_list=['--id'], help='service principal name, or object id or the service principal')

--- a/src/azure-cli/azure/cli/command_modules/role/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/role/custom.py
@@ -1157,7 +1157,7 @@ def list_service_principal_owners(client, identifier):
 def create_service_principal_for_rbac(
         # pylint:disable=too-many-statements,too-many-locals, too-many-branches, unused-argument
         cmd, display_name=None, years=None, create_cert=False, cert=None, scopes=None, role=None,
-        show_auth_for_sdk=None, skip_assignment=False, keyvault=None):
+        show_auth_in_json=None, skip_assignment=False, keyvault=None):
     import time
 
     if role and not scopes or not role and scopes:
@@ -1272,7 +1272,7 @@ def create_service_principal_for_rbac(
 
     logger.warning(CREDENTIAL_WARNING)
 
-    if show_auth_for_sdk:
+    if show_auth_in_json:
         from azure.cli.core._profile import Profile
         profile = Profile(cli_ctx=cmd.cli_ctx)
         result = profile.get_sp_auth_info(scopes[0].split('/')[2] if scopes else None,


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az ad sp create-for-rbac`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR is going to add alias `--json-auth` for the parameter `--sdk-auth` of the command `az ad sp create-for-rbac`. 

As mentioned in #19872, `--sdk-auth` was deprecated since Python SDK has deprecated the usage of the output JSON file, there are still other places where this JSON file is used, like GitHub Action. To avoid confusion in naming, we introduce the alias `--json-auth` for `--sdk-auth`. 

Some documents should be updated synchronously.
- https://github.com/MicrosoftDocs/azure-dev-docs/blob/main/articles/github/connect-from-azure.md#use-the-azure-login-action-with-a-service-principal-secret
- https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/aks/kubernetes-action.md#create-secrets
- https://github.com/MicrosoftDocs/azure-devops-docs/blob/master/docs/pipelines/targets/azure-stack.md#create-or-validate-your-spn
- https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-netapp-files/azacsnap-installation.md#azure-netapp-files-with-virtual-machine
- https://github.com/MicrosoftDocs/azure-stack-docs/blob/main/azure-stack/user/ci-cd-github-action-webapp.md#create-a-service-principal
- https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/application-gateway/ingress-controller-install-existing.md#using-a-service-principal


Close https://github.com/Azure/login/issues/314

**Testing Guide**
<!--Example commands with explanations.-->
`az ad sp create-for-rbac --json-auth`: with no deprecation message
`az ad sp create-for-rbac --sdk-auth`: still shows deprecation message

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->
`az ad sp create-for-rbac`: Add alias `--json-auth` for `--sdk-auth`

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
