### PR TITLE
{AKS} AKS monitor metrics param should be --enable-azuremonitormetrics

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_help.py
@@ -479,7 +479,7 @@ parameters:
   - name: --enable-keda
     type: bool
     short-summary: Enable KEDA workload auto-scaler.
-  - name: --enable-azure-monitor-metrics
+  - name: --enable-azuremonitormetrics
     type: bool
     short-summary: Enable Azure Monitor Metrics Profile
   - name: --azure-monitor-workspace-resource-id
@@ -568,7 +568,7 @@ examples:
   - name: Create a kubernetes cluster with KEDA workload autoscaler enabled.
     text: az aks create -g MyResourceGroup -n MyManagedCluster --enable-keda
   - name: Create a kubernetes cluster with Azure Monitor Metrics enabled.
-    text: az aks create -g MyResourceGroup -n MyManagedCluster --enable-azure-monitor-metrics
+    text: az aks create -g MyResourceGroup -n MyManagedCluster --enable-azuremonitormetrics
 """
 
 helps['aks update'] = """
@@ -811,7 +811,7 @@ parameters:
   - name: --disable-keda
     type: bool
     short-summary: Disable KEDA workload auto-scaler.
-  - name: --enable-azure-monitor-metrics
+  - name: --enable-azuremonitormetrics
     type: bool
     short-summary: Enable Azure Monitor Metrics Profile
   - name: --azure-monitor-workspace-resource-id


### PR DESCRIPTION
There is a parameter reference error in az aks for enabling Azure Monitor metrics

**Incorrect Command**: `az aks create --enable-azure-monitor-metrics`

**Correct Command**: `az aks create --enable-azuremonitormetrics`

This PR has the documentation fix.

Fixes Azure/azure-cli#26600

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
