### PR TITLE
[Backup] `az backup protection backup-now`: Allow `--enable-compression` to be set to `true` for SAPHANA Workloads

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
+++ b/src/azure-cli-core/azure/cli/core/auth/landing_pages/success.html
@@ -6,7 +6,7 @@
     <title>Login successfully</title>
     <style>
         body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
 
         code {
@@ -22,8 +22,8 @@
     <h3>You have logged into Microsoft Azure!</h3>
     <p>You can close this window, or we will redirect you to the <a href="https://docs.microsoft.com/cli/azure/">Azure CLI documentation</a> in 1 minute.</p>
     <h3>Announcements</h3>
-    <p>[Windows only] Starting in May 2023, Azure CLI will authenticate using the <a href="https://learn.microsoft.com/windows/uwp/security/web-account-manager">Web Account Manager</a> (WAM) broker by default.</p>
-    <p>To help us collect feedback on the new login experience, you may opt-in to use WAM by running the following commands:</p>
+    <p>[Windows only] Azure CLI is collecting feedback on using the <a href="https://learn.microsoft.com/windows/uwp/security/web-account-manager">Web Account Manager</a> (WAM) broker for the login experience.</p>
+    <p>You may opt-in to use WAM by running the following commands:</p>
     <code>
         az config set core.allow_broker=true<br>
         az account clear<br>

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -479,11 +479,11 @@ def backup_now(cmd, client, resource_group_name, vault_name, item, retain_until,
 
     backup_item_type = item_uri.split(';')[0]
 
-    # if not cust_help.is_sql(backup_item_type) and enable_compression:
-    #     raise CLIError(
-    #         """
-    #         Enable compression is not applicable for SAPHanaDatabase item type.
-    #         """)
+    if not (cust_help.is_sql(backup_item_type) or cust_help.is_hana(backup_item_type)) and enable_compression:
+        raise CLIError(
+            """
+            Enable compression is only applicable for SQLDataBase and SAPHanaDatabase item types.
+            """)
 
     if cust_help.is_hana(backup_item_type) and backup_type.lower() in ['log', 'copyonlyfull', 'incremental']:
         raise CLIError(

--- a/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
+++ b/src/azure-cli/azure/cli/command_modules/backup/custom_wl.py
@@ -478,11 +478,12 @@ def backup_now(cmd, client, resource_group_name, vault_name, item, retain_until,
     item_uri = cust_help.get_protected_item_uri_from_id(item.id)
 
     backup_item_type = item_uri.split(';')[0]
-    if not cust_help.is_sql(backup_item_type) and enable_compression:
-        raise CLIError(
-            """
-            Enable compression is not applicable for SAPHanaDatabase item type.
-            """)
+
+    # if not cust_help.is_sql(backup_item_type) and enable_compression:
+    #     raise CLIError(
+    #         """
+    #         Enable compression is not applicable for SAPHanaDatabase item type.
+    #         """)
 
     if cust_help.is_hana(backup_item_type) and backup_type.lower() in ['log', 'copyonlyfull', 'incremental']:
         raise CLIError(

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_csr.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_csr.yaml
@@ -1,0 +1,8042 @@
+interactions:
+- request:
+    body: '{"location": "eastasia", "properties": {"monitoringSettings": {"azureMonitorAlertSettings":
+      {"alertsForAllJobFailures": "Enabled"}, "classicAlertSettings": {"alertsForCriticalOperations":
+      "Enabled"}}}, "sku": {"name": "Standard"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '230'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000002","etag":"W/\"datetime''2023-01-05T10%3A35%3A57.0099927Z''\"","properties":{"provisioningState":"Provisioning","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","encryption":null,"monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzthZjJjODQyZi1iYmE2LTQyNzMtYWU5YS1hZWU4MzNhMmQ0MmY=?api-version=2022-04-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '640'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:35:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '207'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzthZjJjODQyZi1iYmE2LTQyNzMtYWU5YS1hZWU4MzNhMmQ0MmY=?api-version=2022-04-01
+  response:
+    body:
+      string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/operationStatus/MjA0NzthZjJjODQyZi1iYmE2LTQyNzMtYWU5YS1hZWU4MzNhMmQ0MmY=\"\
+        ,\r\n  \"name\": \"MjA0NzthZjJjODQyZi1iYmE2LTQyNzMtYWU5YS1hZWU4MzNhMmQ0MmY=\"\
+        ,\r\n  \"status\": \"Succeeded\",\r\n  \"percentComplete\": 0.0\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '360'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:36:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --location
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000002","etag":"W/\"datetime''2023-01-05T10%3A35%3A58.7212304Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","encryption":null,"backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:36:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Enabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '419'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"enhancedSecurityState": "Enabled", "softDeleteFeatureState":
+      "Disabled"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault backup-properties set
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --soft-delete-feature-state
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PATCH
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupconfig/vaultconfig","name":"vaultconfig","type":"Microsoft.RecoveryServices/vaults/backupconfig","properties":{"enhancedSecurityState":"Enabled","softDeleteFeatureState":"Disabled","softDeleteRetentionPeriodInDays":14,"isSoftDeleteFeatureStateEditable":true}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '420'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1184'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"eastasia","tags":{"product":"azurecli","cause":"automation","date":"2023-01-05T10:35:53Z"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '312'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+  response:
+    body:
+      string: "[\r\n  {\r\n    \"location\": \"eastasia\",\r\n    \"name\": \"9600.20721.221203\"\
+        ,\r\n    \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n  }\r\n]"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15999,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43999
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions/9600.20721.221203?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n \
+        \   \"architecture\": \"x64\",\r\n    \"replicaType\": \"Unmanaged\",\r\n\
+        \    \"disallowed\": {\r\n      \"vmDiskType\": \"None\"\r\n    },\r\n   \
+        \ \"automaticOSUpgradeProperties\": {\r\n      \"automaticOSUpgradeSupported\"\
+        : true\r\n    },\r\n    \"imageDeprecationStatus\": {\r\n      \"imageState\"\
+        : \"Active\"\r\n    },\r\n    \"features\": [\r\n      {\r\n        \"name\"\
+        : \"IsAcceleratedNetworkSupported\",\r\n        \"value\": \"True\"\r\n  \
+        \    },\r\n      {\r\n        \"name\": \"DiskControllerTypes\",\r\n     \
+        \   \"value\": \"SCSI\"\r\n      },\r\n      {\r\n        \"name\": \"IsHibernateSupported\"\
+        ,\r\n        \"value\": \"False\"\r\n      }\r\n    ],\r\n    \"osDiskImage\"\
+        : {\r\n      \"operatingSystem\": \"Windows\",\r\n      \"sizeInGb\": 128,\r\
+        \n      \"sizeInBytes\": 136367309312\r\n    },\r\n    \"dataDiskImages\"\
+        : []\r\n  },\r\n  \"location\": \"eastasia\",\r\n  \"name\": \"9600.20721.221203\"\
+        ,\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1078'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:10 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12999,Microsoft.Compute/GetVMImageFromLocation30Min;73999
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-network/21.0.1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks?api-version=2022-01-01
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+  response:
+    body:
+      string: "[\r\n  {\r\n    \"location\": \"eastasia\",\r\n    \"name\": \"9600.20721.221203\"\
+        ,\r\n    \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n  }\r\n]"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15998,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43998
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions/9600.20721.221203?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n \
+        \   \"architecture\": \"x64\",\r\n    \"replicaType\": \"Unmanaged\",\r\n\
+        \    \"disallowed\": {\r\n      \"vmDiskType\": \"None\"\r\n    },\r\n   \
+        \ \"automaticOSUpgradeProperties\": {\r\n      \"automaticOSUpgradeSupported\"\
+        : true\r\n    },\r\n    \"imageDeprecationStatus\": {\r\n      \"imageState\"\
+        : \"Active\"\r\n    },\r\n    \"features\": [\r\n      {\r\n        \"name\"\
+        : \"IsAcceleratedNetworkSupported\",\r\n        \"value\": \"True\"\r\n  \
+        \    },\r\n      {\r\n        \"name\": \"DiskControllerTypes\",\r\n     \
+        \   \"value\": \"SCSI\"\r\n      },\r\n      {\r\n        \"name\": \"IsHibernateSupported\"\
+        ,\r\n        \"value\": \"False\"\r\n      }\r\n    ],\r\n    \"osDiskImage\"\
+        : {\r\n      \"operatingSystem\": \"Windows\",\r\n      \"sizeInGb\": 128,\r\
+        \n      \"sizeInBytes\": 136367309312\r\n    },\r\n    \"dataDiskImages\"\
+        : []\r\n  },\r\n  \"location\": \"eastasia\",\r\n  \"name\": \"9600.20721.221203\"\
+        ,\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1078'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12998,Microsoft.Compute/GetVMImageFromLocation30Min;73998
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions?$top=1&$orderby=name%20desc&api-version=2022-08-01
+  response:
+    body:
+      string: "[\r\n  {\r\n    \"location\": \"eastasia\",\r\n    \"name\": \"9600.20721.221203\"\
+        ,\r\n    \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n  }\r\n]"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '317'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/ListVMImagesVersionsFromLocation3Min;15997,Microsoft.Compute/ListVMImagesVersionsFromLocation30Min;43997
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Compute/locations/eastasia/publishers/MicrosoftWindowsServer/artifacttypes/vmimage/offers/WindowsServer/skus/2012-R2-Datacenter/versions/9600.20721.221203?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"properties\": {\r\n    \"hyperVGeneration\": \"V1\",\r\n \
+        \   \"architecture\": \"x64\",\r\n    \"replicaType\": \"Unmanaged\",\r\n\
+        \    \"disallowed\": {\r\n      \"vmDiskType\": \"None\"\r\n    },\r\n   \
+        \ \"automaticOSUpgradeProperties\": {\r\n      \"automaticOSUpgradeSupported\"\
+        : true\r\n    },\r\n    \"imageDeprecationStatus\": {\r\n      \"imageState\"\
+        : \"Active\"\r\n    },\r\n    \"features\": [\r\n      {\r\n        \"name\"\
+        : \"IsAcceleratedNetworkSupported\",\r\n        \"value\": \"True\"\r\n  \
+        \    },\r\n      {\r\n        \"name\": \"DiskControllerTypes\",\r\n     \
+        \   \"value\": \"SCSI\"\r\n      },\r\n      {\r\n        \"name\": \"IsHibernateSupported\"\
+        ,\r\n        \"value\": \"False\"\r\n      }\r\n    ],\r\n    \"osDiskImage\"\
+        : {\r\n      \"operatingSystem\": \"Windows\",\r\n      \"sizeInGb\": 128,\r\
+        \n      \"sizeInBytes\": 136367309312\r\n    },\r\n    \"dataDiskImages\"\
+        : []\r\n  },\r\n  \"location\": \"eastasia\",\r\n  \"name\": \"9600.20721.221203\"\
+        ,\r\n  \"id\": \"/Subscriptions/00000000-0000-0000-0000-000000000000/Providers/Microsoft.Compute/Locations/eastasia/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2012-R2-Datacenter/Versions/9600.20721.221203\"\
+        \r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1078'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/GetVMImageFromLocation3Min;12997,Microsoft.Compute/GetVMImageFromLocation30Min;73997
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"template": {"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0", "parameters": {"adminPassword": {"type": "securestring",
+      "metadata": {"description": "Secure adminPassword"}}}, "variables": {}, "resources":
+      [{"name": "clitest-vm000003VNET", "type": "Microsoft.Network/virtualNetworks",
+      "location": "eastasia", "apiVersion": "2015-06-15", "dependsOn": [], "tags":
+      {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099",
+      "AutoShutdown": "No"}, "properties": {"addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+      "subnets": [{"name": "clitest-vm000003Subnet", "properties": {"addressPrefix":
+      "10.0.0.0/24"}}]}}, {"type": "Microsoft.Network/networkSecurityGroups", "name":
+      "clitest-vm000003NSG", "apiVersion": "2015-06-15", "location": "eastasia", "tags":
+      {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099",
+      "AutoShutdown": "No"}, "dependsOn": []}, {"apiVersion": "2022-01-01", "type":
+      "Microsoft.Network/publicIPAddresses", "name": "clitest-vm000003PublicIP", "location":
+      "eastasia", "tags": {"MabUsed": "Yes", "Owner": "sisi", "Purpose": "CLITest",
+      "DeleteBy": "12-2099", "AutoShutdown": "No"}, "dependsOn": [], "properties":
+      {"publicIPAllocationMethod": null}}, {"apiVersion": "2015-06-15", "type": "Microsoft.Network/networkInterfaces",
+      "name": "clitest-vm000003VMNic", "location": "eastasia", "tags": {"MabUsed":
+      "Yes", "Owner": "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown":
+      "No"}, "dependsOn": ["Microsoft.Network/virtualNetworks/clitest-vm000003VNET",
+      "Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG", "Microsoft.Network/publicIpAddresses/clitest-vm000003PublicIP"],
+      "properties": {"ipConfigurations": [{"name": "ipconfigclitest-vm000003", "properties":
+      {"privateIPAllocationMethod": "Dynamic", "subnet": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000003VNET/subnets/clitest-vm000003Subnet"},
+      "publicIPAddress": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP"}}}],
+      "networkSecurityGroup": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG"}}},
+      {"apiVersion": "2022-08-01", "type": "Microsoft.Compute/virtualMachines", "name":
+      "clitest-vm000003", "location": "eastasia", "tags": {"MabUsed": "Yes", "Owner":
+      "sisi", "Purpose": "CLITest", "DeleteBy": "12-2099", "AutoShutdown": "No"},
+      "dependsOn": ["Microsoft.Network/networkInterfaces/clitest-vm000003VMNic"],
+      "properties": {"hardwareProfile": {"vmSize": "Standard_DS1_v2"}, "networkProfile":
+      {"networkInterfaces": [{"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic",
+      "properties": {"deleteOption": null}}]}, "storageProfile": {"osDisk": {"createOption":
+      "fromImage", "name": null, "caching": "ReadWrite", "managedDisk": {"storageAccountType":
+      null}}, "imageReference": {"publisher": "MicrosoftWindowsServer", "offer": "WindowsServer",
+      "sku": "2012-R2-Datacenter", "version": "latest"}}, "osProfile": {"computerName":
+      "clitest-vm000003", "adminUsername": "clitest-vm000003", "adminPassword": "[parameters(''adminPassword'')]"}}}],
+      "outputs": {}}, "parameters": {"adminPassword": {"value": "%j^VYw9Q3Z@Cu$*h"}},
+      "mode": "incremental"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3602'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_FP2TWD660Yabc9jigOF8FOFIjlfikAci","name":"vm_deploy_FP2TWD660Yabc9jigOF8FOFIjlfikAci","type":"Microsoft.Resources/deployments","properties":{"templateHash":"16567151540843360698","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Accepted","timestamp":"2023-01-05T10:37:27.8839594Z","duration":"PT0.0009248S","correlationId":"3f643deb-68b2-41ad-9c87-8e97e715778d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastasia"]},{"resourceType":"networkSecurityGroups","locations":["eastasia"]},{"resourceType":"publicIPAddresses","locations":["eastasia"]},{"resourceType":"networkInterfaces","locations":["eastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000003"}]}}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_FP2TWD660Yabc9jigOF8FOFIjlfikAci/operationStatuses/08585286918408880453?api-version=2021-04-01
+      cache-control:
+      - no-cache
+      content-length:
+      - '2535'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1191'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585286918408880453?api-version=2021-04-01
+  response:
+    body:
+      string: '{"status":"Running"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '20'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:37:59 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment/operationStatuses/08585286918408880453?api-version=2021-04-01
+  response:
+    body:
+      string: '{"status":"Succeeded"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '22'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.Resources/deployments/mock-deployment?api-version=2021-04-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Resources/deployments/vm_deploy_FP2TWD660Yabc9jigOF8FOFIjlfikAci","name":"vm_deploy_FP2TWD660Yabc9jigOF8FOFIjlfikAci","type":"Microsoft.Resources/deployments","properties":{"templateHash":"16567151540843360698","parameters":{"adminPassword":{"type":"SecureString"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2023-01-05T10:38:22.4257997Z","duration":"PT54.5427651S","correlationId":"3f643deb-68b2-41ad-9c87-8e97e715778d","providers":[{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastasia"]},{"resourceType":"networkSecurityGroups","locations":["eastasia"]},{"resourceType":"publicIPAddresses","locations":["eastasia"]},{"resourceType":"networkInterfaces","locations":["eastasia"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastasia"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000003VNET","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"clitest-vm000003VNET"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"clitest-vm000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"clitest-vm000003PublicIP"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000003VMNic"},{"dependsOn":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"clitest-vm000003VMNic"}],"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"clitest-vm000003"}],"outputs":{},"outputResources":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP"},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000003VNET"}]}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3370'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003?$expand=instanceView&api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003\"\
+        ,\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\"\
+        : \"eastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\"\
+        : \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\"\
+        ,\r\n    \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"\
+        vmId\": \"5bae0d4a-500d-4462-91b9-43226110b046\",\r\n    \"hardwareProfile\"\
+        : {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n    \"storageProfile\"\
+        : {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\"\
+        ,\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\"\
+        ,\r\n        \"version\": \"latest\",\r\n        \"exactVersion\": \"9600.20721.221203\"\
+        \r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n\
+        \        \"name\": \"clitest-vm000003_disk1_cb044a9abb5844b2b13eee1de5d377bd\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/clitest-vm000003_disk1_cb044a9abb5844b2b13eee1de5d377bd\"\
+        \r\n        },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\"\
+        : 127\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
+        : {\r\n      \"computerName\": \"clitest-vm000003\",\r\n      \"adminUsername\"\
+        : \"clitest-vm000003\",\r\n      \"windowsConfiguration\": {\r\n        \"\
+        provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true,\r\n\
+        \        \"patchSettings\": {\r\n          \"patchMode\": \"AutomaticByOS\"\
+        ,\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n    \
+        \    \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\"\
+        : [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\"\
+        : true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"instanceView\"\
+        : {\r\n      \"vmAgent\": {\r\n        \"vmAgentVersion\": \"Unknown\",\r\n\
+        \        \"statuses\": [\r\n          {\r\n            \"code\": \"ProvisioningState/Unavailable\"\
+        ,\r\n            \"level\": \"Warning\",\r\n            \"displayStatus\"\
+        : \"Not Ready\",\r\n            \"message\": \"VM status blob is found but\
+        \ not yet populated.\",\r\n            \"time\": \"2023-01-05T10:38:33+00:00\"\
+        \r\n          }\r\n        ]\r\n      },\r\n      \"disks\": [\r\n       \
+        \ {\r\n          \"name\": \"clitest-vm000003_disk1_cb044a9abb5844b2b13eee1de5d377bd\"\
+        ,\r\n          \"statuses\": [\r\n            {\r\n              \"code\"\
+        : \"ProvisioningState/succeeded\",\r\n              \"level\": \"Info\",\r\
+        \n              \"displayStatus\": \"Provisioning succeeded\",\r\n       \
+        \       \"time\": \"2023-01-05T10:37:59.4202369+00:00\"\r\n            }\r\
+        \n          ]\r\n        }\r\n      ],\r\n      \"hyperVGeneration\": \"V1\"\
+        ,\r\n      \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\"\
+        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning\
+        \ succeeded\",\r\n          \"time\": \"2023-01-05T10:38:18.0610719+00:00\"\
+        \r\n        },\r\n        {\r\n          \"code\": \"PowerState/running\"\
+        ,\r\n          \"level\": \"Info\",\r\n          \"displayStatus\": \"VM running\"\
+        \r\n        }\r\n      ]\r\n    },\r\n    \"timeCreated\": \"2023-01-05T10:37:57.6545906+00:00\"\
+        \r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '3426'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3984,Microsoft.Compute/LowCostGet30Min;31984
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-network/21.0.1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic?api-version=2022-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000003VMNic\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic\"\
+        ,\r\n  \"etag\": \"W/\\\"11616057-f5a1-4535-aed0-ee3197b80bf2\\\"\",\r\n \
+        \ \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\": \"sisi\",\r\n\
+        \    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\",\r\n    \"\
+        AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"provisioningState\"\
+        : \"Succeeded\",\r\n    \"resourceGuid\": \"4b653085-dfa3-42e4-af65-21830f53e3c1\"\
+        ,\r\n    \"ipConfigurations\": [\r\n      {\r\n        \"name\": \"ipconfigclitest-vm000003\"\
+        ,\r\n        \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic/ipConfigurations/ipconfigclitest-vm000003\"\
+        ,\r\n        \"etag\": \"W/\\\"11616057-f5a1-4535-aed0-ee3197b80bf2\\\"\"\
+        ,\r\n        \"type\": \"Microsoft.Network/networkInterfaces/ipConfigurations\"\
+        ,\r\n        \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\
+        ,\r\n          \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\"\
+        : \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\":\
+        \ \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP\"\
+        \r\n          },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/virtualNetworks/clitest-vm000003VNET/subnets/clitest-vm000003Subnet\"\
+        \r\n          },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\"\
+        : \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n\
+        \      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"\
+        internalDomainNameSuffix\": \"vhvmks3tlb2efkaf4vohgd1zue.hx.internal.cloudapp.net\"\
+        \r\n    },\r\n    \"macAddress\": \"60-45-BD-56-E1-C3\",\r\n    \"enableAcceleratedNetworking\"\
+        : false,\r\n    \"vnetEncryptionSupported\": false,\r\n    \"enableIPForwarding\"\
+        : false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkSecurityGroups/clitest-vm000003NSG\"\
+        \r\n    },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n    \
+        \  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003\"\
+        \r\n    },\r\n    \"hostedWorkloads\": [],\r\n    \"tapConfigurations\": [],\r\
+        \n    \"nicType\": \"Standard\",\r\n    \"allowPort25Out\": true\r\n  },\r\
+        \n  \"type\": \"Microsoft.Network/networkInterfaces\",\r\n  \"location\":\
+        \ \"eastasia\",\r\n  \"kind\": \"Regular\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2652'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:35 GMT
+      etag:
+      - W/"11616057-f5a1-4535-aed0-ee3197b80bf2"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - 4286a289-8213-4491-b652-7954689793d7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - vm create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -g --image --admin-username --admin-password --tags --nsg-rule
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-network/21.0.1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP?api-version=2022-01-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000003PublicIP\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/publicIPAddresses/clitest-vm000003PublicIP\"\
+        ,\r\n  \"etag\": \"W/\\\"efcb876f-fab7-4f5e-a5f3-79020590fd89\\\"\",\r\n \
+        \ \"location\": \"eastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\"\
+        ,\r\n    \"Owner\": \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\"\
+        : \"12-2099\",\r\n    \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\"\
+        : {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":\
+        \ \"7cc26870-defe-4859-a16c-3329d5aada24\",\r\n    \"ipAddress\": \"104.208.72.225\"\
+        ,\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\"\
+        : \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\
+        \n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic/ipConfigurations/ipconfigclitest-vm000003\"\
+        \r\n    }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\
+        \n  \"sku\": {\r\n    \"name\": \"Basic\",\r\n    \"tier\": \"Regional\"\r\
+        \n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1089'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:36 GMT
+      etag:
+      - W/"efcb876f-fab7-4f5e-a5f3-79020590fd89"
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-arm-service-request-id:
+      - f46e0237-b472-4726-8d39-a4b36233ce12
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-compute/29.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003?api-version=2022-08-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"clitest-vm000003\",\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003\"\
+        ,\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\"\
+        : \"eastasia\",\r\n  \"tags\": {\r\n    \"MabUsed\": \"Yes\",\r\n    \"Owner\"\
+        : \"sisi\",\r\n    \"Purpose\": \"CLITest\",\r\n    \"DeleteBy\": \"12-2099\"\
+        ,\r\n    \"AutoShutdown\": \"No\"\r\n  },\r\n  \"properties\": {\r\n    \"\
+        vmId\": \"5bae0d4a-500d-4462-91b9-43226110b046\",\r\n    \"hardwareProfile\"\
+        : {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n    },\r\n    \"storageProfile\"\
+        : {\r\n      \"imageReference\": {\r\n        \"publisher\": \"MicrosoftWindowsServer\"\
+        ,\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\": \"2012-R2-Datacenter\"\
+        ,\r\n        \"version\": \"latest\",\r\n        \"exactVersion\": \"9600.20721.221203\"\
+        \r\n      },\r\n      \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n\
+        \        \"name\": \"clitest-vm000003_disk1_cb044a9abb5844b2b13eee1de5d377bd\"\
+        ,\r\n        \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\"\
+        ,\r\n        \"managedDisk\": {\r\n          \"storageAccountType\": \"Premium_LRS\"\
+        ,\r\n          \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/disks/clitest-vm000003_disk1_cb044a9abb5844b2b13eee1de5d377bd\"\
+        \r\n        },\r\n        \"deleteOption\": \"Detach\",\r\n        \"diskSizeGB\"\
+        : 127\r\n      },\r\n      \"dataDisks\": []\r\n    },\r\n    \"osProfile\"\
+        : {\r\n      \"computerName\": \"clitest-vm000003\",\r\n      \"adminUsername\"\
+        : \"clitest-vm000003\",\r\n      \"windowsConfiguration\": {\r\n        \"\
+        provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\": true,\r\n\
+        \        \"patchSettings\": {\r\n          \"patchMode\": \"AutomaticByOS\"\
+        ,\r\n          \"assessmentMode\": \"ImageDefault\"\r\n        },\r\n    \
+        \    \"enableVMAgentPlatformUpdates\": false\r\n      },\r\n      \"secrets\"\
+        : [],\r\n      \"allowExtensionOperations\": true,\r\n      \"requireGuestProvisionSignal\"\
+        : true\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\"\
+        :\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Network/networkInterfaces/clitest-vm000003VMNic\"\
+        }]},\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"timeCreated\":\
+        \ \"2023-01-05T10:37:57.6545906+00:00\"\r\n  }\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2210'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-resource:
+      - Microsoft.Compute/LowCostGet3Min;3983,Microsoft.Compute/LowCostGet30Min;31983
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000002","etag":"W/\"datetime''2023-01-05T10%3A36%3A59.9735218Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","encryption":null,"backupStorageVersion":"Unassigned","monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '673'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:39 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2023-01-05T20:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2023-01-05T20:30:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '764'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '142'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv/protectableItems/vm;iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv","name":"iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg/providers/Microsoft.Compute/virtualMachines/clitest-vmzd3mv","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vmzd3mv","protectionState":"NotProtected"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;report-rg;reportvm1/protectableItems/vm;iaasvmcontainerv2;report-rg;reportvm1","name":"iaasvmcontainerv2;report-rg;reportvm1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/report-rg/providers/Microsoft.Compute/virtualMachines/reportvm1","virtualMachineVersion":"Compute","resourceGroup":"report-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"reportvm1","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2043'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '148'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/refreshContainers?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationsStatus/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 10:38:44 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1194'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 10:38:46 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '146'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 10:38:51 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '145'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/operationResults/af73a224-7aea-4d5a-83d2-047963bff40e?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      date:
+      - Thu, 05 Jan 2023 10:38:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectableItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv/protectableItems/vm;iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv","name":"iaasvmcontainerv2;clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg;clitest-vmzd3mv","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg/providers/Microsoft.Compute/virtualMachines/clitest-vmzd3mv","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg3vrlz2gbeyv7lxittxxbp724whphtvbo3cmjkypf5ftfv35sjislmirqh3oojhlxg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vmzd3mv","protectionState":"NotProtected"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectableItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"clitest-vm000003","protectionState":"NotProtected"}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;report-rg;reportvm1/protectableItems/vm;iaasvmcontainerv2;report-rg;reportvm1","name":"iaasvmcontainerv2;report-rg;reportvm1","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectableItems","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/report-rg/providers/Microsoft.Compute/virtualMachines/reportvm1","virtualMachineVersion":"Compute","resourceGroup":"report-rg","backupManagementType":"AzureIaasVM","protectableItemType":"Microsoft.Compute/virtualMachines","friendlyName":"reportvm1","protectionState":"NotProtected"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2949'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:38:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '144'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"protectedItemType": "Microsoft.Compute/virtualMachines",
+      "sourceResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003",
+      "policyId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: PUT
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/protectedItems/vm%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/operationsStatus/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 10:39:01 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/vm;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/operationResults/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1188'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '120'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '119'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '118'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '117'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '116'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"InProgress","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '115'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/e99479e2-c951-461b-bb02-f5299e1f3e61?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"e99479e2-c951-461b-bb02-f5299e1f3e61","name":"e99479e2-c951-461b-bb02-f5299e1f3e61","status":"Succeeded","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"2023-01-05T10:39:01.4280774Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"ca5b0796-992a-40c0-8d64-24ca630bcd45"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '114'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection enable-for-vm
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v --vm -p
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ca5b0796-992a-40c0-8d64-24ca630bcd45?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/ca5b0796-992a-40c0-8d64-24ca630bcd45","name":"ca5b0796-992a-40c0-8d64-24ca630bcd45","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT30.811425S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000003","Policy Name":"DefaultPolicy"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"ConfigureBackup","status":"Completed","startTime":"2023-01-05T10:39:01.4280774Z","endTime":"2023-01-05T10:39:32.2395024Z","activityId":"1d9b7cbb-8ce5-11ed-b42a-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '847'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"IRPending","healthStatus":"Passed","lastBackupStatus":"","lastBackupTime":"2001-01-01T00:00:00Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1781'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"objectType": "IaasVMBackupRequest", "recoveryPointExpiryTimeInUTC":
+      "2023-02-04T00:00:00.000Z"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: POST
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/backup?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/operationsStatus/7cd31057-3b76-4905-975c-65b9f8aa43f5?api-version=2022-06-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 10:39:43 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/operationResults/7cd31057-3b76-4905-975c-65b9f8aa43f5?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-writes:
+      - '1193'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/7cd31057-3b76-4905-975c-65b9f8aa43f5?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"7cd31057-3b76-4905-975c-65b9f8aa43f5","name":"7cd31057-3b76-4905-975c-65b9f8aa43f5","status":"Succeeded","startTime":"2023-01-05T10:39:43.9081786Z","endTime":"2023-01-05T10:39:43.9081786Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"f2375a27-d38e-43e0-9969-fdee473e2e5d"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '304'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '107'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection backup-now
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --retain-until --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT3.704505S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT2.5890013S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1183'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT5.7415728S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT4.6260691S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1184'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '135'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT6.6787937S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT5.56329S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1182'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:39:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT37.708771S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT36.5932673S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1185'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:40:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT1M8.6089892S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT1M7.4934855S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:40:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '132'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT1M39.6764352S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT1M38.5609315S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:41:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT2M10.4865271S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT2M9.3710234S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:41:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT2M41.4784831S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT2M40.3629794S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:42:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT3M12.3836349S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT3M11.2681312S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:42:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '125'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT3M43.4405245S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT3M42.3250208S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:43:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '123'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT4M14.2862434S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT4M13.1707397S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:43:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '122'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT4M45.2057707S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT4M44.090267S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1189'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:44:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '121'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT5M16.8166893S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT5M15.7011856S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:45:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '120'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT5M47.7326039S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT5M46.6171002S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:45:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '119'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT6M18.6020375S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT6M17.4865338S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:46:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '118'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT6M49.4667205S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT6M48.3512168S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:46:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '117'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT7M20.34951S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"0001-01-01T00:00:00","duration":"PT7M19.2340063S","status":"InProgress"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1188'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:47:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '116'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT7M51.2427556S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:47:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '115'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT8M22.1757526S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:48:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '114'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT8M53.0393475S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:48:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '113'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT9M23.9614678S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:49:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '112'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT9M55.4795194S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:49:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '111'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT10M27.7285403S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"0001-01-01T00:00:00","endTime":"0001-01-01T00:00:00","duration":"PT0S","status":"NotStarted"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1199'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:50:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '110'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT10M58.5163024S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT3M15.8026114S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:50:42 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '107'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT11M29.3512672S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT3M46.6375762S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:51:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '105'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT12M0.1665139S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT4M17.4528229S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:51:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '103'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT12M30.9540971S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT4M48.2404061S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:52:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '101'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT13M1.7731135S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT5M19.0594225S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:52:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT13M32.6256236S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT5M49.9119326S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:53:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '97'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT14M3.4646751S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT6M20.7509841S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:53:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '93'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT14M34.3557653S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT6M51.6420743S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:54:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '90'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT15M5.162285S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT7M22.448594S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1216'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:54:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '87'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT15M36.1131997S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT7M53.3995087S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:55:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '84'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT16M7.0222935S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT8M24.3086025S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:55:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '81'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT16M38.521988S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT8M55.808297S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:56:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '78'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT17M9.5837647S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT9M26.8700737S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:56:52 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '75'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT17M40.5623942S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT9M57.8487032S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:57:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '72'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT18M11.4720804S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT10M28.7583894S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:57:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '69'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT18M42.3927622S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT10M59.6790712S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:58:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '66'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT19M13.2567568S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT11M30.5430658S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:58:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '63'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT19M44.1799253S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT12M1.4662343S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:59:28 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '60'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT20M15.0819828S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT12M32.3682918S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 10:59:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '57'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT20M46.0531378S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT13M3.3394468S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:00:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '54'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT21M17.1832366S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT13M34.4695456S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:01:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '51'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT21M48.2540039S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT14M5.5403129S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:01:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '48'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT22M19.7787147S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT14M37.0650237S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:02:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '45'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT22M50.777759S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT15M8.064068S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:02:34 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '42'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT23M21.7005502S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT15M38.9868592S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:03:05 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '39'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT23M52.5455771S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT16M9.8318861S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:03:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '36'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT24M23.5557286S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT16M40.8420376S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:04:07 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '33'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT24M54.5729248S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT17M11.8592338S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:04:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '30'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT25M25.5151704S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT17M42.8014794S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:05:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '27'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT25M56.4864964S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT18M13.7728054S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:05:40 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '24'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT26M27.3783401S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT18M44.6646491S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:06:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '21'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT26M58.2598511S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT19M15.5461601S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:06:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '18'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT27M29.1072905S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT19M46.3935995S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:07:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '15'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT28M0.4937762S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT20M17.7800852S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:07:44 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '12'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT28M31.3994512S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT20M48.6857602S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:08:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '9'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT29M2.2883743S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT21M19.5746833S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:08:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '6'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT29M33.2760683S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT21M50.5623773S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:09:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '3'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT30M4.1142642S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT22M21.4005732S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:09:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"error":{"code":"ResourceRequestsThrottled","message":"Number of requests
+        for action ''Microsoft.RecoveryServices/vaults/backupJobs/read'' exceeded
+        the limit of ''150'' for time interval ''01:00:00''. Please try again after
+        ''324'' seconds."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '236'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:10:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 429
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT36M1.934664S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT28M19.220973S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:15:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '134'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT36M33.6876749S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT28M50.9739839S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:16:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '133'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT37M4.6357119S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT29M21.9220209S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:16:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '132'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT37M36.3896105S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT29M53.6759195S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:17:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '131'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT38M7.5031066S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT30M24.7894156S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:17:51 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '130'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT38M38.4194333S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT30M55.7057423S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:18:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '129'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT39M9.4178435S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT31M26.7041525S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1219'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:18:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '128'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT39M40.5431752S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT31M57.8294842S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:19:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '127'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT40M11.417896S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT32M28.704205S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1218'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:19:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '126'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT40M42.2809665S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT32M59.5672755S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:20:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '125'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT41M14.2650999S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"0001-01-01T00:00:00","duration":"PT33M31.5514089S","status":"InProgress"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"InProgress","startTime":"2023-01-05T10:39:43.9081786Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:20:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '124'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup job wait
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -n
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/f2375a27-d38e-43e0-9969-fdee473e2e5d","name":"f2375a27-d38e-43e0-9969-fdee473e2e5d","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","actionsInfo":[1],"containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT41M16.7549914S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[{"taskId":"Take
+        Snapshot","startTime":"2023-01-05T10:39:45.2586709Z","endTime":"2023-01-05T10:47:26.6224913Z","duration":"PT7M41.3638204S","status":"Completed"},{"taskId":"Transfer
+        data to vault","startTime":"2023-01-05T10:47:26.8568582Z","endTime":"2023-01-05T11:20:59.8825133Z","duration":"PT33M33.0256551S","status":"Completed"}],"propertyBag":{"VM
+        Name":"clitest-vm000003","Recovery Point Expiry Time in UTC":"2/4/2023 12:00:00
+        AM","Backup Size":"11326 MB"},"internalPropertyBag":{"IsInstantRpJob":"True"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"Backup","status":"Completed","startTime":"2023-01-05T10:39:43.9081786Z","endTime":"2023-01-05T11:21:00.66317Z","activityId":"43b79687-8ce5-11ed-8072-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1291'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:21:29 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '123'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"Passed","healthDetails":[{"code":400239,"title":"IaasVmHealthGreenDefault","message":"Backup
+        pre-check status of this virtual machine is OK.","recommendations":[]}],"lastBackupStatus":"Completed","lastBackupTime":"2023-01-05T10:39:43.9081786Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2023-01-05T10:39:51.9529674Z","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2156'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup recoverypoint list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/recoveryPoints?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/recoveryPoints/2027240748883986535","name":"2027240748883986535","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"IaasVMRecoveryPoint","recoveryPointType":"AppConsistent","recoveryPointTime":"2023-01-05T10:39:51.9529674Z","recoveryPointAdditionalInfo":"","sourceVMStorageType":"PremiumVMOnPartialPremiumStorage","isSourceVMEncrypted":false,"isInstantIlrSessionActive":false,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"},{"type":"HardenedRP","status":"Valid"}],"isManagedVirtualMachine":true,"virtualMachineSize":"Standard_DS1_v2","originalStorageAccountOption":false,"osType":"Windows","recoveryPointMoveReadinessInfo":{"ArchivedRP":{"isReadyForMove":false,"additionalInfo":"Recovery
+        point cannot be moved to Archive tier due to insufficient retention duration
+        specified in policy.. Update policy on the protected item with appropriate
+        retention setting and try again."}}}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1326'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:03 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"Passed","healthDetails":[{"code":400239,"title":"IaasVmHealthGreenDefault","message":"Backup
+        pre-check status of this virtual machine is OK.","recommendations":[]}],"lastBackupStatus":"Completed","lastBackupTime":"2023-01-05T10:39:43.9081786Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2023-01-05T10:39:51.9529674Z","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2156'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '137'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+friendlyName+eq+%27clitest-vm000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:08 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"Passed","healthDetails":[{"code":400239,"title":"IaasVmHealthGreenDefault","message":"Backup
+        pre-check status of this virtual machine is OK.","recommendations":[]}],"lastBackupStatus":"Completed","lastBackupTime":"2023-01-05T10:39:43.9081786Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2023-01-05T10:39:51.9529674Z","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2156'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '140'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+friendlyName+eq+%27clitest-vm000003%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:11 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '139'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/recoveryPoints/2027240748883986535?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/recoveryPoints/2027240748883986535","name":"2027240748883986535","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints","properties":{"objectType":"IaasVMRecoveryPoint","recoveryPointType":"AppConsistent","recoveryPointTime":"2023-01-05T10:39:51.9529674Z","recoveryPointAdditionalInfo":"","sourceVMStorageType":"PremiumVMOnPartialPremiumStorage","isSourceVMEncrypted":false,"isInstantIlrSessionActive":false,"recoveryPointTierDetails":[{"type":"InstantRP","status":"Valid"},{"type":"HardenedRP","status":"Valid"}],"isManagedVirtualMachine":true,"virtualMachineSize":"Standard_DS1_v2","originalStorageAccountOption":false,"osType":"Windows","recoveryPointMoveReadinessInfo":{"ArchivedRP":{"isReadyForMove":false,"additionalInfo":"Recovery
+        point cannot be moved to Archive tier due to insufficient retention duration
+        specified in policy.. Update policy on the protected item with appropriate
+        retention setting and try again."}}}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1314'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '147'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2022-04-01
+  response:
+    body:
+      string: '{"location":"eastasia","name":"clitest-vault000002","etag":"W/\"datetime''2023-01-05T10%3A36%3A59.9735218Z''\"","properties":{"provisioningState":"Succeeded","privateEndpointStateForBackup":"None","privateEndpointStateForSiteRecovery":"None","encryption":null,"backupStorageVersion":"V2","redundancySettings":{"standardTierStorageRedundancy":"GeoRedundant","crossRegionRestore":"Disabled"},"monitoringSettings":{"azureMonitorAlertSettings":{"alertsForAllJobFailures":"Enabled"},"classicAlertSettings":{"alertsForCriticalOperations":"Enabled"}}},"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","type":"Microsoft.RecoveryServices/vaults","sku":{"name":"Standard"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '767'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupEncryptionConfigs/backupResourceEncryptionConfig?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupEncryptionConfigs/backupResourceEncryptionConfig","name":"backupResourceEncryptionConfig","type":"Microsoft.RecoveryServices/vaults/backupEncryptionConfigs","properties":{"useSystemAssignedIdentity":true,"encryptionAtRestType":"MicrosoftManaged","lastUpdateStatus":"NotEnabled","infrastructureEncryptionState":"Disabled"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '483'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '149'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-iaasvm-rg-donotuse/providers/Microsoft.ClassicStorage/storageAccounts/clitestiaasvmsadonotuse?api-version=2015-12-01
+  response:
+    body:
+      string: '{"error":{"code":"AuthorizationFailed","message":"The client ''zubairabid@microsoft.com''
+        with object id ''12f8ea5c-1212-449e-b31c-0a574f43076e'' does not have authorization
+        to perform action ''Microsoft.ClassicStorage/storageAccounts/read'' over scope
+        ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-iaasvm-rg-donotuse/providers/Microsoft.ClassicStorage/storageAccounts/clitestiaasvmsadonotuse''
+        or the scope is invalid. If access was recently granted, please refresh your
+        credentials."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '510'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:17 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup restore restore-disks
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -v -c -i -r --target-subscription -t --storage-account --restore-to-staging-storage-account
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-azure-mgmt-resource/21.1.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-iaasvm-rg-donotuse/providers/Microsoft.Storage/storageAccounts/clitestiaasvmsadonotuse?api-version=2016-01-01
+  response:
+    body:
+      string: '{"error":{"code":"AuthorizationFailed","message":"The client ''zubairabid@microsoft.com''
+        with object id ''12f8ea5c-1212-449e-b31c-0a574f43076e'' does not have authorization
+        to perform action ''Microsoft.Storage/storageAccounts/read'' over scope ''/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest-iaasvm-rg-donotuse/providers/Microsoft.Storage/storageAccounts/clitestiaasvmsadonotuse''
+        or the scope is invalid. If access was recently granted, please refresh your
+        credentials."}}'
+    headers:
+      cache-control:
+      - no-cache
+      connection:
+      - close
+      content-length:
+      - '496'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-failure-cause:
+      - gateway
+    status:
+      code: 403
+      message: Forbidden
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type -v -g --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectionContainers?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","virtualMachineVersion":"Compute","resourceGroup":"clitest.rg000001","friendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"Microsoft.Compute/virtualMachines","protectableObjectType":"Microsoft.Compute/virtualMachines"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '924'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:21 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '141'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup item list
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c --query
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"Passed","healthDetails":[{"code":400239,"title":"IaasVmHealthGreenDefault","message":"Backup
+        pre-check status of this virtual machine is OK.","recommendations":[]}],"lastBackupStatus":"Completed","lastBackupTime":"2023-01-05T10:39:43.9081786Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2023-01-05T10:39:51.9529674Z","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2156'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:23 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '136'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupProtectedItems?api-version=2022-06-01-preview&%24filter=backupManagementType+eq+%27AzureIaasVM%27+and+itemType+eq+%27VM%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003/protectedItems/VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","name":"VM;iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems","properties":{"kpisHealths":{"BackupOperationStatusKPI":{"resourceHealthStatus":"Healthy","resourceHealthDetails":[{"code":0,"title":"Success","message":"","recommendations":[]}]}},"friendlyName":"clitest-vm000003","virtualMachineId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","protectionStatus":"Healthy","protectionState":"Protected","healthStatus":"Passed","healthDetails":[{"code":400239,"title":"IaasVmHealthGreenDefault","message":"Backup
+        pre-check status of this virtual machine is OK.","recommendations":[]}],"lastBackupStatus":"Completed","lastBackupTime":"2023-01-05T10:39:43.9081786Z","protectedItemDataId":"2027200375611991146","ConfiguredRPGenerationFrequency":"00:00:00","protectedItemType":"Microsoft.Compute/virtualMachines","backupManagementType":"AzureIaasVM","workloadType":"VM","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.Compute/virtualMachines/clitest-vm000003","policyId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupPolicies/DefaultPolicy","policyName":"DefaultPolicy","lastRecoveryPoint":"2023-01-05T10:39:51.9529674Z","vaultId":"https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002","isArchiveEnabled":false,"softDeleteRetentionPeriod":0}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '2156'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '135'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupResourceGuardProxies?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"value":[]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupFabrics/Azure/protectionContainers/IaasVMContainer%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003/protectedItems/VM%3Biaasvmcontainerv2%3Bclitest.rg000001%3Bclitest-vm000003?api-version=2022-06-01-preview
+  response:
+    body:
+      string: ''
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 11:22:28 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperationResults/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-deletes:
+      - '14994'
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '105'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:38 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '104'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:43 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '103'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '102'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:22:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '101'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '100'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:06 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '99'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '98'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:18 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '97'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '96'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '95'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '94'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:41 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '93'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '92'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:53 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '91'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:23:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '90'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:24:04 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '89'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:24:09 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '88'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"InProgress","startTime":"2023-01-05T11:22:28.795608Z","endTime":"0001-01-01T00:00:00"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '187'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:24:15 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '87'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupOperations/a42afe39-1833-4256-8352-3ca73f042eb2?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"a42afe39-1833-4256-8352-3ca73f042eb2","name":"a42afe39-1833-4256-8352-3ca73f042eb2","status":"Succeeded","startTime":"2023-01-05T11:22:28.795608Z","endTime":"2023-01-05T11:22:28.795608Z","properties":{"objectType":"OperationStatusJobExtendedInfo","jobId":"959201ae-063c-432d-9208-262883b766c1"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:24:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '86'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup protection disable
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - --backup-management-type --workload-type -g -v -c -i --delete-backup-data
+        --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservicesbackup/1.0.0b1 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/959201ae-063c-432d-9208-262883b766c1?api-version=2022-06-01-preview
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002/backupJobs/959201ae-063c-432d-9208-262883b766c1","name":"959201ae-063c-432d-9208-262883b766c1","type":"Microsoft.RecoveryServices/vaults/backupJobs","properties":{"jobType":"AzureIaaSVMJob","containerName":"iaasvmcontainerv2;clitest.rg000001;clitest-vm000003","duration":"PT1M51.5001536S","virtualMachineVersion":"Compute","extendedInfo":{"tasksList":[],"propertyBag":{"VM
+        Name":"clitest-vm000003","Number of Recovery Points":"1"}},"entityFriendlyName":"clitest-vm000003","backupManagementType":"AzureIaasVM","operation":"DeleteBackupData","status":"Completed","startTime":"2023-01-05T11:22:28.795608Z","endTime":"2023-01-05T11:24:20.2957616Z","activityId":"3b6146f1-8ceb-11ed-830d-60a5e243551b"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '852'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Thu, 05 Jan 2023 11:24:24 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '122'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup vault delete
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      ParameterSetName:
+      - -n -g --yes
+      User-Agent:
+      - AZURECLI/2.43.0 (PIP) azsdk-python-mgmt-recoveryservices/2.1.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: DELETE
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.RecoveryServices/vaults/clitest-vault000002?api-version=2022-04-01
+  response:
+    body:
+      string: ''
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '0'
+      date:
+      - Thu, 05 Jan 2023 11:24:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Kestrel
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '5'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_wl_hana_container.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_wl_hana_container.yaml
@@ -13,22 +13,178 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27
   response:
     body:
-      string: "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;adkayeth;sdfsfabadf\",\"name\":\"VMAppContainer;Compute;adkayeth;sdfsfabadf\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sdfsfabadf\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adkayeth/providers/Microsoft.Compute/virtualMachines/sdfsfabadf\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;afstests;testAkash123\",\"name\":\"VMAppContainer;Compute;afstests;testAkash123\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"testAkash123\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/afstests/providers/Microsoft.Compute/virtualMachines/testAkash123\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akkanaseCcyGrs;akkanaseTest34\",\"name\":\"VMAppContainer;Compute;akkanaseCcyGrs;akkanaseTest34\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"akkanaseTest34\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCcyGrs/providers/Microsoft.Compute/virtualMachines/akkanaseTest34\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akkanaseCMK;akkanaseTest\",\"name\":\"VMAppContainer;Compute;akkanaseCMK;akkanaseTest\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"akkanaseTest\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCMK/providers/Microsoft.Compute/virtualMachines/akkanaseTest\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akneema;akneema-tvm\",\"name\":\"VMAppContainer;Compute;akneema;akneema-tvm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"akneema-tvm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-tvm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;clitest-rg-donotuse;clitest-sql-donotuse\",\"name\":\"VMAppContainer;Compute;clitest-rg-donotuse;clitest-sql-donotuse\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"clitest-sql-donotuse\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-rg-donotuse/providers/Microsoft.Compute/virtualMachines/clitest-sql-donotuse\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;gvjreddy_test_rg;edgezonetest3\",\"name\":\"VMAppContainer;Compute;gvjreddy_test_rg;edgezonetest3\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"edgezonetest3\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gvjreddy_test_rg/providers/Microsoft.Compute/virtualMachines/edgezonetest3\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;gvjreddy_test_rg;gvj-dblslsh-rst\",\"name\":\"VMAppContainer;Compute;gvjreddy_test_rg;gvj-dblslsh-rst\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"gvj-dblslsh-rst\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gvjreddy_test_rg/providers/Microsoft.Compute/virtualMachines/gvj-dblslsh-rst\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiaga-adhoc-vm\",\"name\":\"VMAppContainer;Compute;hiagarg;hiaga-adhoc-vm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"hiaga-adhoc-vm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiaga-adhoc-vm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiagaNewVm1\",\"name\":\"VMAppContainer;Compute;hiagarg;hiagaNewVm1\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"hiagaNewVm1\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiagaNewVm1\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiaganewVM2\",\"name\":\"VMAppContainer;Compute;hiagarg;hiaganewVM2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"hiaganewVM2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiaganewVM2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiaganewVM3\",\"name\":\"VMAppContainer;Compute;hiagarg;hiaganewVM3\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"hiaganewVM3\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiaganewVM3\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiagavm\",\"name\":\"VMAppContainer;Compute;hiagarg;hiagavm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"hiagavm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiagavm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-clitest-rg;clitestvm\",\"name\":\"VMAppContainer;Compute;iaasvm-clitest-rg;clitestvm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"clitestvm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Compute/virtualMachines/clitestvm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-clitest-rg;iaasvm-clitest-vm2\",\"name\":\"VMAppContainer;Compute;iaasvm-clitest-rg;iaasvm-clitest-vm2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"iaasvm-clitest-vm2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Compute/virtualMachines/iaasvm-clitest-vm2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-pstest-rg;iaasvm-pstest-vm\",\"name\":\"VMAppContainer;Compute;iaasvm-pstest-rg;iaasvm-pstest-vm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"iaasvm-pstest-vm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-pstest-rg/providers/Microsoft.Compute/virtualMachines/iaasvm-pstest-vm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm.cmk.descrr;iaas-win-des\",\"name\":\"VMAppContainer;Compute;iaasvm.cmk.descrr;iaas-win-des\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"iaas-win-des\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.cmk.descrr/providers/Microsoft.Compute/virtualMachines/iaas-win-des\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm.existing.crr;iaasextchg-win-v2\",\"name\":\"VMAppContainer;Compute;iaasvm.existing.crr;iaasextchg-win-v2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"iaasextchg-win-v2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.crr/providers/Microsoft.Compute/virtualMachines/iaasextchg-win-v2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2\",\"name\":\"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"saphana-clitestvm-donotuse2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-5\",\"name\":\"VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-5\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sarath-encrypted-ccyvm-5\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarath-encrypted-ccyvm-5\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-6\",\"name\":\"VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-6\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sarath-encrypted-ccyvm-6\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarath-encrypted-ccyvm-6\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm\",\"name\":\"VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sql-clicloudtest-vm\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clicloudtest-rg/providers/Microsoft.Compute/virtualMachines/sql-clicloudtest-vm\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm2\",\"name\":\"VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sql-clicloudtest-vm2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clicloudtest-rg/providers/Microsoft.Compute/virtualMachines/sql-clicloudtest-vm2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse\",\"name\":\"VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sql-clitestvm-donotuse\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clitest-rg/providers/Microsoft.Compute/virtualMachines/sql-clitestvm-donotuse\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse2\",\"name\":\"VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"sql-clitestvm-donotuse2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clitest-rg/providers/Microsoft.Compute/virtualMachines/sql-clitestvm-donotuse2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;ztst-%E4%B8%AD%E6%96%87%E5%90%8D%E8%B5%84%E6%BA%90%E7%BB%84;zvmtst-2\",\"name\":\"VMAppContainer;Compute;ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4;zvmtst-2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"zvmtst-2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4/providers/Microsoft.Compute/virtualMachines/zvmtst-2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;ztst-%E4%B8%AD%E6%96%87%E5%90%8D%E8%B5%84%E6%BA%90%E7%BB%84;zvmtst-3\",\"name\":\"VMAppContainer;Compute;ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4;zvmtst-3\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"zvmtst-3\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4/providers/Microsoft.Compute/virtualMachines/zvmtst-3\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvm-jsdk1\",\"name\":\"VMAppContainer;Compute;zubairRG;zvm-jsdk1\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"zvm-jsdk1\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvm-jsdk1\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvm-jsdk2\",\"name\":\"VMAppContainer;Compute;zubairRG;zvm-jsdk2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"zvm-jsdk2\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvm-jsdk2\"}},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvmdelete\",\"name\":\"VMAppContainer;Compute;zubairRG;zvmdelete\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"properties\":{\"friendlyName\":\"zvmdelete\",\"backupManagementType\":\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\":\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvmdelete\"}}]}"
+      string: "{\"value\":[{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;adkayeth;sdfsfabadf\"\
+        ,\"name\":\"VMAppContainer;Compute;adkayeth;sdfsfabadf\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sdfsfabadf\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/adkayeth/providers/Microsoft.Compute/virtualMachines/sdfsfabadf\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;afstests;testAkash123\"\
+        ,\"name\":\"VMAppContainer;Compute;afstests;testAkash123\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"testAkash123\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/afstests/providers/Microsoft.Compute/virtualMachines/testAkash123\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akkanaseCcyGrs;akkanaseTest34\"\
+        ,\"name\":\"VMAppContainer;Compute;akkanaseCcyGrs;akkanaseTest34\",\"type\"\
+        :\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"akkanaseTest34\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCcyGrs/providers/Microsoft.Compute/virtualMachines/akkanaseTest34\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akkanaseCMK;akkanaseTest\"\
+        ,\"name\":\"VMAppContainer;Compute;akkanaseCMK;akkanaseTest\",\"type\":\"\
+        Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\",\"\
+        properties\":{\"friendlyName\":\"akkanaseTest\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akkanaseCMK/providers/Microsoft.Compute/virtualMachines/akkanaseTest\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;akneema;akneema-tvm\"\
+        ,\"name\":\"VMAppContainer;Compute;akneema;akneema-tvm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"akneema-tvm\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/akneema/providers/Microsoft.Compute/virtualMachines/akneema-tvm\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;clitest-rg-donotuse;clitest-sql-donotuse\"\
+        ,\"name\":\"VMAppContainer;Compute;clitest-rg-donotuse;clitest-sql-donotuse\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"clitest-sql-donotuse\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest-rg-donotuse/providers/Microsoft.Compute/virtualMachines/clitest-sql-donotuse\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;gvjreddy_test_rg;edgezonetest3\"\
+        ,\"name\":\"VMAppContainer;Compute;gvjreddy_test_rg;edgezonetest3\",\"type\"\
+        :\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"edgezonetest3\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gvjreddy_test_rg/providers/Microsoft.Compute/virtualMachines/edgezonetest3\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;gvjreddy_test_rg;gvj-dblslsh-rst\"\
+        ,\"name\":\"VMAppContainer;Compute;gvjreddy_test_rg;gvj-dblslsh-rst\",\"type\"\
+        :\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"gvj-dblslsh-rst\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/gvjreddy_test_rg/providers/Microsoft.Compute/virtualMachines/gvj-dblslsh-rst\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;hiagavm\"\
+        ,\"name\":\"VMAppContainer;Compute;hiagarg;hiagavm\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"hiagavm\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/hiagavm\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;hiagarg;sql-pstest-vm3\"\
+        ,\"name\":\"VMAppContainer;Compute;hiagarg;sql-pstest-vm3\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sql-pstest-vm3\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hiagarg/providers/Microsoft.Compute/virtualMachines/sql-pstest-vm3\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-clitest-rg;clitestvm\"\
+        ,\"name\":\"VMAppContainer;Compute;iaasvm-clitest-rg;clitestvm\",\"type\"\
+        :\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"clitestvm\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Compute/virtualMachines/clitestvm\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-clitest-rg;iaasvm-clitest-vm2\"\
+        ,\"name\":\"VMAppContainer;Compute;iaasvm-clitest-rg;iaasvm-clitest-vm2\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"iaasvm-clitest-vm2\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-clitest-rg/providers/Microsoft.Compute/virtualMachines/iaasvm-clitest-vm2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm-pstest-rg;iaasvm-pstest-vm\"\
+        ,\"name\":\"VMAppContainer;Compute;iaasvm-pstest-rg;iaasvm-pstest-vm\",\"\
+        type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"iaasvm-pstest-vm\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm-pstest-rg/providers/Microsoft.Compute/virtualMachines/iaasvm-pstest-vm\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm.cmk.descrr;iaas-win-des\"\
+        ,\"name\":\"VMAppContainer;Compute;iaasvm.cmk.descrr;iaas-win-des\",\"type\"\
+        :\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"iaas-win-des\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.cmk.descrr/providers/Microsoft.Compute/virtualMachines/iaas-win-des\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;iaasvm.existing.crr;iaasextchg-win-v2\"\
+        ,\"name\":\"VMAppContainer;Compute;iaasvm.existing.crr;iaasextchg-win-v2\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"iaasextchg-win-v2\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/iaasvm.existing.crr/providers/Microsoft.Compute/virtualMachines/iaasextchg-win-v2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2\"\
+        ,\"name\":\"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"saphana-clitestvm-donotuse2\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-5\"\
+        ,\"name\":\"VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-5\",\"\
+        type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sarath-encrypted-ccyvm-5\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarath-encrypted-ccyvm-5\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-6\"\
+        ,\"name\":\"VMAppContainer;Compute;sarath-rg;sarath-encrypted-ccyvm-6\",\"\
+        type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sarath-encrypted-ccyvm-6\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sarath-rg/providers/Microsoft.Compute/virtualMachines/sarath-encrypted-ccyvm-6\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm\"\
+        ,\"name\":\"VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sql-clicloudtest-vm\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clicloudtest-rg/providers/Microsoft.Compute/virtualMachines/sql-clicloudtest-vm\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm2\"\
+        ,\"name\":\"VMAppContainer;Compute;sql-clicloudtest-rg;sql-clicloudtest-vm2\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sql-clicloudtest-vm2\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clicloudtest-rg/providers/Microsoft.Compute/virtualMachines/sql-clicloudtest-vm2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse\"\
+        ,\"name\":\"VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sql-clitestvm-donotuse\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clitest-rg/providers/Microsoft.Compute/virtualMachines/sql-clitestvm-donotuse\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse2\"\
+        ,\"name\":\"VMAppContainer;Compute;sql-clitest-rg;sql-clitestvm-donotuse2\"\
+        ,\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"sql-clitestvm-donotuse2\",\"backupManagementType\"\
+        :\"AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sql-clitest-rg/providers/Microsoft.Compute/virtualMachines/sql-clitestvm-donotuse2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;ztst-%E4%B8%AD%E6%96%87%E5%90%8D%E8%B5%84%E6%BA%90%E7%BB%84;zvmtst-2\"\
+        ,\"name\":\"VMAppContainer;Compute;ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4\
+        ;zvmtst-2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"zvmtst-2\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ztst-\u4E2D\
+        \u6587\u540D\u8D44\u6E90\u7EC4/providers/Microsoft.Compute/virtualMachines/zvmtst-2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;ztst-%E4%B8%AD%E6%96%87%E5%90%8D%E8%B5%84%E6%BA%90%E7%BB%84;zvmtst-3\"\
+        ,\"name\":\"VMAppContainer;Compute;ztst-\u4E2D\u6587\u540D\u8D44\u6E90\u7EC4\
+        ;zvmtst-3\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"zvmtst-3\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ztst-\u4E2D\
+        \u6587\u540D\u8D44\u6E90\u7EC4/providers/Microsoft.Compute/virtualMachines/zvmtst-3\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvm-jsdk1\"\
+        ,\"name\":\"VMAppContainer;Compute;zubairRG;zvm-jsdk1\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"zvm-jsdk1\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvm-jsdk1\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvm-jsdk2\"\
+        ,\"name\":\"VMAppContainer;Compute;zubairRG;zvm-jsdk2\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"zvm-jsdk2\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvm-jsdk2\"\
+        }},{\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectableContainers/VMAppContainer;Compute;zubairRG;zvmdelete\"\
+        ,\"name\":\"VMAppContainer;Compute;zubairRG;zvmdelete\",\"type\":\"Microsoft.RecoveryServices/vaults/backupFabrics/protectableContainers\"\
+        ,\"properties\":{\"friendlyName\":\"zvmdelete\",\"backupManagementType\":\"\
+        AzureWorkload\",\"protectableContainerType\":\"VMAppContainer\",\"healthStatus\"\
+        :\"Healthy\",\"containerId\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/zubairRG/providers/Microsoft.Compute/virtualMachines/zvmdelete\"\
+        }}]}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '21521'
+      - '19469'
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:31 GMT
+      - Fri, 09 Jun 2023 09:31:05 GMT
       expires:
       - '-1'
       pragma:
@@ -70,8 +226,8 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2?api-version=2023-02-01
   response:
@@ -79,7 +235,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -87,11 +243,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:34 GMT
+      - Fri, 09 Jun 2023 09:31:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -121,16 +277,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -138,11 +294,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:35 GMT
+      - Fri, 09 Jun 2023 09:31:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -152,7 +308,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '277'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -172,16 +328,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -189,11 +345,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:40 GMT
+      - Fri, 09 Jun 2023 09:31:14 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -203,7 +359,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '276'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:
@@ -223,16 +379,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -240,11 +396,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:46 GMT
+      - Fri, 09 Jun 2023 09:31:19 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -254,7 +410,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '275'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -274,16 +430,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -291,11 +447,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:52 GMT
+      - Fri, 09 Jun 2023 09:31:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -305,7 +461,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '274'
+      - '296'
       x-powered-by:
       - ASP.NET
     status:
@@ -325,16 +481,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -342,11 +498,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:49:58 GMT
+      - Fri, 09 Jun 2023 09:31:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -356,7 +512,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '273'
+      - '295'
       x-powered-by:
       - ASP.NET
     status:
@@ -376,16 +532,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -393,11 +549,572 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:02 GMT
+      - Fri, 09 Jun 2023 09:31:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '294'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:31:41 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '293'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:31:47 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '292'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:31:52 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '291'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:31:57 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '290'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:02 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '289'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:09 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '288'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:14 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '287'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:20 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '286'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:25 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '285'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:31 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '284'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container register
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -v -g --backup-management-type --workload-type --resource-id
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
+  response:
+    body:
+      string: '{}'
+    headers:
+      azure-asyncoperation:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
+      cache-control:
+      - no-cache
+      content-length:
+      - '2'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:32:36 GMT
+      expires:
+      - '-1'
+      location:
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -427,16 +1144,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -444,11 +1161,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:08 GMT
+      - Fri, 09 Jun 2023 09:32:42 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -478,16 +1195,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -495,11 +1212,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:14 GMT
+      - Fri, 09 Jun 2023 09:32:47 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -529,16 +1246,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -546,11 +1263,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:19 GMT
+      - Fri, 09 Jun 2023 09:32:52 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -580,16 +1297,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -597,11 +1314,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:25 GMT
+      - Fri, 09 Jun 2023 09:32:58 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -631,16 +1348,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -648,11 +1365,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:30 GMT
+      - Fri, 09 Jun 2023 09:33:03 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -682,16 +1399,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -699,11 +1416,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:35 GMT
+      - Fri, 09 Jun 2023 09:33:09 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -733,16 +1450,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -750,11 +1467,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:41 GMT
+      - Fri, 09 Jun 2023 09:33:14 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -784,16 +1501,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -801,11 +1518,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:47 GMT
+      - Fri, 09 Jun 2023 09:33:20 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -835,16 +1552,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -852,11 +1569,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:52 GMT
+      - Fri, 09 Jun 2023 09:33:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -886,16 +1603,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -903,11 +1620,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:50:57 GMT
+      - Fri, 09 Jun 2023 09:33:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -937,16 +1654,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -954,11 +1671,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:04 GMT
+      - Fri, 09 Jun 2023 09:33:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -988,16 +1705,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1005,11 +1722,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:09 GMT
+      - Fri, 09 Jun 2023 09:33:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1039,16 +1756,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1056,11 +1773,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:14 GMT
+      - Fri, 09 Jun 2023 09:33:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1090,16 +1807,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1107,11 +1824,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:20 GMT
+      - Fri, 09 Jun 2023 09:33:52 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1141,16 +1858,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1158,11 +1875,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:25 GMT
+      - Fri, 09 Jun 2023 09:33:58 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1192,16 +1909,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1209,11 +1926,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:32 GMT
+      - Fri, 09 Jun 2023 09:34:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1243,16 +1960,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1260,11 +1977,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:37 GMT
+      - Fri, 09 Jun 2023 09:34:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1294,16 +2011,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1311,11 +2028,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:42 GMT
+      - Fri, 09 Jun 2023 09:34:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1345,16 +2062,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1362,11 +2079,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:48 GMT
+      - Fri, 09 Jun 2023 09:34:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1396,16 +2113,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1413,11 +2130,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:53 GMT
+      - Fri, 09 Jun 2023 09:34:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1447,16 +2164,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1464,11 +2181,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:51:59 GMT
+      - Fri, 09 Jun 2023 09:34:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1498,16 +2215,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1515,11 +2232,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:04 GMT
+      - Fri, 09 Jun 2023 09:34:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1549,16 +2266,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1566,11 +2283,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:10 GMT
+      - Fri, 09 Jun 2023 09:34:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1600,16 +2317,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1617,11 +2334,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:16 GMT
+      - Fri, 09 Jun 2023 09:34:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1651,16 +2368,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1668,11 +2385,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:21 GMT
+      - Fri, 09 Jun 2023 09:34:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1702,16 +2419,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1719,11 +2436,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:26 GMT
+      - Fri, 09 Jun 2023 09:35:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1753,16 +2470,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1770,11 +2487,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:33 GMT
+      - Fri, 09 Jun 2023 09:35:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1804,16 +2521,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1821,11 +2538,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:38 GMT
+      - Fri, 09 Jun 2023 09:35:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1855,16 +2572,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1872,11 +2589,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:43 GMT
+      - Fri, 09 Jun 2023 09:35:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1906,16 +2623,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1923,11 +2640,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:49 GMT
+      - Fri, 09 Jun 2023 09:35:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -1957,16 +2674,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -1974,11 +2691,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:52:55 GMT
+      - Fri, 09 Jun 2023 09:35:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2008,16 +2725,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2025,11 +2742,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:01 GMT
+      - Fri, 09 Jun 2023 09:35:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2059,16 +2776,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2076,11 +2793,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:06 GMT
+      - Fri, 09 Jun 2023 09:35:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2110,16 +2827,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2127,11 +2844,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:12 GMT
+      - Fri, 09 Jun 2023 09:35:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2161,16 +2878,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2178,11 +2895,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:17 GMT
+      - Fri, 09 Jun 2023 09:35:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2212,16 +2929,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2229,11 +2946,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:23 GMT
+      - Fri, 09 Jun 2023 09:35:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2263,16 +2980,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2280,11 +2997,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:28 GMT
+      - Fri, 09 Jun 2023 09:36:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2314,16 +3031,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2331,11 +3048,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:33 GMT
+      - Fri, 09 Jun 2023 09:36:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2365,16 +3082,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2382,11 +3099,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:39 GMT
+      - Fri, 09 Jun 2023 09:36:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2416,16 +3133,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2433,11 +3150,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:45 GMT
+      - Fri, 09 Jun 2023 09:36:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2467,16 +3184,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2484,11 +3201,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:50 GMT
+      - Fri, 09 Jun 2023 09:36:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2518,16 +3235,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2535,11 +3252,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:53:55 GMT
+      - Fri, 09 Jun 2023 09:36:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2569,16 +3286,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2586,11 +3303,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:54:00 GMT
+      - Fri, 09 Jun 2023 09:36:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2620,16 +3337,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -2637,11 +3354,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:54:06 GMT
+      - Fri, 09 Jun 2023 09:36:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -2671,1900 +3388,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type --resource-id
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/c304e20a-8e76-4272-be7d-11c665f3ea90?api-version=2023-02-01
   response:
     body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:12 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '238'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:18 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '237'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:23 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '236'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:29 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '235'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:34 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '234'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:39 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '233'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:45 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '232'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:51 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '231'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:54:55 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '230'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:02 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '240'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:07 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '239'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:13 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '238'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:18 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '237'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:23 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '236'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:29 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '235'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:34 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '234'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:41 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '233'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:46 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '232'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:51 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '231'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:55:57 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '230'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:02 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '229'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:07 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '228'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:13 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '227'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:19 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '226'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:24 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '225'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:30 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '224'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:35 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '223'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:41 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '222'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:46 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '221'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:52 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '220'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:56:58 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '219'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:03 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '218'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:08 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '217'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:13 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '216'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:19 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '215'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:25 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '214'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:31 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '213'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type --resource-id
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/a08287ff-8dba-476f-bf1a-b122f1fe7ded?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -4580,7 +3410,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:36 GMT
+      - Fri, 09 Jun 2023 09:36:46 GMT
       expires:
       - '-1'
       pragma:
@@ -4596,7 +3426,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '212'
+      - '238'
       x-powered-by:
       - ASP.NET
     status:
@@ -4616,13 +3446,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -4638,7 +3468,123 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:37 GMT
+      - Fri, 09 Jun 2023 09:36:47 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -v -g --backup-management-type
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+        for the SAP HANA instance is not in running state.","recommendations":["Please
+        start the SAP HANA system by running the command ''HDB start'' as the sidadm
+        user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+        for the SAP HANA instance is not in running state.","recommendations":["Please
+        start the SAP HANA system by running the command ''HDB start'' as the sidadm
+        user and retry the operation."]},"additionalDetail":"[HANAPlugin]: SystemDB
+        is not in running state.","protectableItemCount":{"SAPHanaSystem":1}}}]}},"friendlyName":"saphana-clitestvm-donotuse2","backupManagementType":"AzureWorkload","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"VMAppContainer","protectableObjectType":"VMAppContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1736'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:36:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-IIS/10.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-ms-ratelimit-remaining-subscription-resource-requests:
+      - '299'
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - backup container show
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -n -v -g --backup-management-type
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
+  response:
+    body:
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+        for the SAP HANA instance is not in running state.","recommendations":["Please
+        start the SAP HANA system by running the command ''HDB start'' as the sidadm
+        user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+        for the SAP HANA instance is not in running state.","recommendations":["Please
+        start the SAP HANA system by running the command ''HDB start'' as the sidadm
+        user and retry the operation."]},"additionalDetail":"[HANAPlugin]: SystemDB
+        is not in running state.","protectableItemCount":{"SAPHanaSystem":1}}}]}},"friendlyName":"saphana-clitestvm-donotuse2","backupManagementType":"AzureWorkload","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"VMAppContainer","protectableObjectType":"VMAppContainer"}}]}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1736'
+      content-type:
+      - application/json
+      date:
+      - Fri, 09 Jun 2023 09:36:50 GMT
       expires:
       - '-1'
       pragma:
@@ -4668,135 +3614,19 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       CommandName:
-      - backup container show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -v -g --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
-        for the SAP HANA instance is not in running state.","recommendations":["Please
-        start the SAP HANA system by running the command ''HDB start'' as the sidadm
-        user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
-        for the SAP HANA instance is not in running state.","recommendations":["Please
-        start the SAP HANA system by running the command ''HDB start'' as the sidadm
-        user and retry the operation."]},"additionalDetail":"[HANAPlugin]: SystemDB
-        is not in running state.","protectableItemCount":{"SAPHanaSystem":1}}}]}},"friendlyName":"saphana-clitestvm-donotuse2","backupManagementType":"AzureWorkload","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"VMAppContainer","protectableObjectType":"VMAppContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1736'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container show
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -n -v -g --backup-management-type
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
-  response:
-    body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
-        for the SAP HANA instance is not in running state.","recommendations":["Please
-        start the SAP HANA system by running the command ''HDB start'' as the sidadm
-        user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
-        for the SAP HANA instance is not in running state.","recommendations":["Please
-        start the SAP HANA system by running the command ''HDB start'' as the sidadm
-        user and retry the operation."]},"additionalDetail":"[HANAPlugin]: SystemDB
-        is not in running state.","protectableItemCount":{"SAPHanaSystem":1}}}]}},"friendlyName":"saphana-clitestvm-donotuse2","backupManagementType":"AzureWorkload","registrationStatus":"Registered","healthStatus":"Healthy","containerType":"VMAppContainer","protectableObjectType":"VMAppContainer"}}]}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '1736'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 11:57:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
       - backup container list
       Connection:
       - keep-alive
       ParameterSetName:
       - -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -4812,7 +3642,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:42 GMT
+      - Fri, 09 Jun 2023 09:36:51 GMT
       expires:
       - '-1'
       pragma:
@@ -4848,13 +3678,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -4870,7 +3700,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:44 GMT
+      - Fri, 09 Jun 2023 09:36:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4886,7 +3716,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '298'
+      - '299'
       x-powered-by:
       - ASP.NET
     status:
@@ -4912,8 +3742,8 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2?api-version=2023-02-01
   response:
@@ -4921,7 +3751,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4929,11 +3759,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:46 GMT
+      - Fri, 09 Jun 2023 09:36:54 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -4963,16 +3793,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -4980,11 +3810,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:47 GMT
+      - Fri, 09 Jun 2023 09:36:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5014,16 +3844,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5031,11 +3861,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:53 GMT
+      - Fri, 09 Jun 2023 09:37:01 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5065,16 +3895,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5082,11 +3912,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:57:58 GMT
+      - Fri, 09 Jun 2023 09:37:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5116,16 +3946,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5133,11 +3963,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:04 GMT
+      - Fri, 09 Jun 2023 09:37:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5167,16 +3997,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5184,11 +4014,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:09 GMT
+      - Fri, 09 Jun 2023 09:37:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5218,16 +4048,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5235,11 +4065,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:14 GMT
+      - Fri, 09 Jun 2023 09:37:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5269,16 +4099,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5286,11 +4116,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:20 GMT
+      - Fri, 09 Jun 2023 09:37:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5320,16 +4150,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5337,11 +4167,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:26 GMT
+      - Fri, 09 Jun 2023 09:37:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5371,16 +4201,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5388,11 +4218,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:31 GMT
+      - Fri, 09 Jun 2023 09:37:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5422,16 +4252,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5439,11 +4269,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:37 GMT
+      - Fri, 09 Jun 2023 09:37:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5473,16 +4303,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5490,11 +4320,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:42 GMT
+      - Fri, 09 Jun 2023 09:37:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5524,16 +4354,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5541,11 +4371,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:48 GMT
+      - Fri, 09 Jun 2023 09:37:55 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5575,16 +4405,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5592,11 +4422,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:53 GMT
+      - Fri, 09 Jun 2023 09:38:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5626,16 +4456,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5643,11 +4473,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:58:59 GMT
+      - Fri, 09 Jun 2023 09:38:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5677,16 +4507,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5694,11 +4524,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:04 GMT
+      - Fri, 09 Jun 2023 09:38:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5728,16 +4558,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5745,11 +4575,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:10 GMT
+      - Fri, 09 Jun 2023 09:38:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5779,16 +4609,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5796,11 +4626,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:15 GMT
+      - Fri, 09 Jun 2023 09:38:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5830,16 +4660,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5847,11 +4677,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:21 GMT
+      - Fri, 09 Jun 2023 09:38:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5881,16 +4711,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5898,11 +4728,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:26 GMT
+      - Fri, 09 Jun 2023 09:38:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5932,16 +4762,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -5949,11 +4779,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:32 GMT
+      - Fri, 09 Jun 2023 09:38:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -5983,16 +4813,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6000,11 +4830,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:37 GMT
+      - Fri, 09 Jun 2023 09:38:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6034,16 +4864,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6051,11 +4881,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:43 GMT
+      - Fri, 09 Jun 2023 09:38:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6085,16 +4915,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6102,11 +4932,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:48 GMT
+      - Fri, 09 Jun 2023 09:38:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6136,16 +4966,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6153,11 +4983,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:53 GMT
+      - Fri, 09 Jun 2023 09:39:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6187,16 +5017,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6204,11 +5034,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 11:59:59 GMT
+      - Fri, 09 Jun 2023 09:39:06 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6238,16 +5068,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6255,11 +5085,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:05 GMT
+      - Fri, 09 Jun 2023 09:39:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6289,16 +5119,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6306,11 +5136,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:10 GMT
+      - Fri, 09 Jun 2023 09:39:18 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6340,16 +5170,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6357,11 +5187,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:15 GMT
+      - Fri, 09 Jun 2023 09:39:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6391,16 +5221,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6408,11 +5238,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:21 GMT
+      - Fri, 09 Jun 2023 09:39:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6442,16 +5272,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6459,11 +5289,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:26 GMT
+      - Fri, 09 Jun 2023 09:39:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6493,16 +5323,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6510,11 +5340,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:32 GMT
+      - Fri, 09 Jun 2023 09:39:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6544,16 +5374,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6561,11 +5391,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:37 GMT
+      - Fri, 09 Jun 2023 09:39:45 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6595,16 +5425,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6612,11 +5442,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:43 GMT
+      - Fri, 09 Jun 2023 09:39:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6646,16 +5476,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6663,11 +5493,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:49 GMT
+      - Fri, 09 Jun 2023 09:39:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6697,16 +5527,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6714,11 +5544,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:00:54 GMT
+      - Fri, 09 Jun 2023 09:40:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6748,16 +5578,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6765,11 +5595,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:00 GMT
+      - Fri, 09 Jun 2023 09:40:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6799,16 +5629,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6816,11 +5646,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:05 GMT
+      - Fri, 09 Jun 2023 09:40:12 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6850,16 +5680,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6867,11 +5697,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:10 GMT
+      - Fri, 09 Jun 2023 09:40:17 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6901,16 +5731,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6918,11 +5748,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:16 GMT
+      - Fri, 09 Jun 2023 09:40:23 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -6952,16 +5782,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -6969,11 +5799,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:22 GMT
+      - Fri, 09 Jun 2023 09:40:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7003,16 +5833,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7020,11 +5850,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:27 GMT
+      - Fri, 09 Jun 2023 09:40:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7054,16 +5884,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7071,11 +5901,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:32 GMT
+      - Fri, 09 Jun 2023 09:40:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7105,16 +5935,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7122,11 +5952,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:38 GMT
+      - Fri, 09 Jun 2023 09:40:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7156,16 +5986,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7173,11 +6003,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:44 GMT
+      - Fri, 09 Jun 2023 09:40:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7207,16 +6037,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7224,11 +6054,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:49 GMT
+      - Fri, 09 Jun 2023 09:40:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7258,16 +6088,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7275,11 +6105,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:01:55 GMT
+      - Fri, 09 Jun 2023 09:41:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7309,16 +6139,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7326,11 +6156,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:00 GMT
+      - Fri, 09 Jun 2023 09:41:07 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7360,16 +6190,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7377,11 +6207,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:06 GMT
+      - Fri, 09 Jun 2023 09:41:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7411,16 +6241,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7428,11 +6258,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:11 GMT
+      - Fri, 09 Jun 2023 09:41:19 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7462,16 +6292,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7479,11 +6309,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:16 GMT
+      - Fri, 09 Jun 2023 09:41:24 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7513,16 +6343,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7530,11 +6360,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:23 GMT
+      - Fri, 09 Jun 2023 09:41:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7564,16 +6394,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7581,11 +6411,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:28 GMT
+      - Fri, 09 Jun 2023 09:41:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7615,16 +6445,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7632,11 +6462,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:33 GMT
+      - Fri, 09 Jun 2023 09:41:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7666,16 +6496,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7683,11 +6513,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:39 GMT
+      - Fri, 09 Jun 2023 09:41:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7717,16 +6547,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7734,11 +6564,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:45 GMT
+      - Fri, 09 Jun 2023 09:41:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7768,16 +6598,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7785,11 +6615,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:50 GMT
+      - Fri, 09 Jun 2023 09:41:57 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7819,16 +6649,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7836,11 +6666,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:02:56 GMT
+      - Fri, 09 Jun 2023 09:42:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7870,16 +6700,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7887,11 +6717,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:01 GMT
+      - Fri, 09 Jun 2023 09:42:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7921,16 +6751,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7938,11 +6768,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:07 GMT
+      - Fri, 09 Jun 2023 09:42:13 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -7972,16 +6802,16 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -7989,11 +6819,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:12 GMT
+      - Fri, 09 Jun 2023 09:42:19 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8023,64 +6853,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type --workload-type -y --container-name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/f20126e9-df66-44a3-9b15-f0872996219d?api-version=2023-02-01
   response:
     body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 12:03:17 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '239'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container re-register
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g --backup-management-type --workload-type -y --container-name
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/ff7385dc-a4e6-4e8f-8e9b-d3ac9474643e?api-version=2023-02-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -8096,7 +6875,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:24 GMT
+      - Fri, 09 Jun 2023 09:42:24 GMT
       expires:
       - '-1'
       pragma:
@@ -8112,7 +6891,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '238'
+      - '239'
       x-powered-by:
       - ASP.NET
     status:
@@ -8132,13 +6911,13 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -8154,7 +6933,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:25 GMT
+      - Fri, 09 Jun 2023 09:42:25 GMT
       expires:
       - '-1'
       pragma:
@@ -8170,7 +6949,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '297'
       x-powered-by:
       - ASP.NET
     status:
@@ -8190,13 +6969,13 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-05-11T11:49:40.9857792Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","name":"VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2","type":"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers","properties":{"sourceResourceId":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.Compute/virtualMachines/saphana-clitestvm-donotuse2","lastUpdatedTime":"2023-06-09T09:31:12.5813536Z","extendedInfo":{"hostServerName":"saphana-clitestvm-donotuse2","inquiryInfo":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
         for the SAP HANA instance is not in running state.","recommendations":["Please
         start the SAP HANA system by running the command ''HDB start'' as the sidadm
         user and retry the operation."]},"inquiryDetails":[{"type":"SAPHana","itemCount":0,"inquiryValidation":{"status":"Failed","errorDetail":{"code":"UserErrorHANASystemDBNotRunning","message":"SYSTEMDB
@@ -8212,7 +6991,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:27 GMT
+      - Fri, 09 Jun 2023 09:42:26 GMT
       expires:
       - '-1'
       pragma:
@@ -8250,8 +7029,8 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2?api-version=2023-02-01
   response:
@@ -8259,17 +7038,17 @@ interactions:
       string: ''
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
       - '0'
       date:
-      - Thu, 11 May 2023 12:03:29 GMT
+      - Fri, 09 Jun 2023 09:42:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupOperationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?fabricName=Azure?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupOperationResults/6261842d-e101-4866-8492-6f9271d58171?fabricName=Azure?api-version=2023-02-01
       pragma:
       - no-cache
       strict-transport-security:
@@ -8297,16 +7076,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8314,11 +7093,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:30 GMT
+      - Fri, 09 Jun 2023 09:42:29 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8348,16 +7127,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8365,11 +7144,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:35 GMT
+      - Fri, 09 Jun 2023 09:42:35 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8399,16 +7178,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8416,11 +7195,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:41 GMT
+      - Fri, 09 Jun 2023 09:42:41 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8450,16 +7229,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8467,11 +7246,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:47 GMT
+      - Fri, 09 Jun 2023 09:42:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8501,16 +7280,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8518,11 +7297,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:52 GMT
+      - Fri, 09 Jun 2023 09:42:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8552,16 +7331,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8569,11 +7348,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:03:57 GMT
+      - Fri, 09 Jun 2023 09:42:56 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8603,16 +7382,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8620,11 +7399,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:03 GMT
+      - Fri, 09 Jun 2023 09:43:02 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8654,16 +7433,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8671,11 +7450,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:09 GMT
+      - Fri, 09 Jun 2023 09:43:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8705,16 +7484,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8722,11 +7501,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:15 GMT
+      - Fri, 09 Jun 2023 09:43:14 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8756,16 +7535,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8773,11 +7552,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:20 GMT
+      - Fri, 09 Jun 2023 09:43:19 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8807,16 +7586,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8824,11 +7603,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:26 GMT
+      - Fri, 09 Jun 2023 09:43:25 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8858,16 +7637,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8875,11 +7654,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:30 GMT
+      - Fri, 09 Jun 2023 09:43:30 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8909,16 +7688,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8926,11 +7705,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:37 GMT
+      - Fri, 09 Jun 2023 09:43:36 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -8960,16 +7739,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -8977,11 +7756,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:41 GMT
+      - Fri, 09 Jun 2023 09:43:40 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -9011,16 +7790,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -9028,11 +7807,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:48 GMT
+      - Fri, 09 Jun 2023 09:43:46 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -9062,16 +7841,16 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/6261842d-e101-4866-8492-6f9271d58171?api-version=2019-05-13-preview
       cache-control:
       - no-cache
       content-length:
@@ -9079,11 +7858,11 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:04:53 GMT
+      - Fri, 09 Jun 2023 09:43:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
       pragma:
       - no-cache
       server:
@@ -9113,61 +7892,10 @@ interactions:
       ParameterSetName:
       - -v -g -c -y
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
-  response:
-    body:
-      string: '{}'
-    headers:
-      azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationsStatus/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2019-05-13-preview
-      cache-control:
-      - no-cache
-      content-length:
-      - '2'
-      content-type:
-      - application/json
-      date:
-      - Thu, 11 May 2023 12:04:59 GMT
-      expires:
-      - '-1'
-      location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer;Compute;saphana-clitest-rg;saphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-IIS/10.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-      x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '283'
-      x-powered-by:
-      - ASP.NET
-    status:
-      code: 202
-      message: Accepted
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - backup container unregister
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -v -g -c -y
-      User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/7ebb5c3c-fb32-4413-a31f-591249f5abac?api-version=2023-02-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupFabrics/Azure/protectionContainers/VMAppContainer%3BCompute%3Bsaphana-clitest-rg%3Bsaphana-clitestvm-donotuse2/operationResults/6261842d-e101-4866-8492-6f9271d58171?api-version=2023-02-01
   response:
     body:
       string: ''
@@ -9175,7 +7903,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 11 May 2023 12:05:04 GMT
+      - Fri, 09 Jun 2023 09:43:57 GMT
       pragma:
       - no-cache
       strict-transport-security:
@@ -9183,7 +7911,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '282'
+      - '283'
       x-powered-by:
       - ASP.NET
     status:
@@ -9203,8 +7931,8 @@ interactions:
       ParameterSetName:
       - -v -g --backup-management-type
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupProtectionContainers?api-version=2023-02-01&%24filter=backupManagementType+eq+%27AzureWorkload%27+and+status+eq+%27Registered%27
   response:
@@ -9218,7 +7946,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:05:06 GMT
+      - Fri, 09 Jun 2023 09:43:58 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_wl_hana_policy.yaml
+++ b/src/azure-cli/azure/cli/command_modules/backup/tests/latest/recordings/test_backup_wl_hana_policy.yaml
@@ -13,8 +13,8 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/saphana-clitestpolicy-donotuse?api-version=2023-02-01
   response:
@@ -28,7 +28,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:14:28 GMT
+      - Wed, 07 Jun 2023 06:35:51 GMT
       expires:
       - '-1'
       pragma:
@@ -86,8 +86,8 @@ interactions:
       ParameterSetName:
       - -g -v --policy --backup-management-type --workload-type --name
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/clitest-policy000001?api-version=2023-02-01
   response:
@@ -101,7 +101,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:14:32 GMT
+      - Wed, 07 Jun 2023 06:35:53 GMT
       expires:
       - '-1'
       pragma:
@@ -117,7 +117,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
       x-powered-by:
       - ASP.NET
     status:
@@ -137,13 +137,13 @@ interactions:
       ParameterSetName:
       - -g -v
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies?api-version=2023-02-01
   response:
     body:
-      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2022-05-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/clitest-policy000001","name":"clitest-policy000001","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SAPHanaDatabase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-09-30T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":180,"durationType":"Days"}},"weeklySchedule":{"daysOfTheWeek":["Sunday"],"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":104,"durationType":"Weeks"}},"monthlySchedule":{"retentionScheduleFormatType":"Weekly","retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":60,"durationType":"Months"}},"yearlySchedule":{"retentionScheduleFormatType":"Weekly","monthsOfYear":["January"],"retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":10,"durationType":"Years"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":120},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":15,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2022-05-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/saphana-clitestpolicy-donotuse","name":"saphana-clitestpolicy-donotuse","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SAPHanaDatabase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-09-30T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":180,"durationType":"Days"}},"weeklySchedule":{"daysOfTheWeek":["Sunday"],"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":104,"durationType":"Weeks"}},"monthlySchedule":{"retentionScheduleFormatType":"Weekly","retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":60,"durationType":"Months"}},"yearlySchedule":{"retentionScheduleFormatType":"Weekly","monthsOfYear":["January"],"retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":10,"durationType":"Years"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":120},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":15,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/EnhancedPolicy","name":"EnhancedPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","policyType":"V2","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicyV2","scheduleRunFrequency":"Hourly","hourlySchedule":{"interval":4,"scheduleWindowStartTime":"2022-05-16T08:00:00Z","scheduleWindowDuration":12}},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T08:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
+      string: '{"value":[{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/HourlyLogBackup","name":"HourlyLogBackup","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SQLDataBase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2022-05-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":60},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":30,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/DefaultPolicy","name":"DefaultPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2022-05-16T17:00:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T17:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/saphana-clitestpolicy-donotuse","name":"saphana-clitestpolicy-donotuse","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SAPHanaDatabase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-09-30T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":180,"durationType":"Days"}},"weeklySchedule":{"daysOfTheWeek":["Sunday"],"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":104,"durationType":"Weeks"}},"monthlySchedule":{"retentionScheduleFormatType":"Weekly","retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":60,"durationType":"Months"}},"yearlySchedule":{"retentionScheduleFormatType":"Weekly","monthsOfYear":["January"],"retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":10,"durationType":"Years"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":120},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":15,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/clitest-policy000001","name":"clitest-policy000001","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureWorkload","workLoadType":"SAPHanaDatabase","settings":{"timeZone":"UTC","issqlcompression":false,"isCompression":false},"subProtectionPolicy":[{"policyType":"Full","schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicy","scheduleRunFrequency":"Daily","scheduleRunTimes":["2020-09-30T19:30:00Z"],"scheduleWeeklyFrequency":0},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":180,"durationType":"Days"}},"weeklySchedule":{"daysOfTheWeek":["Sunday"],"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":104,"durationType":"Weeks"}},"monthlySchedule":{"retentionScheduleFormatType":"Weekly","retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":60,"durationType":"Months"}},"yearlySchedule":{"retentionScheduleFormatType":"Weekly","monthsOfYear":["January"],"retentionScheduleWeekly":{"daysOfTheWeek":["Sunday"],"weeksOfTheMonth":["First"]},"retentionTimes":["2020-09-30T19:30:00Z"],"retentionDuration":{"count":10,"durationType":"Years"}}}},{"policyType":"Log","schedulePolicy":{"schedulePolicyType":"LogSchedulePolicy","scheduleFrequencyInMins":120},"retentionPolicy":{"retentionPolicyType":"SimpleRetentionPolicy","retentionDuration":{"count":15,"durationType":"Days"}}}],"protectedItemsCount":0}},{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/EnhancedPolicy","name":"EnhancedPolicy","type":"Microsoft.RecoveryServices/vaults/backupPolicies","properties":{"backupManagementType":"AzureIaasVM","policyType":"V2","instantRPDetails":{},"schedulePolicy":{"schedulePolicyType":"SimpleSchedulePolicyV2","scheduleRunFrequency":"Hourly","hourlySchedule":{"interval":4,"scheduleWindowStartTime":"2022-05-16T08:00:00Z","scheduleWindowDuration":12}},"retentionPolicy":{"retentionPolicyType":"LongTermRetentionPolicy","dailySchedule":{"retentionTimes":["2022-05-16T08:00:00Z"],"retentionDuration":{"count":30,"durationType":"Days"}}},"instantRpRetentionRangeInDays":2,"timeZone":"UTC","protectedItemsCount":0}}]}'
     headers:
       cache-control:
       - no-cache
@@ -152,7 +152,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:14:34 GMT
+      - Wed, 07 Jun 2023 06:35:55 GMT
       expires:
       - '-1'
       pragma:
@@ -188,8 +188,8 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/clitest-policy000001?api-version=2023-02-01
   response:
@@ -203,7 +203,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:14:35 GMT
+      - Wed, 07 Jun 2023 06:35:56 GMT
       expires:
       - '-1'
       pragma:
@@ -241,8 +241,8 @@ interactions:
       ParameterSetName:
       - -g -v -n
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies/clitest-policy000001?api-version=2023-02-01
   response:
@@ -254,7 +254,7 @@ interactions:
       content-length:
       - '0'
       date:
-      - Thu, 11 May 2023 12:14:38 GMT
+      - Wed, 07 Jun 2023 06:35:57 GMT
       expires:
       - '-1'
       pragma:
@@ -284,8 +284,8 @@ interactions:
       ParameterSetName:
       - -g -v
       User-Agent:
-      - AZURECLI/2.48.1 (MSI) azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.8.5
-        (Windows-10-10.0.22000-SP0)
+      - AZURECLI/2.49.0 azsdk-python-mgmt-recoveryservicesbackup/6.0.0 Python/3.10.7
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/saphana-clitest-rg/providers/Microsoft.RecoveryServices/vaults/saphana-clitestvault-donotuse/backupPolicies?api-version=2023-02-01
   response:
@@ -299,7 +299,7 @@ interactions:
       content-type:
       - application/json
       date:
-      - Thu, 11 May 2023 12:14:39 GMT
+      - Wed, 07 Jun 2023 06:35:59 GMT
       expires:
       - '-1'
       pragma:
@@ -315,7 +315,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-resource-requests:
-      - '299'
+      - '298'
       x-powered-by:
       - ASP.NET
     status:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az backup protection backup-now`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Compressed backups have been enabled for SAP HANA. The current CLI blocks `backup protection backup-now` calls when the `--enable-compression` flag is set to `true`. This PR unblocks that scenario.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[backup] `az backup protection backup-now`: Allow `--enable-compression` to be set to `true` for SAPHANA Workloads

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
