### PR TITLE
{Packaging} Bump MSAL to 1.22.0

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -53,7 +53,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.10.1',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.20.0',
+    'msal[broker]==1.22.0',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -110,7 +110,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0
+msal[broker]==1.22.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -111,7 +111,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0
+msal[broker]==1.22.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -110,7 +110,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.20.0
+msal[broker]==1.22.0
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Description**<!--Mandatory-->
Bump MSAL to 1.22.0 in order to pick up https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/553/commits/1bb5476fa15d80c44c33915ebe5c8c2b7f7a88d5 released by https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/553.

This allows using higher versions of `cryptography` (https://github.com/Azure/azure-cli/pull/26596).
