### PR TITLE
{Packaging} Bump cryptography to 41.0.1 and pyOpenSSL to 23.2.0

### DIFF
--- a/scripts/ci/dependency_check.bat
+++ b/scripts/ci/dependency_check.bat
@@ -1,5 +1,8 @@
 pushd %~dp0..\..
 
+Rem Upgrade pip to the latest version
+python -m pip install --upgrade pip
+
 Rem Uninstall any cruft that can poison the rest of the checks in this script.
 pip freeze > baseline_deps.txt
 pip uninstall -y -r baseline_deps.txt

--- a/scripts/ci/dependency_check.sh
+++ b/scripts/ci/dependency_check.sh
@@ -4,6 +4,9 @@ set -ev
 
 REPO_ROOT="$(dirname ${BASH_SOURCE[0]})/../.."
 
+# Upgrade pip to the latest version
+python -m pip install --upgrade pip
+
 # Uninstall any cruft that can poison the rest of the checks in this script.
 pip freeze > baseline_deps.txt
 pip uninstall -y -r baseline_deps.txt || true

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -97,7 +97,7 @@ certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-cryptography==38.0.4
+cryptography==41.0.1
 fabric==2.4.0
 humanfriendly==10.0
 idna==2.8
@@ -124,7 +124,7 @@ pycparser==2.19
 PyGithub==1.55
 PyJWT==2.4.0
 PyNaCl==1.5.0
-pyOpenSSL==22.1.0
+pyOpenSSL==23.2.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.31.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -97,7 +97,7 @@ certifi==2022.12.7
 cffi==1.15.0
 chardet==3.0.4
 colorama==0.4.4
-cryptography==38.0.4
+cryptography==41.0.1
 distro==1.6.0
 fabric==2.4.0
 humanfriendly==10.0
@@ -125,7 +125,7 @@ pycparser==2.19
 PyGithub==1.55
 PyJWT==2.4.0
 PyNaCl==1.5.0
-pyOpenSSL==22.1.0
+pyOpenSSL==23.2.0
 python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.31.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
Rework of https://github.com/Azure/azure-cli/pull/26596

As explained in https://github.com/Azure/azure-cli/pull/26596#issuecomment-1590590291, only bumping `cryptography` is not enough. `pyOpenSSL` should be bumped at the same time.

Close #25913 
