### PR TITLE
{Keyvault} `az keyvault certificate show`: Fix 'NoneType object is not iterable' error

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -324,7 +324,7 @@ def transform_certificate_policy(policy, policy_id):
                     "daysBeforeExpiry": getattr(action, "days_before_expiry", None),
                     "lifetimePercentage": getattr(action, "lifetime_percentage", None)
                 }
-            } for action in getattr(policy, "lifetime_actions", [])],
+            } for action in (getattr(policy, "lifetime_actions", None) or [])],
             "secretProperties": {
                 "contentType": getattr(policy, "content_type", None)
             },

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_transformers.py
@@ -324,7 +324,7 @@ def transform_certificate_policy(policy, policy_id):
                     "daysBeforeExpiry": getattr(action, "days_before_expiry", None),
                     "lifetimePercentage": getattr(action, "lifetime_percentage", None)
                 }
-            } for action in getattr(policy, "lifetime_actions", None)],
+            } for action in getattr(policy, "lifetime_actions", [])],
             "secretProperties": {
                 "contentType": getattr(policy, "content_type", None)
             },


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault certificate show`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az keyvault certificate show` would throw
```
cli.azure.cli.core.azclierror: Traceback (most recent call last):
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/keyvault/_command_type.py", line 135, in keyvault_command_handler
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/core/commands/arm.py", line 429, in show_exception_handler
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/keyvault/_command_type.py", line 116, in keyvault_command_handler
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/keyvault/_transformers.py", line 285, in transform_certificate_show
  File "D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\azure/cli/command_modules/keyvault/_transformers.py", line 329, in transform_certificate_policy
TypeError: 'NoneType' object is not iterable
```
when the certificate doesn't have any lifetime actions.

This PR would fix NoneType iteration error.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
