### PR TITLE
[Sqlvm] Fix #2442969: `az sql vm enable-azure-ad-auth/validate-azure-ad-auth`: Workaround Graph API bug by using client side filtering upon failure

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
@@ -444,10 +444,12 @@ def _send(cli_ctx, method, url, param=None, body=None):
 # https://graph.microsoft.com/v1.0/servicePrincipals/{principalId}/transitiveMemberOf/microsoft.graph.directoryRole
 # retrieve all directory role assigned to a service principal
 def _directory_role_list(cli_ctx, principal_id):
+    logger.debug("Retrieving transitive directory roles of a MSI from Graph API with server side filtering.")
     DIRECTORY_ROLE_URL = "/servicePrincipals/{}/transitiveMemberOf/microsoft.graph.directoryRole"
     try:
         role_list = _send(cli_ctx, "GET", DIRECTORY_ROLE_URL.format(principal_id))
         if role_list is None:
+            logger.warning("Graph API server side filtering failed, Retry retrieving transitive directory roles of a MSI from Graph API with client side filtering. It is NOT a failure.")
             role_list = _directory_role_list2(cli_ctx, principal_id)
         return role_list
     except Exception as ex:

--- a/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/sqlvm/_validators.py
@@ -453,8 +453,9 @@ def _directory_role_list(cli_ctx, principal_id):
     except Exception as ex:
         raise InvalidArgumentValueError(MICROSOFT_GRAPH_API_ERROR.format(ex)) from ex
 
+
 # https://graph.microsoft.com/v1.0/servicePrincipals/{principalId}/transitiveMemberOf
-# Currently there is a bug in Graph API that causes internal server error in the Graph API service side filtering 
+# Currently there is a bug in Graph API that causes internal server error in the Graph API service side filtering
 # when the MSI is a member of an AAD group. The ICM incident is as below:
 # https://portal.microsofticm.com/imp/v3/incidents/details/392112435/home
 #
@@ -468,6 +469,7 @@ def _directory_role_list2(cli_ctx, principal_id):
         return [role for role in role_list if role["@odata.type"] == "#microsoft.graph.directoryRole"]
     except Exception as ex:
         raise InvalidArgumentValueError(MICROSOFT_GRAPH_API_ERROR.format(ex)) from ex
+
 
 # https://graph.microsoft.com/v1.0/servicePrincipals/{principalId}/appRoleAssignments
 # retrieve all app role assignments to a service principal


### PR DESCRIPTION
**Related command**
az sql vm enable-azure-ad-auth
az sql vm validate-azure-ad-auth

**Description**<!--Mandatory-->
There is a regression in Graph API related with server side filtering in retrieving all transitive directory roles a MSI belongs to as detailed in the following IcM ticket and bug. 
https://portal.microsofticm.com/imp/v3/incidents/details/392112435/home
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2591038
The deployment of a fix from Graph team is around September this year. Since this is a major use scenario of SQLVM AAD authentication feature, we decide to work around this bug in our Azure CLI by retrying the client side filtering when a server side filtering fails. 

**Testing Guide**
I have manually tested all scenarios. It is hard to add automated test here because this feature requires high AAD privilege (AAD global admin) in the process.

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
