### PR TITLE
[Storage] Fix #26567: `az storage blob download-batch`: When matching `--pattern`, list blobs with prefix to reduce the number of list calls

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/util.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/util.py
@@ -38,7 +38,11 @@ def collect_blob_objects(blob_service, container, pattern=None):
             blobs = blob_service.list_blobs(container)
         else:
             container_client = blob_service.get_container_client(container=container)
-            blobs = container_client.list_blobs()
+            prefix = _get_prefix(pattern)
+            if prefix:
+                blobs = container_client.list_blobs(name_starts_with=prefix)
+            else:
+                blobs = container_client.list_blobs()
         for blob in blobs:
             try:
                 blob_name = blob.name.encode('utf-8') if isinstance(blob.name, unicode) else blob.name
@@ -257,6 +261,19 @@ def mkdir_p(path):
 
 def _pattern_has_wildcards(p):
     return not p or p.find('*') != -1 or p.find('?') != -1 or p.find('[') != -1
+
+
+def _get_prefix(p):
+    if not p:
+        return p
+    pattern_start = len(p)
+    for index, ch in enumerate(p):
+        if ch == '*' or ch == '?' or ch == '[':
+            pattern_start = index
+            break
+    if pattern_start == len(p):
+        return None
+    return p[:pattern_start]
 
 
 def _match_path(path, pattern):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage blob download-batch`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
When matching pattern, previously first grabs the full list before trying to filter. Now list blobs with prefix to reduce the number of list calls. Fix #26567 

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] `az storage blob download-batch`: When matching pattern, list blobs with prefix to reduce the number of list calls

---


---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
