### PR TITLE
Update vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,12 @@ RUN ./scripts/install_full.sh && python ./scripts/trim_sdk.py \
     )" \
  && apk add --virtual .rundeps $runDeps
 
+# update vulnerabilities
+RUN apk upgrade openssl
+RUN apk upgrade binutils --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN pip install cryptography -U
+RUN pip install requests -U
+
 WORKDIR /
 
 # Remove CLI source code from the final image and normalize line endings.


### PR DESCRIPTION
**Related command**
N/A

**Description**<!--Mandatory-->
Fixes vulnerabilities in mcr.microsoft.com/azure-cli:2.49.0. Affected packages are:
-   cryptography 38.0.4 (pip)
-   requests 2.26.0 (pip)
-   openssl 3.1.0-r4 (apk)
-   binutils 2.40-r6 (apk)

**Testing Guide**
N/A

**History Notes**
N/A

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
