### PR TITLE
[App Service] Fix #25497: `az webapp deploy`: Fix extension parsing if `src-path` has multiple '.'s

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -5067,14 +5067,14 @@ def _get_onedeploy_request_body(params):
 
 
 def _update_artifact_type(params):
-    import ntpath
+    import os
 
     if params.artifact_type is not None:
         return
 
     # Interpret deployment type from the file extension if the type parameter is not passed
-    file_name = ntpath.basename(params.src_path)
-    file_extension = file_name.split(".", 1)[1]
+    file_name, file_extension = os.path.splitext(params.src_path)
+    file_extension = file_extension[1:]
     if file_extension in ('war', 'jar', 'ear', 'zip'):
         params.artifact_type = file_extension
     elif file_extension in ('sh', 'bat'):

--- a/src/azure-cli/azure/cli/command_modules/appservice/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/appservice/custom.py
@@ -5073,7 +5073,7 @@ def _update_artifact_type(params):
         return
 
     # Interpret deployment type from the file extension if the type parameter is not passed
-    file_name, file_extension = os.path.splitext(params.src_path)
+    _, file_extension = os.path.splitext(params.src_path)
     file_extension = file_extension[1:]
     if file_extension in ('war', 'jar', 'ear', 'zip'):
         params.artifact_type = file_extension


### PR DESCRIPTION
**Related command**
az webapp deploy

**Description**<!--Mandatory-->
Changing the file extension parsing logic to work with file paths that have multiple '.'s. Previous logic was written with the assumption that there would only be a single '.' character that splits the file name from the extension.

Issue_Close: #25497

**Testing Guide**
`az webapp deploy --resource-group [rg-name] --name [app-name] --src-path "[path-to-zip-file]" --type zip`
If `--src-path` has multiple '.'s such as 'test.app.zip' this command used to default to type=static. With this fix, the command will correctly select type=zip when passed the same filename.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
