### PR TITLE
{Keyvault} `az keyvault key/secret/certificate/storage/role`: Get endpoint from vault server

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -516,9 +516,11 @@ def _get_base_url_type(cli_ctx, service):
                 return 'https://{}{}'.format(name, suffix)
 
             if vaults:
+                from msrestazure.tools import parse_resource_id
+                id_comps = parse_resource_id(vaults[0].id)
                 vault_client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_KEYVAULT).vaults
-                vault = vault_client.get(resource_group_name=vaults[0].resource_group, vault_name=name)
-                logger.warning(f"Get vault uri from vault properties {vault.properties}.")
+                vault = vault_client.get(resource_group_name=id_comps['resource_group'], vault_name=name)
+                logger.debug(f"Get vault uri from vault properties {vault.properties}.")
                 return vault.properties.vault_uri
         return 'https://{}{}'.format(name, suffix)
 

--- a/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_validators.py
@@ -505,6 +505,15 @@ def _get_base_url_type(cli_ctx, service):
             suffix = ''
 
     def base_url_type(name):
+        if service == 'vault':
+            client = get_mgmt_service_client(cli_ctx, ResourceType.MGMT_KEYVAULT).vaults
+            for vault in client.list():
+                if vault.name.lower() == name.lower():
+                    from msrestazure.tools import parse_resource_id
+                    id_comps = parse_resource_id(vault.id)
+                    vault = client.get(resource_group_name=id_comps['resource_group'], vault_name=vault.name)
+                    logger.warning(f"Get vault uri from vault properties {vault.properties}.")
+                    return vault.properties.vault_uri
         return 'https://{}{}'.format(name, suffix)
 
     return base_url_type


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault key/secret/certificate/storage/role`
all data plane commands

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Keyvault data plane clients all require `vault_url` parameter. When customer provide `--vault-name`, we used to construct the `vault_url` with name and suffix in the format of `f'https://{vault_name}{cli_ctx.cloud.suffixes.keyvault_dns}'`. The suffix differs for different clouds:
https://github.com/Azure/azure-cli/blob/d4b27cb16c119e275323e69a4284f14b9d338042/src/azure-cli-core/azure/cli/core/cloud.py#L322 https://github.com/Azure/azure-cli/blob/d4b27cb16c119e275323e69a4284f14b9d338042/src/azure-cli-core/azure/cli/core/cloud.py#L356 https://github.com/Azure/azure-cli/blob/d4b27cb16c119e275323e69a4284f14b9d338042/src/azure-cli-core/azure/cli/core/cloud.py#L388 https://github.com/Azure/azure-cli/blob/d4b27cb16c119e275323e69a4284f14b9d338042/src/azure-cli-core/azure/cli/core/cloud.py#L415

But in the near feature, keyvault is going to support **DNS partitioning**. By that time, the suffix should be like `.vault.z23.azure.net`, which means the endpoint should contain zone info.

So instead of construct the `vault_url` by ourselves, we need to get the endpoint from vault server instead.

**Testing Guide**
<!--Example commands with explanations.-->



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
