### PR TITLE
{AppConfig} `az appconfig snapshot list`: Remove command test coverage linter exclusion

### DIFF
--- a/linter_exclusions.yml
+++ b/linter_exclusions.yml
@@ -711,11 +711,6 @@ appconfig kv import:
     src_connection_string:
       rule_exclusions:
       - option_length_too_long
-appconfig snapshot list:
-  parameters:
-    snapshot_name:
-      rule_exclusions:
-      - missing_parameter_test_coverage
 appconfig update:
   parameters:
     encryption_key_version:


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az appconfig snapshot list`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR removes the linter exclusion that for the snapshot list command parameter `--snapshot-name`. This follows an update to fix a CI issue that was marking an already covered test as missing in test coverage.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

{AppConfig} `az appconfig snapshot list`: Remove command test coverage linter exclusion

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
