### PR TITLE
[Service Fabric] `az sf managed-node-type create`: creates nodetype with 2022-Datacenter vmSku as default

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/servicefabric/_help.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/_help.py
@@ -489,7 +489,7 @@ examples:
 
 helps['sf managed-node-type create'] = """
 type: command
-short-summary: Delete a managed cluster.
+short-summary: Create node type on a managed cluster.
 examples:
   - name: Create primary node type with 5 nodes.
     text: >
@@ -501,7 +501,7 @@ examples:
 
 helps['sf managed-node-type update'] = """
 type: command
-short-summary: Update a managed cluster.
+short-summary: Update node type on a managed cluster.
 examples:
   - name: Update the instance count of the node type.
     text: >

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/_params.py
@@ -311,7 +311,7 @@ def load_arguments(self, _):  # pylint: disable=too-many-statements
         c.argument('vm_size', help='The size of virtual machines in the pool. All virtual machines in a pool are the same size.', default='Standard_D2')
         c.argument('vm_image_publisher', help='The publisher of the Azure Virtual Machines Marketplace image.', default='MicrosoftWindowsServer')
         c.argument('vm_image_offer', help='The offer type of the Azure Virtual Machines Marketplace image.', default='WindowsServer')
-        c.argument('vm_image_sku', help='The SKU of the Azure Virtual Machines Marketplace image.', default='2019-Datacenter')
+        c.argument('vm_image_sku', help='The SKU of the Azure Virtual Machines Marketplace image.', default='2022-Datacenter')
         c.argument('vm_image_version', help='The version of the Azure Virtual Machines Marketplace image. ', default='latest')
         c.argument('capacity', arg_type=capacity)
         c.argument('placement_property', arg_type=placement_property)

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_basic_cluster.yaml
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_basic_cluster.yaml
@@ -13,22 +13,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:51 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -56,22 +55,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:51 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -99,22 +97,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -142,22 +139,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -185,22 +181,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -228,22 +223,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -271,22 +265,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -314,22 +307,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:53 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -357,22 +349,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -400,22 +391,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -443,22 +433,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:53 GMT
+      - Mon, 26 Jun 2023 23:50:34 GMT
       expires:
       - '-1'
       pragma:
@@ -486,22 +475,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:34 GMT
       expires:
       - '-1'
       pragma:
@@ -529,22 +517,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:52 GMT
+      - Mon, 26 Jun 2023 23:50:34 GMT
       expires:
       - '-1'
       pragma:
@@ -572,22 +559,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:53 GMT
+      - Mon, 26 Jun 2023 23:50:35 GMT
       expires:
       - '-1'
       pragma:
@@ -615,22 +601,21 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T19:16:51Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_basic_cluster","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '363'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:53 GMT
+      - Mon, 26 Jun 2023 23:50:36 GMT
       expires:
       - '-1'
       pragma:
@@ -666,8 +651,8 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -676,12 +661,12 @@ interactions:
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {\r\n    \"key1\":
         \"value1\",\r\n    \"key2\": \"value2\"\r\n  },\r\n  \"systemData\": {\r\n
-        \   \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T19:16:55.8562919+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T19:16:55.8562919+00:00\"\r\n
+        \   \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.6009903+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.6009903+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"9635dd64-c073-4345-a237-859afeda45bd\",\r\n
+        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"534d8e76-098d-4a54-a1fc-1274f0a6f27d\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n    \"clusterCertificateThumbprints\":
@@ -692,15 +677,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1383'
+      - '1345'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:16:58 GMT
+      - Mon, 26 Jun 2023 23:50:42 GMT
       expires:
       - '-1'
       pragma:
@@ -734,14 +719,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -751,7 +736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:17:28 GMT
+      - Mon, 26 Jun 2023 23:50:42 GMT
       expires:
       - '-1'
       pragma:
@@ -784,14 +769,64 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:51:13 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -801,7 +836,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:17:59 GMT
+      - Mon, 26 Jun 2023 23:51:43 GMT
       expires:
       - '-1'
       pragma:
@@ -834,14 +869,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -851,7 +886,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:18:29 GMT
+      - Mon, 26 Jun 2023 23:52:13 GMT
       expires:
       - '-1'
       pragma:
@@ -884,14 +919,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -901,7 +936,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:18:59 GMT
+      - Mon, 26 Jun 2023 23:52:44 GMT
       expires:
       - '-1'
       pragma:
@@ -934,64 +969,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 19:19:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1001,7 +986,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:20:01 GMT
+      - Mon, 26 Jun 2023 23:53:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1034,14 +1019,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f4f70002-f464-4860-b4c3-1793a405848e?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b5240001-445c-435b-b447-094684a7645b?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"f4f70002-f464-4860-b4c3-1793a405848e\",\r\n  \"startTime\":
-        \"2023-02-07T19:16:58.6186708Z\",\r\n  \"endTime\": \"2023-02-07T19:20:18.6253479Z\",\r\n
+      string: "{\r\n  \"name\": \"b5240001-445c-435b-b447-094684a7645b\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"2023-06-26T23:53:44.1313647Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -1051,7 +1036,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:20:31 GMT
+      - Mon, 26 Jun 2023 23:53:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1084,8 +1069,8 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --tags
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -1094,17 +1079,17 @@ interactions:
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {\r\n    \"key1\":
         \"value1\",\r\n    \"key2\": \"value2\"\r\n  },\r\n  \"systemData\": {\r\n
-        \   \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T19:16:55.8562919+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T19:16:55.8562919+00:00\"\r\n
+        \   \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.6009903+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.6009903+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"9635dd64-c073-4345-a237-859afeda45bd\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"534d8e76-098d-4a54-a1fc-1274f0a6f27d\",\r\n
         \   \"clusterState\": \"WaitingForNodes\",\r\n    \"clusterUpgradeMode\":
         \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\": false,\r\n    \"clusterUpgradeCadence\":
         \"Wave0\",\r\n    \"adminUserName\": \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n
         \   \"fqdn\": \"sfrp-cli-000002.eastasia.cloudapp.azure.com\",\r\n    \"ipv4Address\":
-        \"20.187.99.143\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"E172F76D3FCB9353FC639C7A853ABB4839BD1078\"\r\n
+        \"20.24.198.216\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"2C85386F5BF0FFDF737536583D7077A0581ECCAA\"\r\n
         \   ],\r\n    \"clientConnectionPort\": 19000,\r\n    \"httpGatewayConnectionPort\":
         19080,\r\n    \"allowRdpAccess\": false,\r\n    \"clients\": [\r\n      {\r\n
         \       \"isAdmin\": true,\r\n        \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n
@@ -1114,11 +1099,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1577'
+      - '1539'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:20:31 GMT
+      - Mon, 26 Jun 2023 23:53:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1140,7 +1125,7 @@ interactions:
 - request:
     body: '{"properties": {"isPrimary": true, "vmInstanceCount": 5, "dataDiskSizeGB":
       100, "vmSize": "Standard_D2", "vmImagePublisher": "MicrosoftWindowsServer",
-      "vmImageOffer": "WindowsServer", "vmImageSku": "2019-Datacenter", "vmImageVersion":
+      "vmImageOffer": "WindowsServer", "vmImageSku": "2022-Datacenter", "vmImageVersion":
       "latest", "isStateless": false, "multiplePlacementGroups": false}}'
     headers:
       Accept:
@@ -1158,8 +1143,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -1169,7 +1154,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -1177,7 +1162,7 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -1185,7 +1170,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:20:36 GMT
+      - Mon, 26 Jun 2023 23:53:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1202,7 +1187,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1196'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -1220,24 +1205,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 5.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '191'
+      - '190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:21:06 GMT
+      - Mon, 26 Jun 2023 23:53:50 GMT
       expires:
       - '-1'
       pragma:
@@ -1270,14 +1255,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1287,7 +1272,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:21:37 GMT
+      - Mon, 26 Jun 2023 23:54:20 GMT
       expires:
       - '-1'
       pragma:
@@ -1320,14 +1305,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1337,7 +1322,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:22:07 GMT
+      - Mon, 26 Jun 2023 23:54:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1370,14 +1355,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1387,7 +1372,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:22:37 GMT
+      - Mon, 26 Jun 2023 23:55:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1420,14 +1405,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1437,7 +1422,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:23:07 GMT
+      - Mon, 26 Jun 2023 23:55:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1470,14 +1455,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1487,7 +1472,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:23:37 GMT
+      - Mon, 26 Jun 2023 23:56:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1520,14 +1505,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1537,7 +1522,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:24:08 GMT
+      - Mon, 26 Jun 2023 23:56:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1570,14 +1555,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1587,7 +1572,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:24:39 GMT
+      - Mon, 26 Jun 2023 23:57:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1620,14 +1605,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1637,7 +1622,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:25:09 GMT
+      - Mon, 26 Jun 2023 23:57:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1670,14 +1655,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1687,7 +1672,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:25:39 GMT
+      - Mon, 26 Jun 2023 23:58:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1720,14 +1705,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1737,7 +1722,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:26:09 GMT
+      - Mon, 26 Jun 2023 23:58:53 GMT
       expires:
       - '-1'
       pragma:
@@ -1770,14 +1755,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1787,7 +1772,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:26:40 GMT
+      - Mon, 26 Jun 2023 23:59:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1820,14 +1805,364 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:59:54 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:00:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:00:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:01:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:01:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:02:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:02:57 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1837,7 +2172,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:27:11 GMT
+      - Tue, 27 Jun 2023 00:03:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1870,14 +2205,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1887,7 +2222,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:27:41 GMT
+      - Tue, 27 Jun 2023 00:03:57 GMT
       expires:
       - '-1'
       pragma:
@@ -1920,14 +2255,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1937,7 +2272,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:28:11 GMT
+      - Tue, 27 Jun 2023 00:04:27 GMT
       expires:
       - '-1'
       pragma:
@@ -1970,14 +2305,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1987,7 +2322,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:28:41 GMT
+      - Tue, 27 Jun 2023 00:04:57 GMT
       expires:
       - '-1'
       pragma:
@@ -2020,14 +2355,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2037,7 +2372,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:29:12 GMT
+      - Tue, 27 Jun 2023 00:05:28 GMT
       expires:
       - '-1'
       pragma:
@@ -2070,14 +2405,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2087,7 +2422,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:29:43 GMT
+      - Tue, 27 Jun 2023 00:05:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2120,14 +2455,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2137,7 +2472,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:30:13 GMT
+      - Tue, 27 Jun 2023 00:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -2170,14 +2505,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2187,7 +2522,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:30:43 GMT
+      - Tue, 27 Jun 2023 00:06:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2220,14 +2555,414 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/4a2d0002-ef0b-41b6-8f73-38de86330de0?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"4a2d0002-ef0b-41b6-8f73-38de86330de0\",\r\n  \"startTime\":
-        \"2023-02-07T19:20:36.7660951Z\",\r\n  \"endTime\": \"2023-02-07T19:31:11.0798937Z\",\r\n
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:07:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:08:00 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:08:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:09:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:09:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:10:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:10:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:11:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/480b0001-6cb5-4ddc-a7f5-0485b07c41c4?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"480b0001-6cb5-4ddc-a7f5-0485b07c41c4\",\r\n  \"startTime\":
+        \"2023-06-26T23:53:50.7877549Z\",\r\n  \"endTime\": \"2023-06-27T00:11:25.3573714Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -2237,7 +2972,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:13 GMT
+      - Tue, 27 Jun 2023 00:11:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2270,8 +3005,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2281,7 +3016,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2295,7 +3030,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:13 GMT
+      - Tue, 27 Jun 2023 00:11:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2330,8 +3065,8 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2346,7 +3081,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:16 GMT
+      - Tue, 27 Jun 2023 00:11:36 GMT
       expires:
       - '-1'
       pragma:
@@ -2377,8 +3112,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -2387,18 +3122,18 @@ interactions:
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {\r\n    \"key1\":
         \"value1\",\r\n    \"key2\": \"value2\"\r\n  },\r\n  \"systemData\": {\r\n
-        \   \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T19:16:55.8562919+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T19:16:55.8562919+00:00\"\r\n
+        \   \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.6009903+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.6009903+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"9635dd64-c073-4345-a237-859afeda45bd\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1390.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"534d8e76-098d-4a54-a1fc-1274f0a6f27d\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n    \"fqdn\": \"sfrp-cli-000002.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.187.99.143\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"E172F76D3FCB9353FC639C7A853ABB4839BD1078\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.198.216\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"2C85386F5BF0FFDF737536583D7077A0581ECCAA\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -2408,11 +3143,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1611'
+      - '1573'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:16 GMT
+      - Tue, 27 Jun 2023 00:11:38 GMT
       expires:
       - '-1'
       pragma:
@@ -2447,8 +3182,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -2457,17 +3192,17 @@ interactions:
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {\r\n    \"key1\":
         \"value1\",\r\n    \"key2\": \"value2\"\r\n  },\r\n  \"systemData\": {\r\n
-        \   \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T19:16:55.8562919+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T19:16:55.8562919+00:00\"\r\n
+        \   \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.6009903+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.6009903+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"9635dd64-c073-4345-a237-859afeda45bd\",\r\n
+        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"534d8e76-098d-4a54-a1fc-1274f0a6f27d\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n    \"fqdn\": \"sfrp-cli-000002.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.187.99.143\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"E172F76D3FCB9353FC639C7A853ABB4839BD1078\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.198.216\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"2C85386F5BF0FFDF737536583D7077A0581ECCAA\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -2475,19 +3210,19 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1536'
+      - '1498'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:19 GMT
+      - Tue, 27 Jun 2023 00:11:42 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -2497,7 +3232,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-deletes:
-      - '14998'
+      - '14999'
     status:
       code: 202
       message: Accepted
@@ -2515,15 +3250,15 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -2532,7 +3267,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:31:49 GMT
+      - Tue, 27 Jun 2023 00:11:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2565,14 +3300,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2582,7 +3317,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:32:18 GMT
+      - Tue, 27 Jun 2023 00:12:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2615,14 +3350,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2632,7 +3367,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:32:49 GMT
+      - Tue, 27 Jun 2023 00:12:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2665,14 +3400,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2682,7 +3417,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:33:19 GMT
+      - Tue, 27 Jun 2023 00:13:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2715,14 +3450,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2732,7 +3467,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:33:49 GMT
+      - Tue, 27 Jun 2023 00:13:44 GMT
       expires:
       - '-1'
       pragma:
@@ -2765,14 +3500,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2782,7 +3517,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:34:20 GMT
+      - Tue, 27 Jun 2023 00:14:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2815,14 +3550,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2832,7 +3567,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:34:50 GMT
+      - Tue, 27 Jun 2023 00:14:44 GMT
       expires:
       - '-1'
       pragma:
@@ -2865,14 +3600,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2882,7 +3617,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:35:21 GMT
+      - Tue, 27 Jun 2023 00:15:14 GMT
       expires:
       - '-1'
       pragma:
@@ -2915,14 +3650,64 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"010a0002-19ea-44be-be54-d75ae85daaab\",\r\n  \"startTime\":
-        \"2023-02-07T19:31:19.2057046Z\",\r\n  \"endTime\": \"2023-02-07T19:35:36.8774357Z\",\r\n
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:15:45 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"7eaf0001-de21-4a64-ac6d-ad48fcdc61f0\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:42.8433711Z\",\r\n  \"endTime\": \"2023-06-27T00:16:00.1921227Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -2932,7 +3717,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:35:51 GMT
+      - Tue, 27 Jun 2023 00:16:15 GMT
       expires:
       - '-1'
       pragma:
@@ -2965,10 +3750,10 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/010a0002-19ea-44be-be54-d75ae85daaab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/7eaf0001-de21-4a64-ac6d-ad48fcdc61f0?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -2976,7 +3761,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Tue, 07 Feb 2023 19:35:51 GMT
+      - Tue, 27 Jun 2023 00:16:15 GMT
       expires:
       - '-1'
       pragma:
@@ -3005,8 +3790,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -3022,7 +3807,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 19:35:51 GMT
+      - Tue, 27 Jun 2023 00:16:17 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_cert_and_ext.yaml
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_cert_and_ext.yaml
@@ -13,13 +13,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -28,7 +27,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:11 GMT
+      - Tue, 27 Jun 2023 17:48:57 GMT
       expires:
       - '-1'
       pragma:
@@ -56,13 +55,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -71,7 +69,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:48:57 GMT
       expires:
       - '-1'
       pragma:
@@ -99,13 +97,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -114,7 +111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:11 GMT
+      - Tue, 27 Jun 2023 17:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -142,13 +139,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -157,7 +153,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:11 GMT
+      - Tue, 27 Jun 2023 17:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -185,13 +181,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -200,7 +195,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -228,13 +223,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -243,7 +237,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -271,13 +265,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -286,7 +279,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:48:58 GMT
       expires:
       - '-1'
       pragma:
@@ -314,13 +307,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -329,7 +321,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:13 GMT
+      - Tue, 27 Jun 2023 17:48:59 GMT
       expires:
       - '-1'
       pragma:
@@ -357,13 +349,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -372,7 +363,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:48:59 GMT
       expires:
       - '-1'
       pragma:
@@ -400,13 +391,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -415,7 +405,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -443,13 +433,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -458,7 +447,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -486,13 +475,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -501,7 +489,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -529,13 +517,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -544,7 +531,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:13 GMT
+      - Tue, 27 Jun 2023 17:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -572,13 +559,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -587,7 +573,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:12 GMT
+      - Tue, 27 Jun 2023 17:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -615,13 +601,12 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-05-15T13:04:34Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_cert_and_ext","date":"2023-06-27T17:48:04Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
@@ -630,7 +615,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:13 GMT
+      - Tue, 27 Jun 2023 17:49:01 GMT
       expires:
       - '-1'
       pragma:
@@ -666,8 +651,8 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -675,12 +660,12 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T13:05:15.0413341+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T17:49:03.0048646+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
+        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"clusterCertificateThumbprints\":
@@ -691,15 +676,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1334'
+      - '1296'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:17 GMT
+      - Tue, 27 Jun 2023 17:49:06 GMT
       expires:
       - '-1'
       pragma:
@@ -715,7 +700,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1198'
+      - '1199'
     status:
       code: 200
       message: OK
@@ -733,14 +718,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -750,7 +735,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:18 GMT
+      - Tue, 27 Jun 2023 17:49:06 GMT
       expires:
       - '-1'
       pragma:
@@ -783,14 +768,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -800,7 +785,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:05:48 GMT
+      - Tue, 27 Jun 2023 17:49:36 GMT
       expires:
       - '-1'
       pragma:
@@ -833,14 +818,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -850,7 +835,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:06:18 GMT
+      - Tue, 27 Jun 2023 17:50:06 GMT
       expires:
       - '-1'
       pragma:
@@ -883,14 +868,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -900,7 +885,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:06:48 GMT
+      - Tue, 27 Jun 2023 17:50:37 GMT
       expires:
       - '-1'
       pragma:
@@ -933,14 +918,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -950,7 +935,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:07:19 GMT
+      - Tue, 27 Jun 2023 17:51:07 GMT
       expires:
       - '-1'
       pragma:
@@ -983,14 +968,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1000,7 +985,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:07:49 GMT
+      - Tue, 27 Jun 2023 17:51:37 GMT
       expires:
       - '-1'
       pragma:
@@ -1033,14 +1018,14 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1050,7 +1035,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:08:19 GMT
+      - Tue, 27 Jun 2023 17:52:07 GMT
       expires:
       - '-1'
       pragma:
@@ -1083,14 +1068,64 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/8e6f0005-dbc0-4968-9c17-309267271128?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"8e6f0005-dbc0-4968-9c17-309267271128\",\r\n  \"startTime\":
-        \"2023-05-15T13:05:17.5720494Z\",\r\n  \"endTime\": \"2023-05-15T13:08:32.2140728Z\",\r\n
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 17:52:37 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/80cb0001-cd49-4760-9b0a-053decd440d0?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"80cb0001-cd49-4760-9b0a-053decd440d0\",\r\n  \"startTime\":
+        \"2023-06-27T17:49:05.4980955Z\",\r\n  \"endTime\": \"2023-06-27T17:52:41.6528864Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -1100,7 +1135,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:08:49 GMT
+      - Tue, 27 Jun 2023 17:53:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1133,8 +1168,8 @@ interactions:
       ParameterSetName:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -1142,17 +1177,17 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T13:05:15.0413341+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T17:49:03.0048646+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
         \   \"clusterState\": \"WaitingForNodes\",\r\n    \"clusterUpgradeMode\":
         \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\": false,\r\n    \"clusterUpgradeCadence\":
         \"Wave0\",\r\n    \"adminUserName\": \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n
         \   \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n    \"ipv4Address\":
-        \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n
+        \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n
         \   ],\r\n    \"clientConnectionPort\": 19000,\r\n    \"httpGatewayConnectionPort\":
         19080,\r\n    \"allowRdpAccess\": false,\r\n    \"clients\": [\r\n      {\r\n
         \       \"isAdmin\": true,\r\n        \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n
@@ -1162,11 +1197,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1529'
+      - '1489'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:08:49 GMT
+      - Tue, 27 Jun 2023 17:53:08 GMT
       expires:
       - '-1'
       pragma:
@@ -1188,7 +1223,7 @@ interactions:
 - request:
     body: '{"properties": {"isPrimary": true, "vmInstanceCount": 5, "dataDiskSizeGB":
       100, "vmSize": "Standard_D2", "vmImagePublisher": "MicrosoftWindowsServer",
-      "vmImageOffer": "WindowsServer", "vmImageSku": "2019-Datacenter", "vmImageVersion":
+      "vmImageOffer": "WindowsServer", "vmImageSku": "2022-Datacenter", "vmImageVersion":
       "latest", "isStateless": false, "multiplePlacementGroups": false}}'
     headers:
       Accept:
@@ -1206,8 +1241,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -1217,7 +1252,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -1225,7 +1260,7 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -1233,7 +1268,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:08:53 GMT
+      - Tue, 27 Jun 2023 17:53:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1268,24 +1303,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 5.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '189'
+      - '190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:08:53 GMT
+      - Tue, 27 Jun 2023 17:53:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1318,24 +1353,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:09:23 GMT
+      - Tue, 27 Jun 2023 17:53:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1368,24 +1403,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:09:54 GMT
+      - Tue, 27 Jun 2023 17:54:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1418,24 +1453,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:10:25 GMT
+      - Tue, 27 Jun 2023 17:54:44 GMT
       expires:
       - '-1'
       pragma:
@@ -1468,24 +1503,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:10:55 GMT
+      - Tue, 27 Jun 2023 17:55:14 GMT
       expires:
       - '-1'
       pragma:
@@ -1518,24 +1553,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:11:25 GMT
+      - Tue, 27 Jun 2023 17:55:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1568,24 +1603,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:11:55 GMT
+      - Tue, 27 Jun 2023 17:56:15 GMT
       expires:
       - '-1'
       pragma:
@@ -1618,24 +1653,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:12:25 GMT
+      - Tue, 27 Jun 2023 17:56:46 GMT
       expires:
       - '-1'
       pragma:
@@ -1668,24 +1703,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:12:56 GMT
+      - Tue, 27 Jun 2023 17:57:16 GMT
       expires:
       - '-1'
       pragma:
@@ -1718,24 +1753,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:13:26 GMT
+      - Tue, 27 Jun 2023 17:57:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1768,24 +1803,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:13:56 GMT
+      - Tue, 27 Jun 2023 17:58:17 GMT
       expires:
       - '-1'
       pragma:
@@ -1818,24 +1853,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:14:27 GMT
+      - Tue, 27 Jun 2023 17:58:47 GMT
       expires:
       - '-1'
       pragma:
@@ -1868,24 +1903,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:14:58 GMT
+      - Tue, 27 Jun 2023 17:59:18 GMT
       expires:
       - '-1'
       pragma:
@@ -1918,24 +1953,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:15:29 GMT
+      - Tue, 27 Jun 2023 17:59:48 GMT
       expires:
       - '-1'
       pragma:
@@ -1968,24 +2003,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:15:59 GMT
+      - Tue, 27 Jun 2023 18:00:19 GMT
       expires:
       - '-1'
       pragma:
@@ -2018,24 +2053,224 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 18:00:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 18:01:20 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 18:01:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 18:02:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:16:29 GMT
+      - Tue, 27 Jun 2023 18:02:51 GMT
       expires:
       - '-1'
       pragma:
@@ -2068,24 +2303,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:16:59 GMT
+      - Tue, 27 Jun 2023 18:03:21 GMT
       expires:
       - '-1'
       pragma:
@@ -2118,24 +2353,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:17:29 GMT
+      - Tue, 27 Jun 2023 18:03:52 GMT
       expires:
       - '-1'
       pragma:
@@ -2168,24 +2403,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:18:00 GMT
+      - Tue, 27 Jun 2023 18:04:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2218,24 +2453,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:18:30 GMT
+      - Tue, 27 Jun 2023 18:04:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2268,24 +2503,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:19:00 GMT
+      - Tue, 27 Jun 2023 18:05:22 GMT
       expires:
       - '-1'
       pragma:
@@ -2318,24 +2553,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:19:31 GMT
+      - Tue, 27 Jun 2023 18:05:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2368,24 +2603,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:20:02 GMT
+      - Tue, 27 Jun 2023 18:06:23 GMT
       expires:
       - '-1'
       pragma:
@@ -2418,24 +2653,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:20:32 GMT
+      - Tue, 27 Jun 2023 18:06:53 GMT
       expires:
       - '-1'
       pragma:
@@ -2468,24 +2703,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:21:02 GMT
+      - Tue, 27 Jun 2023 18:07:24 GMT
       expires:
       - '-1'
       pragma:
@@ -2518,24 +2753,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:21:32 GMT
+      - Tue, 27 Jun 2023 18:07:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2568,24 +2803,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:02 GMT
+      - Tue, 27 Jun 2023 18:08:25 GMT
       expires:
       - '-1'
       pragma:
@@ -2618,24 +2853,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/87f10005-c53b-4df8-b21d-93a42310025d?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/465e0001-5bc6-47d6-8ac8-a3070189a5c1?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"87f10005-c53b-4df8-b21d-93a42310025d\",\r\n  \"startTime\":
-        \"2023-05-15T13:08:53.957157Z\",\r\n  \"endTime\": \"2023-05-15T13:22:27.8128071Z\",\r\n
+      string: "{\r\n  \"name\": \"465e0001-5bc6-47d6-8ac8-a3070189a5c1\",\r\n  \"startTime\":
+        \"2023-06-27T17:53:14.0755092Z\",\r\n  \"endTime\": \"2023-06-27T18:08:48.6345879Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '202'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:33 GMT
+      - Tue, 27 Jun 2023 18:08:55 GMT
       expires:
       - '-1'
       pragma:
@@ -2668,8 +2903,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2679,7 +2914,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2693,7 +2928,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:34 GMT
+      - Tue, 27 Jun 2023 18:08:56 GMT
       expires:
       - '-1'
       pragma:
@@ -2727,8 +2962,8 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2738,7 +2973,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2752,7 +2987,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:36 GMT
+      - Tue, 27 Jun 2023 18:08:58 GMT
       expires:
       - '-1'
       pragma:
@@ -2775,7 +3010,7 @@ interactions:
     body: '{"tags": {}, "properties": {"isPrimary": true, "vmInstanceCount": 5, "dataDiskSizeGB":
       100, "dataDiskType": "StandardSSD_LRS", "placementProperties": {}, "capacities":
       {}, "vmSize": "Standard_D2", "vmImagePublisher": "MicrosoftWindowsServer", "vmImageOffer":
-      "WindowsServer", "vmImageSku": "2019-Datacenter", "vmImageVersion": "latest",
+      "WindowsServer", "vmImageSku": "2022-Datacenter", "vmImageVersion": "latest",
       "vmExtensions": [{"name": "csetest", "properties": {"publisher": "Microsoft.Compute",
       "type": "BGInfo", "typeHandlerVersion": "2.1", "autoUpgradeMinorVersion": true}}],
       "isStateless": false, "multiplePlacementGroups": false}}'
@@ -2796,8 +3031,8 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2807,7 +3042,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2819,7 +3054,7 @@ interactions:
         \ }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -2827,11 +3062,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:39 GMT
+      - Tue, 27 Jun 2023 18:09:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -2861,14 +3096,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 5.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2878,7 +3113,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:22:39 GMT
+      - Tue, 27 Jun 2023 18:09:01 GMT
       expires:
       - '-1'
       pragma:
@@ -2912,14 +3147,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2929,7 +3164,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:23:09 GMT
+      - Tue, 27 Jun 2023 18:09:31 GMT
       expires:
       - '-1'
       pragma:
@@ -2963,14 +3198,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2980,7 +3215,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:23:39 GMT
+      - Tue, 27 Jun 2023 18:10:01 GMT
       expires:
       - '-1'
       pragma:
@@ -3014,14 +3249,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3031,7 +3266,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:24:10 GMT
+      - Tue, 27 Jun 2023 18:10:32 GMT
       expires:
       - '-1'
       pragma:
@@ -3065,14 +3300,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3082,7 +3317,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:24:40 GMT
+      - Tue, 27 Jun 2023 18:11:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3116,14 +3351,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3133,7 +3368,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:25:10 GMT
+      - Tue, 27 Jun 2023 18:11:32 GMT
       expires:
       - '-1'
       pragma:
@@ -3167,14 +3402,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3184,7 +3419,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:25:40 GMT
+      - Tue, 27 Jun 2023 18:12:02 GMT
       expires:
       - '-1'
       pragma:
@@ -3218,14 +3453,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3235,7 +3470,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:26:10 GMT
+      - Tue, 27 Jun 2023 18:12:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3269,14 +3504,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3286,7 +3521,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:26:41 GMT
+      - Tue, 27 Jun 2023 18:13:03 GMT
       expires:
       - '-1'
       pragma:
@@ -3320,14 +3555,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3337,7 +3572,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:27:11 GMT
+      - Tue, 27 Jun 2023 18:13:33 GMT
       expires:
       - '-1'
       pragma:
@@ -3371,14 +3606,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3388,7 +3623,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:27:43 GMT
+      - Tue, 27 Jun 2023 18:14:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3422,14 +3657,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3439,7 +3674,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:28:13 GMT
+      - Tue, 27 Jun 2023 18:14:34 GMT
       expires:
       - '-1'
       pragma:
@@ -3473,14 +3708,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3490,7 +3725,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:28:43 GMT
+      - Tue, 27 Jun 2023 18:15:04 GMT
       expires:
       - '-1'
       pragma:
@@ -3524,14 +3759,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3541,7 +3776,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:29:13 GMT
+      - Tue, 27 Jun 2023 18:15:35 GMT
       expires:
       - '-1'
       pragma:
@@ -3575,14 +3810,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3592,7 +3827,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:29:43 GMT
+      - Tue, 27 Jun 2023 18:16:06 GMT
       expires:
       - '-1'
       pragma:
@@ -3626,14 +3861,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3643,7 +3878,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:30:14 GMT
+      - Tue, 27 Jun 2023 18:16:36 GMT
       expires:
       - '-1'
       pragma:
@@ -3677,14 +3912,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3694,7 +3929,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:30:44 GMT
+      - Tue, 27 Jun 2023 18:17:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3728,14 +3963,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3745,7 +3980,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:31:14 GMT
+      - Tue, 27 Jun 2023 18:17:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3779,14 +4014,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3796,7 +4031,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:31:44 GMT
+      - Tue, 27 Jun 2023 18:18:07 GMT
       expires:
       - '-1'
       pragma:
@@ -3830,14 +4065,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3847,7 +4082,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:32:15 GMT
+      - Tue, 27 Jun 2023 18:18:37 GMT
       expires:
       - '-1'
       pragma:
@@ -3881,14 +4116,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3898,7 +4133,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:32:46 GMT
+      - Tue, 27 Jun 2023 18:19:08 GMT
       expires:
       - '-1'
       pragma:
@@ -3932,14 +4167,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3949,7 +4184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:33:17 GMT
+      - Tue, 27 Jun 2023 18:19:38 GMT
       expires:
       - '-1'
       pragma:
@@ -3983,14 +4218,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4000,7 +4235,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:33:47 GMT
+      - Tue, 27 Jun 2023 18:20:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4034,14 +4269,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4051,7 +4286,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:34:17 GMT
+      - Tue, 27 Jun 2023 18:20:39 GMT
       expires:
       - '-1'
       pragma:
@@ -4085,14 +4320,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4102,7 +4337,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:34:47 GMT
+      - Tue, 27 Jun 2023 18:21:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4136,14 +4371,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4153,7 +4388,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:35:17 GMT
+      - Tue, 27 Jun 2023 18:21:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4187,14 +4422,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4204,7 +4439,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:35:48 GMT
+      - Tue, 27 Jun 2023 18:22:09 GMT
       expires:
       - '-1'
       pragma:
@@ -4238,14 +4473,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4255,7 +4490,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:36:18 GMT
+      - Tue, 27 Jun 2023 18:22:40 GMT
       expires:
       - '-1'
       pragma:
@@ -4289,14 +4524,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4306,7 +4541,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:36:48 GMT
+      - Tue, 27 Jun 2023 18:23:11 GMT
       expires:
       - '-1'
       pragma:
@@ -4340,14 +4575,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4357,7 +4592,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:37:19 GMT
+      - Tue, 27 Jun 2023 18:23:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4391,14 +4626,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4408,7 +4643,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:37:50 GMT
+      - Tue, 27 Jun 2023 18:24:12 GMT
       expires:
       - '-1'
       pragma:
@@ -4442,14 +4677,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4459,7 +4694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:38:20 GMT
+      - Tue, 27 Jun 2023 18:24:42 GMT
       expires:
       - '-1'
       pragma:
@@ -4493,14 +4728,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4510,7 +4745,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:38:50 GMT
+      - Tue, 27 Jun 2023 18:25:13 GMT
       expires:
       - '-1'
       pragma:
@@ -4544,14 +4779,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4561,7 +4796,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:39:20 GMT
+      - Tue, 27 Jun 2023 18:25:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4595,14 +4830,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4612,7 +4847,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:39:51 GMT
+      - Tue, 27 Jun 2023 18:26:14 GMT
       expires:
       - '-1'
       pragma:
@@ -4646,14 +4881,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4663,7 +4898,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:40:22 GMT
+      - Tue, 27 Jun 2023 18:26:43 GMT
       expires:
       - '-1'
       pragma:
@@ -4697,14 +4932,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4714,7 +4949,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:40:52 GMT
+      - Tue, 27 Jun 2023 18:27:14 GMT
       expires:
       - '-1'
       pragma:
@@ -4748,14 +4983,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4765,7 +5000,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:41:22 GMT
+      - Tue, 27 Jun 2023 18:27:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4799,14 +5034,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4816,7 +5051,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:41:52 GMT
+      - Tue, 27 Jun 2023 18:28:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4850,14 +5085,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4867,7 +5102,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:42:22 GMT
+      - Tue, 27 Jun 2023 18:28:45 GMT
       expires:
       - '-1'
       pragma:
@@ -4901,14 +5136,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4918,7 +5153,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:42:53 GMT
+      - Tue, 27 Jun 2023 18:29:15 GMT
       expires:
       - '-1'
       pragma:
@@ -4952,14 +5187,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4969,7 +5204,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:43:23 GMT
+      - Tue, 27 Jun 2023 18:29:45 GMT
       expires:
       - '-1'
       pragma:
@@ -5003,14 +5238,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5020,7 +5255,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:43:55 GMT
+      - Tue, 27 Jun 2023 18:30:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5054,14 +5289,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5071,7 +5306,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:44:25 GMT
+      - Tue, 27 Jun 2023 18:30:47 GMT
       expires:
       - '-1'
       pragma:
@@ -5105,14 +5340,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5122,7 +5357,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:44:55 GMT
+      - Tue, 27 Jun 2023 18:31:18 GMT
       expires:
       - '-1'
       pragma:
@@ -5156,14 +5391,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5173,7 +5408,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:45:25 GMT
+      - Tue, 27 Jun 2023 18:31:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5207,14 +5442,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5224,7 +5459,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:45:55 GMT
+      - Tue, 27 Jun 2023 18:32:17 GMT
       expires:
       - '-1'
       pragma:
@@ -5258,14 +5493,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5275,7 +5510,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:46:25 GMT
+      - Tue, 27 Jun 2023 18:32:48 GMT
       expires:
       - '-1'
       pragma:
@@ -5309,14 +5544,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5326,7 +5561,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:46:55 GMT
+      - Tue, 27 Jun 2023 18:33:18 GMT
       expires:
       - '-1'
       pragma:
@@ -5360,14 +5595,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5377,7 +5612,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:47:27 GMT
+      - Tue, 27 Jun 2023 18:33:49 GMT
       expires:
       - '-1'
       pragma:
@@ -5411,14 +5646,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5428,7 +5663,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:47:58 GMT
+      - Tue, 27 Jun 2023 18:34:19 GMT
       expires:
       - '-1'
       pragma:
@@ -5462,14 +5697,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5479,7 +5714,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:48:28 GMT
+      - Tue, 27 Jun 2023 18:34:49 GMT
       expires:
       - '-1'
       pragma:
@@ -5513,14 +5748,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5530,7 +5765,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:48:58 GMT
+      - Tue, 27 Jun 2023 18:35:20 GMT
       expires:
       - '-1'
       pragma:
@@ -5564,14 +5799,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5581,7 +5816,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:49:28 GMT
+      - Tue, 27 Jun 2023 18:35:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5615,14 +5850,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5632,7 +5867,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:49:58 GMT
+      - Tue, 27 Jun 2023 18:36:20 GMT
       expires:
       - '-1'
       pragma:
@@ -5666,14 +5901,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5683,7 +5918,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:50:28 GMT
+      - Tue, 27 Jun 2023 18:36:50 GMT
       expires:
       - '-1'
       pragma:
@@ -5717,14 +5952,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5734,7 +5969,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:50:59 GMT
+      - Tue, 27 Jun 2023 18:37:22 GMT
       expires:
       - '-1'
       pragma:
@@ -5768,14 +6003,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5785,7 +6020,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:51:29 GMT
+      - Tue, 27 Jun 2023 18:37:52 GMT
       expires:
       - '-1'
       pragma:
@@ -5819,14 +6054,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5836,7 +6071,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:51:59 GMT
+      - Tue, 27 Jun 2023 18:38:23 GMT
       expires:
       - '-1'
       pragma:
@@ -5870,14 +6105,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5887,7 +6122,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:52:30 GMT
+      - Tue, 27 Jun 2023 18:38:53 GMT
       expires:
       - '-1'
       pragma:
@@ -5921,14 +6156,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5938,7 +6173,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:53:01 GMT
+      - Tue, 27 Jun 2023 18:39:24 GMT
       expires:
       - '-1'
       pragma:
@@ -5972,14 +6207,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5989,7 +6224,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:53:31 GMT
+      - Tue, 27 Jun 2023 18:39:53 GMT
       expires:
       - '-1'
       pragma:
@@ -6023,14 +6258,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6040,7 +6275,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:54:02 GMT
+      - Tue, 27 Jun 2023 18:40:23 GMT
       expires:
       - '-1'
       pragma:
@@ -6074,14 +6309,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6091,7 +6326,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:54:32 GMT
+      - Tue, 27 Jun 2023 18:40:54 GMT
       expires:
       - '-1'
       pragma:
@@ -6125,14 +6360,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6142,7 +6377,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:55:02 GMT
+      - Tue, 27 Jun 2023 18:41:24 GMT
       expires:
       - '-1'
       pragma:
@@ -6176,14 +6411,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6193,7 +6428,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:55:32 GMT
+      - Tue, 27 Jun 2023 18:41:55 GMT
       expires:
       - '-1'
       pragma:
@@ -6227,14 +6462,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6244,7 +6479,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:56:02 GMT
+      - Tue, 27 Jun 2023 18:42:25 GMT
       expires:
       - '-1'
       pragma:
@@ -6278,14 +6513,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6295,7 +6530,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:56:33 GMT
+      - Tue, 27 Jun 2023 18:42:56 GMT
       expires:
       - '-1'
       pragma:
@@ -6329,14 +6564,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6346,7 +6581,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:57:03 GMT
+      - Tue, 27 Jun 2023 18:43:26 GMT
       expires:
       - '-1'
       pragma:
@@ -6380,14 +6615,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6397,7 +6632,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:57:33 GMT
+      - Tue, 27 Jun 2023 18:43:55 GMT
       expires:
       - '-1'
       pragma:
@@ -6431,14 +6666,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6448,7 +6683,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:58:05 GMT
+      - Tue, 27 Jun 2023 18:44:27 GMT
       expires:
       - '-1'
       pragma:
@@ -6482,14 +6717,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6499,7 +6734,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:58:35 GMT
+      - Tue, 27 Jun 2023 18:44:57 GMT
       expires:
       - '-1'
       pragma:
@@ -6533,14 +6768,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6550,7 +6785,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:59:05 GMT
+      - Tue, 27 Jun 2023 18:45:28 GMT
       expires:
       - '-1'
       pragma:
@@ -6584,14 +6819,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6601,7 +6836,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 13:59:36 GMT
+      - Tue, 27 Jun 2023 18:45:58 GMT
       expires:
       - '-1'
       pragma:
@@ -6635,14 +6870,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6652,7 +6887,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:00:06 GMT
+      - Tue, 27 Jun 2023 18:46:29 GMT
       expires:
       - '-1'
       pragma:
@@ -6686,14 +6921,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6703,7 +6938,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:00:36 GMT
+      - Tue, 27 Jun 2023 18:46:59 GMT
       expires:
       - '-1'
       pragma:
@@ -6737,14 +6972,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6754,7 +6989,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:01:06 GMT
+      - Tue, 27 Jun 2023 18:47:29 GMT
       expires:
       - '-1'
       pragma:
@@ -6788,14 +7023,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6805,7 +7040,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:01:36 GMT
+      - Tue, 27 Jun 2023 18:47:59 GMT
       expires:
       - '-1'
       pragma:
@@ -6839,14 +7074,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6856,7 +7091,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:02:07 GMT
+      - Tue, 27 Jun 2023 18:48:30 GMT
       expires:
       - '-1'
       pragma:
@@ -6890,14 +7125,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6907,7 +7142,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:02:37 GMT
+      - Tue, 27 Jun 2023 18:49:00 GMT
       expires:
       - '-1'
       pragma:
@@ -6941,14 +7176,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6958,7 +7193,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:03:08 GMT
+      - Tue, 27 Jun 2023 18:49:31 GMT
       expires:
       - '-1'
       pragma:
@@ -6992,14 +7227,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7009,7 +7244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:03:39 GMT
+      - Tue, 27 Jun 2023 18:50:00 GMT
       expires:
       - '-1'
       pragma:
@@ -7043,14 +7278,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7060,7 +7295,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:04:09 GMT
+      - Tue, 27 Jun 2023 18:50:30 GMT
       expires:
       - '-1'
       pragma:
@@ -7094,14 +7329,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7111,7 +7346,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:04:39 GMT
+      - Tue, 27 Jun 2023 18:51:01 GMT
       expires:
       - '-1'
       pragma:
@@ -7145,14 +7380,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7162,7 +7397,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:05:10 GMT
+      - Tue, 27 Jun 2023 18:51:33 GMT
       expires:
       - '-1'
       pragma:
@@ -7196,14 +7431,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7213,7 +7448,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:05:40 GMT
+      - Tue, 27 Jun 2023 18:52:03 GMT
       expires:
       - '-1'
       pragma:
@@ -7247,14 +7482,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7264,7 +7499,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:06:10 GMT
+      - Tue, 27 Jun 2023 18:52:33 GMT
       expires:
       - '-1'
       pragma:
@@ -7298,14 +7533,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7315,7 +7550,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:06:40 GMT
+      - Tue, 27 Jun 2023 18:53:04 GMT
       expires:
       - '-1'
       pragma:
@@ -7349,14 +7584,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7366,7 +7601,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:07:10 GMT
+      - Tue, 27 Jun 2023 18:53:34 GMT
       expires:
       - '-1'
       pragma:
@@ -7400,14 +7635,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7417,7 +7652,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:07:40 GMT
+      - Tue, 27 Jun 2023 18:54:04 GMT
       expires:
       - '-1'
       pragma:
@@ -7451,14 +7686,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7468,7 +7703,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:08:11 GMT
+      - Tue, 27 Jun 2023 18:54:34 GMT
       expires:
       - '-1'
       pragma:
@@ -7502,14 +7737,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7519,7 +7754,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:08:42 GMT
+      - Tue, 27 Jun 2023 18:55:05 GMT
       expires:
       - '-1'
       pragma:
@@ -7553,14 +7788,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7570,7 +7805,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:09:13 GMT
+      - Tue, 27 Jun 2023 18:55:35 GMT
       expires:
       - '-1'
       pragma:
@@ -7604,14 +7839,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7621,7 +7856,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:09:42 GMT
+      - Tue, 27 Jun 2023 18:56:05 GMT
       expires:
       - '-1'
       pragma:
@@ -7655,14 +7890,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7672,7 +7907,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:10:13 GMT
+      - Tue, 27 Jun 2023 18:56:36 GMT
       expires:
       - '-1'
       pragma:
@@ -7706,14 +7941,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7723,7 +7958,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:10:43 GMT
+      - Tue, 27 Jun 2023 18:57:06 GMT
       expires:
       - '-1'
       pragma:
@@ -7757,14 +7992,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7774,7 +8009,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:11:13 GMT
+      - Tue, 27 Jun 2023 18:57:36 GMT
       expires:
       - '-1'
       pragma:
@@ -7808,14 +8043,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7825,7 +8060,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:11:44 GMT
+      - Tue, 27 Jun 2023 18:58:07 GMT
       expires:
       - '-1'
       pragma:
@@ -7859,14 +8094,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7876,7 +8111,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:12:14 GMT
+      - Tue, 27 Jun 2023 18:58:38 GMT
       expires:
       - '-1'
       pragma:
@@ -7910,14 +8145,14 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -7927,7 +8162,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:12:45 GMT
+      - Tue, 27 Jun 2023 18:59:09 GMT
       expires:
       - '-1'
       pragma:
@@ -7961,24 +8196,24 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"01460005-e7b3-4257-b3d5-d50ec83822ab\",\r\n  \"startTime\":
-        \"2023-05-15T13:22:39.422388Z\",\r\n  \"endTime\": \"2023-05-15T14:13:10.54638Z\",\r\n
+      string: "{\r\n  \"name\": \"48ea0001-1125-4547-a73c-91a80ac3d7a6\",\r\n  \"startTime\":
+        \"2023-06-27T18:09:01.306643Z\",\r\n  \"endTime\": \"2023-06-27T18:59:32.7130895Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '200'
+      - '202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:16 GMT
+      - Tue, 27 Jun 2023 18:59:39 GMT
       expires:
       - '-1'
       pragma:
@@ -8012,10 +8247,10 @@ interactions:
       - -g -c -n --extension-name --publisher --extension-type --type-handler-version
         --auto-upgrade-minor-version
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/01460005-e7b3-4257-b3d5-d50ec83822ab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/48ea0001-1125-4547-a73c-91a80ac3d7a6?api-version=2021-05-01
   response:
     body:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodetypes/pnt\",\r\n
@@ -8023,7 +8258,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -8041,7 +8276,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:16 GMT
+      - Tue, 27 Jun 2023 18:59:39 GMT
       expires:
       - '-1'
       pragma:
@@ -8074,8 +8309,8 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -8085,7 +8320,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -8103,7 +8338,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:18 GMT
+      - Tue, 27 Jun 2023 18:59:42 GMT
       expires:
       - '-1'
       pragma:
@@ -8136,22 +8371,21 @@ interactions:
       ParameterSetName:
       - -n -g
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-azure-mgmt-keyvault/10.2.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-keyvault/10.2.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002?api-version=2023-02-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"eastasia","tags":{},"systemData":{"createdBy":"azureclilivetest@azuresdkteam.onmicrosoft.com","createdByType":"User","createdAt":"2023-05-15T13:04:37.67Z","lastModifiedBy":"azureclilivetest@azuresdkteam.onmicrosoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-05-15T13:04:37.67Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","accessPolicies":[{"tenantId":"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a","objectId":"6b30bdc6-696a-46fb-82d7-739c2fb147b7","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002","name":"sfrp-cli-kv-000002","type":"Microsoft.KeyVault/vaults","location":"eastasia","tags":{},"systemData":{"createdBy":"mwesigwaguma@microsoft.com","createdByType":"User","createdAt":"2023-06-27T17:48:19.895Z","lastModifiedBy":"mwesigwaguma@microsoft.com","lastModifiedByType":"User","lastModifiedAt":"2023-06-27T17:48:19.895Z"},"properties":{"sku":{"family":"A","name":"standard"},"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","accessPolicies":[{"tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objectId":"7c25af64-9686-4f2b-8350-66e7f1cd6144","permissions":{"keys":["all"],"secrets":["all"],"certificates":["all"],"storage":["all"]}}],"enabledForDeployment":true,"enabledForTemplateDeployment":true,"enableSoftDelete":true,"softDeleteRetentionInDays":7,"vaultUri":"https://sfrp-cli-kv-000002.vault.azure.net/","provisioningState":"Succeeded","publicNetworkAccess":"Enabled"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '1068'
+      - '1032'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:19 GMT
+      - Tue, 27 Jun 2023 18:59:43 GMT
       expires:
       - '-1'
       pragma:
@@ -8169,7 +8403,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-service-version:
-      - 1.5.770.0
+      - 1.5.822.0
     status:
       code: 200
       message: OK
@@ -8187,8 +8421,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/create?api-version=7.4
   response:
@@ -8203,7 +8436,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:20 GMT
+      - Tue, 27 Jun 2023 18:59:48 GMT
       expires:
       - '-1'
       pragma:
@@ -8211,16 +8444,16 @@ interactions:
       strict-transport-security:
       - max-age=31536000;includeSubDomains
       www-authenticate:
-      - Bearer authorization="https://login.microsoftonline.com/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
+      - Bearer authorization="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47",
         resource="https://vault.azure.net"
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 401
       message: Unauthorized
@@ -8244,15 +8477,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/create?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBjNThhLnXHAceT1nb42w4NdtmxpbgvlIQzChgOGQi+20g/fJ10RJhu1gP/yPeetQVEF02j0yTC9G5tSqsCr7z46LMepZ89nwVXQgPIOWeuaikZSm1GP8UrsTNEEpSJvKIzhpUV5N3F8VllGD9p8DVV9jqR/quymIaWcLnXC/7jAYve3GGLAQWTZAQ+g0zRb2/KhMHf2CJ67AjifQrRwlgiBsZRhbT55TkCoEwEQkn9QWYx7ajBh+S9KEtLwlHn1kP0ni0jL/RGc1JXF2JCDM35S99mLKYlEoHESNL0TrbiiihAavYjML5bVOdnLBAtmSKVPmOcQIe7fOoK0O+QDe+z","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAHGvM30zOikOp5YeFRSrCmcpmsFD+QeFZ1QrhQLvGOFRaRsOOz2IF5YsolPXRwT0MT/+nr1cElmyUlU6+9dQYctxj57AxjUbxqFpSwfhmnPKJv6aqxD2195/z7y1OM2biKVNa0PIAuPoX+l763ZpaGW0EQC8q3bHHMvh2O7gN5uBdIl9u/r0odIltcwxZvXZqboLxVc47+vrCKqM3CPG22/Ar/CPmk2NwfrorXxh+F+ypzf4JFCSU9Z8w97rztKeleJ4u6NuzxfGLhv0OPt/IhmE7jjATfgAne3OpWiPUzzuiqSI+nJxBTglqIRBuRRt8eZ6HISbtgZq94MRtMolPj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"25341dc588134df2a77339f44f461855"}'
+        time based on the issuer provider. Please check again later.","request_id":"fbfde1f2b4ca499ba3d6122f36d87a72"}'
     headers:
       cache-control:
       - no-cache
@@ -8261,11 +8493,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:21 GMT
+      - Tue, 27 Jun 2023 18:59:50 GMT
       expires:
       - '-1'
       location:
-      - https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4&request_id=25341dc588134df2a77339f44f461855
+      - https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4&request_id=fbfde1f2b4ca499ba3d6122f36d87a72
       pragma:
       - no-cache
       strict-transport-security:
@@ -8273,11 +8505,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 202
       message: Accepted
@@ -8291,15 +8523,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBjNThhLnXHAceT1nb42w4NdtmxpbgvlIQzChgOGQi+20g/fJ10RJhu1gP/yPeetQVEF02j0yTC9G5tSqsCr7z46LMepZ89nwVXQgPIOWeuaikZSm1GP8UrsTNEEpSJvKIzhpUV5N3F8VllGD9p8DVV9jqR/quymIaWcLnXC/7jAYve3GGLAQWTZAQ+g0zRb2/KhMHf2CJ67AjifQrRwlgiBsZRhbT55TkCoEwEQkn9QWYx7ajBh+S9KEtLwlHn1kP0ni0jL/RGc1JXF2JCDM35S99mLKYlEoHESNL0TrbiiihAavYjML5bVOdnLBAtmSKVPmOcQIe7fOoK0O+QDe+z","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAHGvM30zOikOp5YeFRSrCmcpmsFD+QeFZ1QrhQLvGOFRaRsOOz2IF5YsolPXRwT0MT/+nr1cElmyUlU6+9dQYctxj57AxjUbxqFpSwfhmnPKJv6aqxD2195/z7y1OM2biKVNa0PIAuPoX+l763ZpaGW0EQC8q3bHHMvh2O7gN5uBdIl9u/r0odIltcwxZvXZqboLxVc47+vrCKqM3CPG22/Ar/CPmk2NwfrorXxh+F+ypzf4JFCSU9Z8w97rztKeleJ4u6NuzxfGLhv0OPt/IhmE7jjATfgAne3OpWiPUzzuiqSI+nJxBTglqIRBuRRt8eZ6HISbtgZq94MRtMolPj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
         certificate created. Certificate request is in progress. This may take some
-        time based on the issuer provider. Please check again later.","request_id":"25341dc588134df2a77339f44f461855"}'
+        time based on the issuer provider. Please check again later.","request_id":"fbfde1f2b4ca499ba3d6122f36d87a72"}'
     headers:
       cache-control:
       - no-cache
@@ -8308,7 +8539,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:22 GMT
+      - Tue, 27 Jun 2023 18:59:50 GMT
       expires:
       - '-1'
       pragma:
@@ -8318,11 +8549,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 200
       message: OK
@@ -8336,13 +8567,56 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBjNThhLnXHAceT1nb42w4NdtmxpbgvlIQzChgOGQi+20g/fJ10RJhu1gP/yPeetQVEF02j0yTC9G5tSqsCr7z46LMepZ89nwVXQgPIOWeuaikZSm1GP8UrsTNEEpSJvKIzhpUV5N3F8VllGD9p8DVV9jqR/quymIaWcLnXC/7jAYve3GGLAQWTZAQ+g0zRb2/KhMHf2CJ67AjifQrRwlgiBsZRhbT55TkCoEwEQkn9QWYx7ajBh+S9KEtLwlHn1kP0ni0jL/RGc1JXF2JCDM35S99mLKYlEoHESNL0TrbiiihAavYjML5bVOdnLBAtmSKVPmOcQIe7fOoK0O+QDe+z","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005","request_id":"25341dc588134df2a77339f44f461855"}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAHGvM30zOikOp5YeFRSrCmcpmsFD+QeFZ1QrhQLvGOFRaRsOOz2IF5YsolPXRwT0MT/+nr1cElmyUlU6+9dQYctxj57AxjUbxqFpSwfhmnPKJv6aqxD2195/z7y1OM2biKVNa0PIAuPoX+l763ZpaGW0EQC8q3bHHMvh2O7gN5uBdIl9u/r0odIltcwxZvXZqboLxVc47+vrCKqM3CPG22/Ar/CPmk2NwfrorXxh+F+ypzf4JFCSU9Z8w97rztKeleJ4u6NuzxfGLhv0OPt/IhmE7jjATfgAne3OpWiPUzzuiqSI+nJxBTglqIRBuRRt8eZ6HISbtgZq94MRtMolPj","cancellation_requested":false,"status":"inProgress","status_details":"Pending
+        certificate created. Certificate request is in progress. This may take some
+        time based on the issuer provider. Please check again later.","request_id":"fbfde1f2b4ca499ba3d6122f36d87a72"}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '1307'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 18:59:50 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000;includeSubDomains
+      x-content-type-options:
+      - nosniff
+      x-ms-keyvault-network-info:
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastasia
+      x-ms-keyvault-service-version:
+      - 1.9.865.1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4
+  response:
+    body:
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAHGvM30zOikOp5YeFRSrCmcpmsFD+QeFZ1QrhQLvGOFRaRsOOz2IF5YsolPXRwT0MT/+nr1cElmyUlU6+9dQYctxj57AxjUbxqFpSwfhmnPKJv6aqxD2195/z7y1OM2biKVNa0PIAuPoX+l763ZpaGW0EQC8q3bHHMvh2O7gN5uBdIl9u/r0odIltcwxZvXZqboLxVc47+vrCKqM3CPG22/Ar/CPmk2NwfrorXxh+F+ypzf4JFCSU9Z8w97rztKeleJ4u6NuzxfGLhv0OPt/IhmE7jjATfgAne3OpWiPUzzuiqSI+nJxBTglqIRBuRRt8eZ6HISbtgZq94MRtMolPj","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005","request_id":"fbfde1f2b4ca499ba3d6122f36d87a72"}'
     headers:
       cache-control:
       - no-cache
@@ -8351,7 +8625,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:23 GMT
+      - Tue, 27 Jun 2023 18:59:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8361,11 +8635,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 200
       message: OK
@@ -8379,13 +8653,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","x5t":"NEWLswjLLQIlkux93sqIn-aTOdA","cer":"MIIDQjCCAiqgAwIBAgIQJ25X3AYIQVeD2/ETL5ncVzANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIzMDUxNTE0MDMyM1oXDTI0MDUxNTE0MTMyM1owHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFPGtyKZQMU2cbxoWEtJrKpVWe6ugMB0GA1UdDgQWBBTxrcimUDFNnG8aFhLSayqVVnuroDANBgkqhkiG9w0BAQsFAAOCAQEAh4RdmJcOKMHT1618s/xwkFB+jwgI2jJFCLQcSrxa3kn12me3DXPZHzdWgEzmOQ0nM9V4oxlMOt0o7VhdW0kmPANwDe6goghZd65vWE/Iip6qruyohuXmOiQq1K+FwoLpYbGAA6Njmthi38pW7DqpDmSV9ss9c3LI6iInr/M81Wr5cOiDsY9AJRpKqAsW6Eu9U5WzxJ6tWP4X7WttoAM9te3CNpxw0A5r9PxeqHBP8zMhx+vQ1rG8nZ2RTLS4gHmJ9lZWYL7dGZigrZ7lmCiubGpr9BQOSOV+2Fy23T/ewIEWi1vGcP3PiskvXuFqBPdtZ052O1WUoQx9TvIsFRtY1w==","attributes":{"enabled":true,"nbf":1684159403,"exp":1715782403,"created":1684160003,"updated":1684160003,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1684160002,"updated":1684160002}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending"}}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","x5t":"aJyq9dxYIbM5d3q1XyjXEXZ_aQY","cer":"MIIDQjCCAiqgAwIBAgIQGX5wOp0aTH6OaGdM5BQ/9zANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIzMDYyNzE4NDk1M1oXDTI0MDYyNzE4NTk1M1owHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFE22yDDlMQCKlmoxdR6YoT8a7/IJMB0GA1UdDgQWBBRNtsgw5TEAipZqMXUemKE/Gu/yCTANBgkqhkiG9w0BAQsFAAOCAQEABfoIeLbtCcnX2zQ69LcyGSu7ivsmzL16acSi6BIVj9jr9fRmvaRTCnZsMOSSUz/HBASyaUYll4Pz3xWgYvU1vvcQpeyeGyxgk16yIxBB78HznyJM76OSWRTFz1Bo3H2X0tOe1WntE80DookeHbXdt03tEgfTRjalS4x+ibJweA1j4Cah8irwtoowVSQJHEQ5n9BxxLtkBvZHRPF4CkY0VETXC+k2Ibh0/ANYyIX8MYgDq35DSetLKuhpDZsZu9bzi78PJEjIRAtCPo65MyLMvTEWDkWrDTm2GFfywIoavKCyvHFNv4FAyeo14P6SD30Abcc9RgsL0heK4ysj2QVW0Q==","attributes":{"enabled":true,"nbf":1687891793,"exp":1719514793,"created":1687892393,"updated":1687892393,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1687892390,"updated":1687892390}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending"}}'
     headers:
       cache-control:
       - no-cache
@@ -8394,7 +8667,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:23 GMT
+      - Tue, 27 Jun 2023 18:59:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8404,11 +8677,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 200
       message: OK
@@ -8422,13 +8695,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQBjNThhLnXHAceT1nb42w4NdtmxpbgvlIQzChgOGQi+20g/fJ10RJhu1gP/yPeetQVEF02j0yTC9G5tSqsCr7z46LMepZ89nwVXQgPIOWeuaikZSm1GP8UrsTNEEpSJvKIzhpUV5N3F8VllGD9p8DVV9jqR/quymIaWcLnXC/7jAYve3GGLAQWTZAQ+g0zRb2/KhMHf2CJ67AjifQrRwlgiBsZRhbT55TkCoEwEQkn9QWYx7ajBh+S9KEtLwlHn1kP0ni0jL/RGc1JXF2JCDM35S99mLKYlEoHESNL0TrbiiihAavYjML5bVOdnLBAtmSKVPmOcQIe7fOoK0O+QDe+z","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005","request_id":"25341dc588134df2a77339f44f461855"}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending","issuer":{"name":"Self"},"csr":"MIICrjCCAZYCAQAwHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaBLMEkGCSqGSIb3DQEJDjE8MDowDgYDVR0PAQH/BAQDAgG+MB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAHGvM30zOikOp5YeFRSrCmcpmsFD+QeFZ1QrhQLvGOFRaRsOOz2IF5YsolPXRwT0MT/+nr1cElmyUlU6+9dQYctxj57AxjUbxqFpSwfhmnPKJv6aqxD2195/z7y1OM2biKVNa0PIAuPoX+l763ZpaGW0EQC8q3bHHMvh2O7gN5uBdIl9u/r0odIltcwxZvXZqboLxVc47+vrCKqM3CPG22/Ar/CPmk2NwfrorXxh+F+ypzf4JFCSU9Z8w97rztKeleJ4u6NuzxfGLhv0OPt/IhmE7jjATfgAne3OpWiPUzzuiqSI+nJxBTglqIRBuRRt8eZ6HISbtgZq94MRtMolPj","cancellation_requested":false,"status":"completed","target":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005","request_id":"fbfde1f2b4ca499ba3d6122f36d87a72"}'
     headers:
       cache-control:
       - no-cache
@@ -8437,7 +8709,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:32 GMT
+      - Tue, 27 Jun 2023 19:00:01 GMT
       expires:
       - '-1'
       pragma:
@@ -8447,11 +8719,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 200
       message: OK
@@ -8465,13 +8737,12 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - azsdk-python-keyvault-certificates/4.7.0 Python/3.10.11 (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - azsdk-python-keyvault-certificates/4.7.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/?api-version=7.4
   response:
     body:
-      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74","x5t":"NEWLswjLLQIlkux93sqIn-aTOdA","cer":"MIIDQjCCAiqgAwIBAgIQJ25X3AYIQVeD2/ETL5ncVzANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIzMDUxNTE0MDMyM1oXDTI0MDUxNTE0MTMyM1owHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhKjstBNZ5YVyT7QTdWdgx33nIbKMrXzA4yGl1Wdhv6gNap45wzpqKqsh2i+UrRLbU/E6S9E6YNq39AzcRLG6TOfbbno2bVkr+yD6IktwvSu+mNqChaRBzTEWlOahufojqj413y2fCo6qFa8pBzli+faKSJK1sMMOL0ljnqCvHJyBznXNX8dnqJIiHK2HJ+dguCnnpPYojyDlHlxxyMn9wDQ6Pv0keljmkCTEe/474zBvDDbrWYUc4ytoWhnyqPf8ugFGjKaFx9FnD2J/jH50Gifvzh0TpkPTumQPuhZpFs5jRMrFTf+tvr34piiU4kWDGzsdjCpJ+VIf2RKXDrEgECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFPGtyKZQMU2cbxoWEtJrKpVWe6ugMB0GA1UdDgQWBBTxrcimUDFNnG8aFhLSayqVVnuroDANBgkqhkiG9w0BAQsFAAOCAQEAh4RdmJcOKMHT1618s/xwkFB+jwgI2jJFCLQcSrxa3kn12me3DXPZHzdWgEzmOQ0nM9V4oxlMOt0o7VhdW0kmPANwDe6goghZd65vWE/Iip6qruyohuXmOiQq1K+FwoLpYbGAA6Njmthi38pW7DqpDmSV9ss9c3LI6iInr/M81Wr5cOiDsY9AJRpKqAsW6Eu9U5WzxJ6tWP4X7WttoAM9te3CNpxw0A5r9PxeqHBP8zMhx+vQ1rG8nZ2RTLS4gHmJ9lZWYL7dGZigrZ7lmCiubGpr9BQOSOV+2Fy23T/ewIEWi1vGcP3PiskvXuFqBPdtZ052O1WUoQx9TvIsFRtY1w==","attributes":{"enabled":true,"nbf":1684159403,"exp":1715782403,"created":1684160003,"updated":1684160003,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1684160002,"updated":1684160002}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending"}}'
+      string: '{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","kid":"https://sfrp-cli-kv-000002.vault.azure.net/keys/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","sid":"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df","x5t":"aJyq9dxYIbM5d3q1XyjXEXZ_aQY","cer":"MIIDQjCCAiqgAwIBAgIQGX5wOp0aTH6OaGdM5BQ/9zANBgkqhkiG9w0BAQsFADAeMRwwGgYDVQQDExNDTElHZXREZWZhdWx0UG9saWN5MB4XDTIzMDYyNzE4NDk1M1oXDTI0MDYyNzE4NTk1M1owHjEcMBoGA1UEAxMTQ0xJR2V0RGVmYXVsdFBvbGljeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOK0mz1cJXDSKhwgMT4FY8Htl9dkRpI/Cwrw3u6QWLVJ2N9SLCCA4JbmJcxrUVTAG2A+Ixq6hguvc4knfGa88YaI3kr76A4iZUjbuA8p5W6F/T1wNyk/oi4zkffQSShWweyeL48k9DWhqVdFz1ye0l5QQNPR/c9qlX+XI9pojk5SA98I+glc/wkv5UuBmnuhZu+As7/V4aAUEi/ey9+jcQIi2nQMvC7wgD57+Td+eC+LaKx2XAmSGhmlkzNhe6/FMFN088+iR4CcgjJMd8oT7EWpMkNYfBY7xaTfz2kNaDwIZwOK6T+nHST0OORbh6+UpRro4DjBdhmoHkIi0BT9ZsECAwEAAaN8MHowDgYDVR0PAQH/BAQDAgG+MAkGA1UdEwQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMB8GA1UdIwQYMBaAFE22yDDlMQCKlmoxdR6YoT8a7/IJMB0GA1UdDgQWBBRNtsgw5TEAipZqMXUemKE/Gu/yCTANBgkqhkiG9w0BAQsFAAOCAQEABfoIeLbtCcnX2zQ69LcyGSu7ivsmzL16acSi6BIVj9jr9fRmvaRTCnZsMOSSUz/HBASyaUYll4Pz3xWgYvU1vvcQpeyeGyxgk16yIxBB78HznyJM76OSWRTFz1Bo3H2X0tOe1WntE80DookeHbXdt03tEgfTRjalS4x+ibJweA1j4Cah8irwtoowVSQJHEQ5n9BxxLtkBvZHRPF4CkY0VETXC+k2Ibh0/ANYyIX8MYgDq35DSetLKuhpDZsZu9bzi78PJEjIRAtCPo65MyLMvTEWDkWrDTm2GFfywIoavKCyvHFNv4FAyeo14P6SD30Abcc9RgsL0heK4ysj2QVW0Q==","attributes":{"enabled":true,"nbf":1687891793,"exp":1719514793,"created":1687892393,"updated":1687892393,"recoveryLevel":"CustomizedRecoverable+Purgeable","recoverableDays":7},"policy":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":true},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"CN=CLIGetDefaultPolicy","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["cRLSign","dataEncipherment","digitalSignature","keyAgreement","keyCertSign","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"days_before_expiry":90},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1687892390,"updated":1687892390}},"pending":{"id":"https://sfrp-cli-kv-000002.vault.azure.net/certificates/sfrp-cli-000005/pending"}}'
     headers:
       cache-control:
       - no-cache
@@ -8480,7 +8751,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:33 GMT
+      - Tue, 27 Jun 2023 19:00:01 GMT
       expires:
       - '-1'
       pragma:
@@ -8490,11 +8761,11 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-keyvault-network-info:
-      - conn_type=Ipv4;addr=13.90.45.74;act_addr_fam=InterNetwork;
+      - conn_type=Ipv4;addr=144.121.60.34;act_addr_fam=InterNetwork;
       x-ms-keyvault-region:
       - eastasia
       x-ms-keyvault-service-version:
-      - 1.9.787.1
+      - 1.9.865.1
     status:
       code: 200
       message: OK
@@ -8512,8 +8783,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -8523,7 +8794,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -8541,7 +8812,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:36 GMT
+      - Tue, 27 Jun 2023 19:00:05 GMT
       expires:
       - '-1'
       pragma:
@@ -8564,9 +8835,9 @@ interactions:
     body: '{"tags": {}, "properties": {"isPrimary": true, "vmInstanceCount": 5, "dataDiskSizeGB":
       100, "dataDiskType": "StandardSSD_LRS", "placementProperties": {}, "capacities":
       {}, "vmSize": "Standard_D2", "vmImagePublisher": "MicrosoftWindowsServer", "vmImageOffer":
-      "WindowsServer", "vmImageSku": "2019-Datacenter", "vmImageVersion": "latest",
+      "WindowsServer", "vmImageSku": "2022-Datacenter", "vmImageVersion": "latest",
       "vmSecrets": [{"sourceVault": {"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002"},
-      "vaultCertificates": [{"certificateUrl": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74",
+      "vaultCertificates": [{"certificateUrl": "https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df",
       "certificateStore": "my"}]}], "vmExtensions": [{"name": "csetest", "properties":
       {"publisher": "Microsoft.Compute", "type": "BGInfo", "typeHandlerVersion": "2.1",
       "autoUpgradeMinorVersion": true}}], "isStateless": false, "multiplePlacementGroups":
@@ -8587,8 +8858,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -8598,14 +8869,14 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Updating\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
         {},\r\n    \"vmSecrets\": [\r\n      {\r\n        \"sourceVault\": {\r\n          \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002\"\r\n
         \       },\r\n        \"vaultCertificates\": [\r\n          {\r\n            \"certificateUrl\":
-        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74\",\r\n
+        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df\",\r\n
         \           \"certificateStore\": \"my\"\r\n          }\r\n        ]\r\n      }\r\n
         \   ],\r\n    \"vmExtensions\": [\r\n      {\r\n        \"name\": \"csetest\",\r\n
         \       \"properties\": {\r\n          \"publisher\": \"Microsoft.Compute\",\r\n
@@ -8615,7 +8886,7 @@ interactions:
         \ }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -8623,11 +8894,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:38 GMT
+      - Tue, 27 Jun 2023 19:00:08 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -8656,14 +8927,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 5.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8673,7 +8944,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:13:39 GMT
+      - Tue, 27 Jun 2023 19:00:08 GMT
       expires:
       - '-1'
       pragma:
@@ -8706,14 +8977,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8723,7 +8994,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:14:09 GMT
+      - Tue, 27 Jun 2023 19:00:38 GMT
       expires:
       - '-1'
       pragma:
@@ -8756,14 +9027,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8773,7 +9044,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:14:39 GMT
+      - Tue, 27 Jun 2023 19:01:13 GMT
       expires:
       - '-1'
       pragma:
@@ -8806,14 +9077,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8823,7 +9094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:15:09 GMT
+      - Tue, 27 Jun 2023 19:04:27 GMT
       expires:
       - '-1'
       pragma:
@@ -8856,14 +9127,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8873,7 +9144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:15:40 GMT
+      - Tue, 27 Jun 2023 19:04:57 GMT
       expires:
       - '-1'
       pragma:
@@ -8906,14 +9177,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8923,7 +9194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:16:10 GMT
+      - Tue, 27 Jun 2023 19:05:27 GMT
       expires:
       - '-1'
       pragma:
@@ -8956,14 +9227,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8973,7 +9244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:16:40 GMT
+      - Tue, 27 Jun 2023 19:05:57 GMT
       expires:
       - '-1'
       pragma:
@@ -9006,14 +9277,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9023,7 +9294,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:17:10 GMT
+      - Tue, 27 Jun 2023 19:06:28 GMT
       expires:
       - '-1'
       pragma:
@@ -9056,14 +9327,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9073,7 +9344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:17:40 GMT
+      - Tue, 27 Jun 2023 19:06:58 GMT
       expires:
       - '-1'
       pragma:
@@ -9106,14 +9377,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9123,7 +9394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:18:11 GMT
+      - Tue, 27 Jun 2023 19:07:29 GMT
       expires:
       - '-1'
       pragma:
@@ -9156,14 +9427,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9173,7 +9444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:18:42 GMT
+      - Tue, 27 Jun 2023 19:07:59 GMT
       expires:
       - '-1'
       pragma:
@@ -9206,14 +9477,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9223,7 +9494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:19:13 GMT
+      - Tue, 27 Jun 2023 19:08:29 GMT
       expires:
       - '-1'
       pragma:
@@ -9256,14 +9527,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9273,7 +9544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:19:43 GMT
+      - Tue, 27 Jun 2023 19:08:59 GMT
       expires:
       - '-1'
       pragma:
@@ -9306,14 +9577,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9323,7 +9594,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:20:13 GMT
+      - Tue, 27 Jun 2023 19:09:30 GMT
       expires:
       - '-1'
       pragma:
@@ -9356,14 +9627,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9373,7 +9644,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:20:43 GMT
+      - Tue, 27 Jun 2023 19:09:59 GMT
       expires:
       - '-1'
       pragma:
@@ -9406,14 +9677,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9423,7 +9694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:21:13 GMT
+      - Tue, 27 Jun 2023 19:10:31 GMT
       expires:
       - '-1'
       pragma:
@@ -9456,14 +9727,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9473,7 +9744,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:21:44 GMT
+      - Tue, 27 Jun 2023 19:11:02 GMT
       expires:
       - '-1'
       pragma:
@@ -9506,14 +9777,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9523,7 +9794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:22:15 GMT
+      - Tue, 27 Jun 2023 19:11:32 GMT
       expires:
       - '-1'
       pragma:
@@ -9556,14 +9827,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9573,7 +9844,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:22:45 GMT
+      - Tue, 27 Jun 2023 19:12:02 GMT
       expires:
       - '-1'
       pragma:
@@ -9606,14 +9877,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9623,7 +9894,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:23:15 GMT
+      - Tue, 27 Jun 2023 19:12:33 GMT
       expires:
       - '-1'
       pragma:
@@ -9656,14 +9927,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9673,7 +9944,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:23:45 GMT
+      - Tue, 27 Jun 2023 19:13:04 GMT
       expires:
       - '-1'
       pragma:
@@ -9706,14 +9977,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9723,7 +9994,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:24:15 GMT
+      - Tue, 27 Jun 2023 19:13:34 GMT
       expires:
       - '-1'
       pragma:
@@ -9756,14 +10027,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9773,7 +10044,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:24:47 GMT
+      - Tue, 27 Jun 2023 19:14:04 GMT
       expires:
       - '-1'
       pragma:
@@ -9806,14 +10077,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9823,7 +10094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:25:17 GMT
+      - Tue, 27 Jun 2023 19:14:35 GMT
       expires:
       - '-1'
       pragma:
@@ -9856,14 +10127,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9873,7 +10144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:25:48 GMT
+      - Tue, 27 Jun 2023 19:15:05 GMT
       expires:
       - '-1'
       pragma:
@@ -9906,14 +10177,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9923,7 +10194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:26:18 GMT
+      - Tue, 27 Jun 2023 19:15:35 GMT
       expires:
       - '-1'
       pragma:
@@ -9956,14 +10227,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9973,7 +10244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:26:48 GMT
+      - Tue, 27 Jun 2023 19:16:05 GMT
       expires:
       - '-1'
       pragma:
@@ -10006,14 +10277,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10023,7 +10294,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:27:18 GMT
+      - Tue, 27 Jun 2023 19:16:35 GMT
       expires:
       - '-1'
       pragma:
@@ -10056,14 +10327,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10073,7 +10344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:27:48 GMT
+      - Tue, 27 Jun 2023 19:17:06 GMT
       expires:
       - '-1'
       pragma:
@@ -10106,14 +10377,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10123,7 +10394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:28:19 GMT
+      - Tue, 27 Jun 2023 19:17:36 GMT
       expires:
       - '-1'
       pragma:
@@ -10156,14 +10427,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10173,7 +10444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:28:49 GMT
+      - Tue, 27 Jun 2023 19:18:07 GMT
       expires:
       - '-1'
       pragma:
@@ -10206,14 +10477,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10223,7 +10494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:29:19 GMT
+      - Tue, 27 Jun 2023 19:18:38 GMT
       expires:
       - '-1'
       pragma:
@@ -10256,14 +10527,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10273,7 +10544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:29:49 GMT
+      - Tue, 27 Jun 2023 19:19:08 GMT
       expires:
       - '-1'
       pragma:
@@ -10306,14 +10577,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10323,7 +10594,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:30:22 GMT
+      - Tue, 27 Jun 2023 19:19:38 GMT
       expires:
       - '-1'
       pragma:
@@ -10356,14 +10627,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10373,7 +10644,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:30:52 GMT
+      - Tue, 27 Jun 2023 19:20:09 GMT
       expires:
       - '-1'
       pragma:
@@ -10406,14 +10677,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10423,7 +10694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:31:22 GMT
+      - Tue, 27 Jun 2023 19:20:39 GMT
       expires:
       - '-1'
       pragma:
@@ -10456,14 +10727,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10473,7 +10744,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:31:52 GMT
+      - Tue, 27 Jun 2023 19:21:09 GMT
       expires:
       - '-1'
       pragma:
@@ -10506,14 +10777,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10523,7 +10794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:32:22 GMT
+      - Tue, 27 Jun 2023 19:21:40 GMT
       expires:
       - '-1'
       pragma:
@@ -10556,14 +10827,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10573,7 +10844,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:32:53 GMT
+      - Tue, 27 Jun 2023 19:22:10 GMT
       expires:
       - '-1'
       pragma:
@@ -10606,14 +10877,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10623,7 +10894,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:33:23 GMT
+      - Tue, 27 Jun 2023 19:22:40 GMT
       expires:
       - '-1'
       pragma:
@@ -10656,14 +10927,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10673,7 +10944,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:33:53 GMT
+      - Tue, 27 Jun 2023 19:23:10 GMT
       expires:
       - '-1'
       pragma:
@@ -10706,14 +10977,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10723,7 +10994,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:34:23 GMT
+      - Tue, 27 Jun 2023 19:23:41 GMT
       expires:
       - '-1'
       pragma:
@@ -10756,14 +11027,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10773,7 +11044,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:34:53 GMT
+      - Tue, 27 Jun 2023 19:24:12 GMT
       expires:
       - '-1'
       pragma:
@@ -10806,14 +11077,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10823,7 +11094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:35:23 GMT
+      - Tue, 27 Jun 2023 19:24:41 GMT
       expires:
       - '-1'
       pragma:
@@ -10856,14 +11127,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10873,7 +11144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:35:55 GMT
+      - Tue, 27 Jun 2023 19:25:12 GMT
       expires:
       - '-1'
       pragma:
@@ -10906,14 +11177,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10923,7 +11194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:36:25 GMT
+      - Tue, 27 Jun 2023 19:25:43 GMT
       expires:
       - '-1'
       pragma:
@@ -10956,14 +11227,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -10973,7 +11244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:36:55 GMT
+      - Tue, 27 Jun 2023 19:31:24 GMT
       expires:
       - '-1'
       pragma:
@@ -11006,14 +11277,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11023,7 +11294,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:37:25 GMT
+      - Tue, 27 Jun 2023 19:31:55 GMT
       expires:
       - '-1'
       pragma:
@@ -11056,14 +11327,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11073,7 +11344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:37:57 GMT
+      - Tue, 27 Jun 2023 19:32:25 GMT
       expires:
       - '-1'
       pragma:
@@ -11106,14 +11377,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11123,7 +11394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:38:27 GMT
+      - Tue, 27 Jun 2023 19:32:55 GMT
       expires:
       - '-1'
       pragma:
@@ -11156,14 +11427,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11173,7 +11444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:38:57 GMT
+      - Tue, 27 Jun 2023 19:33:25 GMT
       expires:
       - '-1'
       pragma:
@@ -11206,14 +11477,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11223,7 +11494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:39:27 GMT
+      - Tue, 27 Jun 2023 19:33:55 GMT
       expires:
       - '-1'
       pragma:
@@ -11256,14 +11527,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11273,7 +11544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:39:57 GMT
+      - Tue, 27 Jun 2023 19:34:26 GMT
       expires:
       - '-1'
       pragma:
@@ -11306,14 +11577,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11323,7 +11594,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:40:27 GMT
+      - Tue, 27 Jun 2023 19:34:56 GMT
       expires:
       - '-1'
       pragma:
@@ -11356,14 +11627,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11373,7 +11644,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:40:57 GMT
+      - Tue, 27 Jun 2023 19:35:26 GMT
       expires:
       - '-1'
       pragma:
@@ -11406,14 +11677,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11423,7 +11694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:41:30 GMT
+      - Tue, 27 Jun 2023 19:35:57 GMT
       expires:
       - '-1'
       pragma:
@@ -11456,14 +11727,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11473,7 +11744,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:42:00 GMT
+      - Tue, 27 Jun 2023 19:36:28 GMT
       expires:
       - '-1'
       pragma:
@@ -11506,14 +11777,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11523,7 +11794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:42:30 GMT
+      - Tue, 27 Jun 2023 19:36:57 GMT
       expires:
       - '-1'
       pragma:
@@ -11556,14 +11827,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11573,7 +11844,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:43:00 GMT
+      - Tue, 27 Jun 2023 19:37:28 GMT
       expires:
       - '-1'
       pragma:
@@ -11606,14 +11877,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11623,7 +11894,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:43:30 GMT
+      - Tue, 27 Jun 2023 19:37:59 GMT
       expires:
       - '-1'
       pragma:
@@ -11656,14 +11927,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11673,7 +11944,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:44:01 GMT
+      - Tue, 27 Jun 2023 19:38:29 GMT
       expires:
       - '-1'
       pragma:
@@ -11706,14 +11977,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11723,7 +11994,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:44:31 GMT
+      - Tue, 27 Jun 2023 19:39:00 GMT
       expires:
       - '-1'
       pragma:
@@ -11756,14 +12027,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11773,7 +12044,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:45:01 GMT
+      - Tue, 27 Jun 2023 19:39:30 GMT
       expires:
       - '-1'
       pragma:
@@ -11806,14 +12077,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11823,7 +12094,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:45:32 GMT
+      - Tue, 27 Jun 2023 19:40:00 GMT
       expires:
       - '-1'
       pragma:
@@ -11856,14 +12127,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11873,7 +12144,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:46:02 GMT
+      - Tue, 27 Jun 2023 19:40:31 GMT
       expires:
       - '-1'
       pragma:
@@ -11906,14 +12177,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11923,7 +12194,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:46:32 GMT
+      - Tue, 27 Jun 2023 19:41:01 GMT
       expires:
       - '-1'
       pragma:
@@ -11956,14 +12227,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -11973,7 +12244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:47:03 GMT
+      - Tue, 27 Jun 2023 19:41:31 GMT
       expires:
       - '-1'
       pragma:
@@ -12006,14 +12277,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12023,7 +12294,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:47:34 GMT
+      - Tue, 27 Jun 2023 19:42:02 GMT
       expires:
       - '-1'
       pragma:
@@ -12056,14 +12327,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12073,7 +12344,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:48:04 GMT
+      - Tue, 27 Jun 2023 19:42:33 GMT
       expires:
       - '-1'
       pragma:
@@ -12106,14 +12377,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12123,7 +12394,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:48:34 GMT
+      - Tue, 27 Jun 2023 19:43:04 GMT
       expires:
       - '-1'
       pragma:
@@ -12156,14 +12427,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12173,7 +12444,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:49:04 GMT
+      - Tue, 27 Jun 2023 19:43:34 GMT
       expires:
       - '-1'
       pragma:
@@ -12206,14 +12477,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12223,7 +12494,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:49:34 GMT
+      - Tue, 27 Jun 2023 19:44:05 GMT
       expires:
       - '-1'
       pragma:
@@ -12256,14 +12527,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12273,7 +12544,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:50:05 GMT
+      - Tue, 27 Jun 2023 19:44:35 GMT
       expires:
       - '-1'
       pragma:
@@ -12306,14 +12577,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12323,7 +12594,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:50:35 GMT
+      - Tue, 27 Jun 2023 19:45:06 GMT
       expires:
       - '-1'
       pragma:
@@ -12356,14 +12627,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12373,7 +12644,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:51:05 GMT
+      - Tue, 27 Jun 2023 19:45:36 GMT
       expires:
       - '-1'
       pragma:
@@ -12406,14 +12677,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12423,7 +12694,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:51:36 GMT
+      - Tue, 27 Jun 2023 19:46:06 GMT
       expires:
       - '-1'
       pragma:
@@ -12456,14 +12727,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12473,7 +12744,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:52:06 GMT
+      - Tue, 27 Jun 2023 19:46:37 GMT
       expires:
       - '-1'
       pragma:
@@ -12506,14 +12777,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12523,7 +12794,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:52:38 GMT
+      - Tue, 27 Jun 2023 19:47:06 GMT
       expires:
       - '-1'
       pragma:
@@ -12556,14 +12827,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12573,7 +12844,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:53:08 GMT
+      - Tue, 27 Jun 2023 19:47:37 GMT
       expires:
       - '-1'
       pragma:
@@ -12606,14 +12877,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -12623,7 +12894,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 14:53:38 GMT
+      - Tue, 27 Jun 2023 19:48:08 GMT
       expires:
       - '-1'
       pragma:
@@ -12656,764 +12927,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:54:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:54:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:55:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:55:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:56:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:56:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:57:10 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:57:40 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:58:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:58:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:59:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 14:59:42 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 15:00:12 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 15:00:43 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Mon, 15 May 2023 15:01:14 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type vm-secret add
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --source-vault-id --certificate-url --certificate-store
-      User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"156f0005-9d4d-47ec-b1e3-82b33804ea23\",\r\n  \"startTime\":
-        \"2023-05-15T14:13:38.8282658Z\",\r\n  \"endTime\": \"2023-05-15T15:01:39.2135133Z\",\r\n
+      string: "{\r\n  \"name\": \"eadc0001-d79a-4d51-a97b-7140bce1199d\",\r\n  \"startTime\":
+        \"2023-06-27T19:00:08.4509657Z\",\r\n  \"endTime\": \"2023-06-27T19:48:09.1912284Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -13423,7 +12944,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:44 GMT
+      - Tue, 27 Jun 2023 19:48:38 GMT
       expires:
       - '-1'
       pragma:
@@ -13456,10 +12977,10 @@ interactions:
       ParameterSetName:
       - -g -c -n --source-vault-id --certificate-url --certificate-store
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/156f0005-9d4d-47ec-b1e3-82b33804ea23?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/eadc0001-d79a-4d51-a97b-7140bce1199d?api-version=2021-05-01
   response:
     body:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodetypes/pnt\",\r\n
@@ -13467,14 +12988,14 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
         {},\r\n    \"vmSecrets\": [\r\n      {\r\n        \"sourceVault\": {\r\n          \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002\"\r\n
         \       },\r\n        \"vaultCertificates\": [\r\n          {\r\n            \"certificateUrl\":
-        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74\",\r\n
+        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df\",\r\n
         \           \"certificateStore\": \"my\"\r\n          }\r\n        ]\r\n      }\r\n
         \   ],\r\n    \"vmExtensions\": [\r\n      {\r\n        \"name\": \"csetest\",\r\n
         \       \"properties\": {\r\n          \"publisher\": \"Microsoft.Compute\",\r\n
@@ -13490,7 +13011,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:44 GMT
+      - Tue, 27 Jun 2023 19:48:38 GMT
       expires:
       - '-1'
       pragma:
@@ -13523,8 +13044,8 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -13534,14 +13055,14 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
         {},\r\n    \"vmSecrets\": [\r\n      {\r\n        \"sourceVault\": {\r\n          \"id\":
         \"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.KeyVault/vaults/sfrp-cli-kv-000002\"\r\n
         \       },\r\n        \"vaultCertificates\": [\r\n          {\r\n            \"certificateUrl\":
-        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/047848176b7f4911ae1e927a058bbb74\",\r\n
+        \"https://sfrp-cli-kv-000002.vault.azure.net/secrets/sfrp-cli-000005/e3194714d0bd4264ba0518a6908394df\",\r\n
         \           \"certificateStore\": \"my\"\r\n          }\r\n        ]\r\n      }\r\n
         \   ],\r\n    \"vmExtensions\": [\r\n      {\r\n        \"name\": \"csetest\",\r\n
         \       \"properties\": {\r\n          \"publisher\": \"Microsoft.Compute\",\r\n
@@ -13557,7 +13078,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:45 GMT
+      - Tue, 27 Jun 2023 19:48:40 GMT
       expires:
       - '-1'
       pragma:
@@ -13590,8 +13111,8 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -13599,18 +13120,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T13:05:15.0413341+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T17:49:03.0048646+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -13620,11 +13141,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1563'
+      - '1523'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:47 GMT
+      - Tue, 27 Jun 2023 19:48:43 GMT
       expires:
       - '-1'
       pragma:
@@ -13649,7 +13170,7 @@ interactions:
       19080, "adminUserName": "vmadmin", "allowRdpAccess": false, "clients": [{"isAdmin":
       true, "thumbprint": "123BDACDCDFB2C7B250192C6078E47D1E1DB119B"}, {"isAdmin":
       false, "thumbprint": "123BDACDCDFB2C7B250192C6078E47D1E1DB7777"}], "clusterCodeVersion":
-      "9.1.1653.9590", "clusterUpgradeMode": "Automatic", "clusterUpgradeCadence":
+      "9.1.1833.9590", "clusterUpgradeMode": "Automatic", "clusterUpgradeCadence":
       "Wave0", "enableAutoOSUpgrade": false, "zonalResiliency": false}}'
     headers:
       Accept:
@@ -13667,8 +13188,8 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -13676,18 +13197,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:01:48.1276226+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T19:48:44.6977358+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      },\r\n
@@ -13696,19 +13217,19 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1674'
+      - '1634'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:47 GMT
+      - Tue, 27 Jun 2023 19:48:44 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -13736,14 +13257,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -13753,7 +13274,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:01:48 GMT
+      - Tue, 27 Jun 2023 19:48:45 GMT
       expires:
       - '-1'
       pragma:
@@ -13786,14 +13307,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -13803,7 +13324,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:02:19 GMT
+      - Tue, 27 Jun 2023 19:49:15 GMT
       expires:
       - '-1'
       pragma:
@@ -13836,14 +13357,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -13853,7 +13374,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:02:49 GMT
+      - Tue, 27 Jun 2023 19:49:45 GMT
       expires:
       - '-1'
       pragma:
@@ -13886,14 +13407,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -13903,7 +13424,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:03:19 GMT
+      - Tue, 27 Jun 2023 19:50:16 GMT
       expires:
       - '-1'
       pragma:
@@ -13936,14 +13457,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -13953,7 +13474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:03:49 GMT
+      - Tue, 27 Jun 2023 19:50:45 GMT
       expires:
       - '-1'
       pragma:
@@ -13986,14 +13507,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14003,7 +13524,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:04:20 GMT
+      - Tue, 27 Jun 2023 19:51:15 GMT
       expires:
       - '-1'
       pragma:
@@ -14036,14 +13557,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14053,7 +13574,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:04:50 GMT
+      - Tue, 27 Jun 2023 19:51:46 GMT
       expires:
       - '-1'
       pragma:
@@ -14086,14 +13607,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14103,7 +13624,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:05:20 GMT
+      - Tue, 27 Jun 2023 19:52:16 GMT
       expires:
       - '-1'
       pragma:
@@ -14136,14 +13657,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14153,7 +13674,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:05:50 GMT
+      - Tue, 27 Jun 2023 19:52:46 GMT
       expires:
       - '-1'
       pragma:
@@ -14186,14 +13707,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14203,7 +13724,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:06:21 GMT
+      - Tue, 27 Jun 2023 19:53:17 GMT
       expires:
       - '-1'
       pragma:
@@ -14236,14 +13757,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14253,7 +13774,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:06:51 GMT
+      - Tue, 27 Jun 2023 19:53:48 GMT
       expires:
       - '-1'
       pragma:
@@ -14286,14 +13807,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14303,7 +13824,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:07:21 GMT
+      - Tue, 27 Jun 2023 19:54:18 GMT
       expires:
       - '-1'
       pragma:
@@ -14336,14 +13857,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14353,7 +13874,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:07:51 GMT
+      - Tue, 27 Jun 2023 19:54:49 GMT
       expires:
       - '-1'
       pragma:
@@ -14386,14 +13907,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14403,7 +13924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:08:23 GMT
+      - Tue, 27 Jun 2023 19:55:19 GMT
       expires:
       - '-1'
       pragma:
@@ -14436,14 +13957,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14453,7 +13974,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:08:53 GMT
+      - Tue, 27 Jun 2023 19:55:50 GMT
       expires:
       - '-1'
       pragma:
@@ -14486,14 +14007,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14503,7 +14024,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:09:23 GMT
+      - Tue, 27 Jun 2023 19:56:20 GMT
       expires:
       - '-1'
       pragma:
@@ -14536,14 +14057,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14553,7 +14074,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:09:54 GMT
+      - Tue, 27 Jun 2023 19:56:50 GMT
       expires:
       - '-1'
       pragma:
@@ -14586,14 +14107,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14603,7 +14124,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:10:24 GMT
+      - Tue, 27 Jun 2023 19:57:21 GMT
       expires:
       - '-1'
       pragma:
@@ -14636,14 +14157,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14653,7 +14174,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:10:55 GMT
+      - Tue, 27 Jun 2023 19:57:51 GMT
       expires:
       - '-1'
       pragma:
@@ -14686,14 +14207,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14703,7 +14224,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:11:25 GMT
+      - Tue, 27 Jun 2023 19:58:21 GMT
       expires:
       - '-1'
       pragma:
@@ -14736,14 +14257,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14753,7 +14274,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:11:55 GMT
+      - Tue, 27 Jun 2023 19:58:53 GMT
       expires:
       - '-1'
       pragma:
@@ -14786,14 +14307,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14803,7 +14324,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:12:25 GMT
+      - Tue, 27 Jun 2023 19:59:23 GMT
       expires:
       - '-1'
       pragma:
@@ -14836,14 +14357,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14853,7 +14374,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:12:56 GMT
+      - Tue, 27 Jun 2023 19:59:54 GMT
       expires:
       - '-1'
       pragma:
@@ -14886,14 +14407,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14903,7 +14424,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:13:26 GMT
+      - Tue, 27 Jun 2023 20:00:24 GMT
       expires:
       - '-1'
       pragma:
@@ -14936,14 +14457,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -14953,7 +14474,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:13:56 GMT
+      - Tue, 27 Jun 2023 20:00:54 GMT
       expires:
       - '-1'
       pragma:
@@ -14986,14 +14507,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15003,7 +14524,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:14:26 GMT
+      - Tue, 27 Jun 2023 20:01:25 GMT
       expires:
       - '-1'
       pragma:
@@ -15036,14 +14557,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15053,7 +14574,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:14:58 GMT
+      - Tue, 27 Jun 2023 20:01:55 GMT
       expires:
       - '-1'
       pragma:
@@ -15086,14 +14607,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15103,7 +14624,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:15:28 GMT
+      - Tue, 27 Jun 2023 20:02:25 GMT
       expires:
       - '-1'
       pragma:
@@ -15136,14 +14657,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15153,7 +14674,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:15:58 GMT
+      - Tue, 27 Jun 2023 20:02:55 GMT
       expires:
       - '-1'
       pragma:
@@ -15186,14 +14707,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15203,7 +14724,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:16:29 GMT
+      - Tue, 27 Jun 2023 20:03:25 GMT
       expires:
       - '-1'
       pragma:
@@ -15236,14 +14757,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15253,7 +14774,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:16:59 GMT
+      - Tue, 27 Jun 2023 20:03:56 GMT
       expires:
       - '-1'
       pragma:
@@ -15286,14 +14807,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15303,7 +14824,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:17:29 GMT
+      - Tue, 27 Jun 2023 20:04:27 GMT
       expires:
       - '-1'
       pragma:
@@ -15336,14 +14857,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15353,7 +14874,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:18:00 GMT
+      - Tue, 27 Jun 2023 20:04:57 GMT
       expires:
       - '-1'
       pragma:
@@ -15386,14 +14907,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15403,7 +14924,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:18:30 GMT
+      - Tue, 27 Jun 2023 20:05:27 GMT
       expires:
       - '-1'
       pragma:
@@ -15436,14 +14957,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15453,7 +14974,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:00 GMT
+      - Tue, 27 Jun 2023 20:05:58 GMT
       expires:
       - '-1'
       pragma:
@@ -15486,24 +15007,24 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d2f20005-69ee-407d-bdde-6c1ec7e3fb79\",\r\n  \"startTime\":
-        \"2023-05-15T15:01:48.3699505Z\",\r\n  \"endTime\": \"2023-05-15T15:19:13.276542Z\",\r\n
+      string: "{\r\n  \"name\": \"bb000001-b05f-4592-ac15-b9c380780728\",\r\n  \"startTime\":
+        \"2023-06-27T19:48:44.8334651Z\",\r\n  \"endTime\": \"2023-06-27T20:06:08.3945176Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '202'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:30 GMT
+      - Tue, 27 Jun 2023 20:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -15536,27 +15057,27 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d2f20005-69ee-407d-bdde-6c1ec7e3fb79?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/bb000001-b05f-4592-ac15-b9c380780728?api-version=2021-05-01
   response:
     body:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:01:48.1276226+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T19:48:44.6977358+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      },\r\n
@@ -15567,11 +15088,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1675'
+      - '1635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:30 GMT
+      - Tue, 27 Jun 2023 20:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -15604,8 +15125,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -15613,18 +15134,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:01:48.1276226+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T19:48:44.6977358+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      },\r\n
@@ -15635,11 +15156,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1675'
+      - '1635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:34 GMT
+      - Tue, 27 Jun 2023 20:06:31 GMT
       expires:
       - '-1'
       pragma:
@@ -15672,8 +15193,8 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -15681,18 +15202,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:01:48.1276226+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T19:48:44.6977358+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      },\r\n
@@ -15703,11 +15224,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1675'
+      - '1635'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:35 GMT
+      - Tue, 27 Jun 2023 20:06:32 GMT
       expires:
       - '-1'
       pragma:
@@ -15731,7 +15252,7 @@ interactions:
       {"dnsName": "sfrp-cli-000003", "clientConnectionPort": 19000, "httpGatewayConnectionPort":
       19080, "adminUserName": "vmadmin", "allowRdpAccess": false, "clients": [{"isAdmin":
       true, "thumbprint": "123BDACDCDFB2C7B250192C6078E47D1E1DB119B"}], "clusterCodeVersion":
-      "9.1.1653.9590", "clusterUpgradeMode": "Automatic", "clusterUpgradeCadence":
+      "9.1.1833.9590", "clusterUpgradeMode": "Automatic", "clusterUpgradeCadence":
       "Wave0", "enableAutoOSUpgrade": false, "zonalResiliency": false}}'
     headers:
       Accept:
@@ -15749,8 +15270,8 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -15758,18 +15279,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:19:36.2912729+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T20:06:33.6541754+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Updating\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -15777,19 +15298,19 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1562'
+      - '1522'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:35 GMT
+      - Tue, 27 Jun 2023 20:06:33 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -15817,14 +15338,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15834,7 +15355,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:19:36 GMT
+      - Tue, 27 Jun 2023 20:06:33 GMT
       expires:
       - '-1'
       pragma:
@@ -15867,14 +15388,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15884,7 +15405,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:20:07 GMT
+      - Tue, 27 Jun 2023 20:07:04 GMT
       expires:
       - '-1'
       pragma:
@@ -15917,14 +15438,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15934,7 +15455,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:20:37 GMT
+      - Tue, 27 Jun 2023 20:07:34 GMT
       expires:
       - '-1'
       pragma:
@@ -15967,14 +15488,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -15984,7 +15505,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:21:07 GMT
+      - Tue, 27 Jun 2023 20:08:04 GMT
       expires:
       - '-1'
       pragma:
@@ -16017,14 +15538,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16034,7 +15555,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:21:37 GMT
+      - Tue, 27 Jun 2023 20:08:35 GMT
       expires:
       - '-1'
       pragma:
@@ -16067,14 +15588,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16084,7 +15605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:22:07 GMT
+      - Tue, 27 Jun 2023 20:09:05 GMT
       expires:
       - '-1'
       pragma:
@@ -16117,14 +15638,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16134,7 +15655,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:22:37 GMT
+      - Tue, 27 Jun 2023 20:09:35 GMT
       expires:
       - '-1'
       pragma:
@@ -16167,14 +15688,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16184,7 +15705,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:23:08 GMT
+      - Tue, 27 Jun 2023 20:10:06 GMT
       expires:
       - '-1'
       pragma:
@@ -16217,14 +15738,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16234,7 +15755,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:23:39 GMT
+      - Tue, 27 Jun 2023 20:10:36 GMT
       expires:
       - '-1'
       pragma:
@@ -16267,14 +15788,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16284,7 +15805,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:24:09 GMT
+      - Tue, 27 Jun 2023 20:11:07 GMT
       expires:
       - '-1'
       pragma:
@@ -16317,14 +15838,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16334,7 +15855,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:24:40 GMT
+      - Tue, 27 Jun 2023 20:11:37 GMT
       expires:
       - '-1'
       pragma:
@@ -16367,14 +15888,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16384,7 +15905,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:25:10 GMT
+      - Tue, 27 Jun 2023 20:12:08 GMT
       expires:
       - '-1'
       pragma:
@@ -16417,14 +15938,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16434,7 +15955,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:25:40 GMT
+      - Tue, 27 Jun 2023 20:12:39 GMT
       expires:
       - '-1'
       pragma:
@@ -16467,14 +15988,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16484,7 +16005,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:26:11 GMT
+      - Tue, 27 Jun 2023 20:13:10 GMT
       expires:
       - '-1'
       pragma:
@@ -16517,14 +16038,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16534,7 +16055,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:26:41 GMT
+      - Tue, 27 Jun 2023 20:13:40 GMT
       expires:
       - '-1'
       pragma:
@@ -16567,14 +16088,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16584,7 +16105,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:27:11 GMT
+      - Tue, 27 Jun 2023 20:14:10 GMT
       expires:
       - '-1'
       pragma:
@@ -16617,14 +16138,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16634,7 +16155,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:27:42 GMT
+      - Tue, 27 Jun 2023 20:14:40 GMT
       expires:
       - '-1'
       pragma:
@@ -16667,14 +16188,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16684,7 +16205,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:28:12 GMT
+      - Tue, 27 Jun 2023 20:15:11 GMT
       expires:
       - '-1'
       pragma:
@@ -16717,14 +16238,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16734,7 +16255,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:28:42 GMT
+      - Tue, 27 Jun 2023 20:15:42 GMT
       expires:
       - '-1'
       pragma:
@@ -16767,14 +16288,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16784,7 +16305,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:29:12 GMT
+      - Tue, 27 Jun 2023 20:16:13 GMT
       expires:
       - '-1'
       pragma:
@@ -16817,14 +16338,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16834,7 +16355,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:29:43 GMT
+      - Tue, 27 Jun 2023 20:16:43 GMT
       expires:
       - '-1'
       pragma:
@@ -16867,14 +16388,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16884,7 +16405,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:30:14 GMT
+      - Tue, 27 Jun 2023 20:17:14 GMT
       expires:
       - '-1'
       pragma:
@@ -16917,14 +16438,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16934,7 +16455,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:30:44 GMT
+      - Tue, 27 Jun 2023 20:17:43 GMT
       expires:
       - '-1'
       pragma:
@@ -16967,14 +16488,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -16984,7 +16505,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:31:14 GMT
+      - Tue, 27 Jun 2023 20:18:14 GMT
       expires:
       - '-1'
       pragma:
@@ -17017,14 +16538,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17034,7 +16555,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:31:44 GMT
+      - Tue, 27 Jun 2023 20:18:44 GMT
       expires:
       - '-1'
       pragma:
@@ -17067,14 +16588,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17084,7 +16605,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:32:15 GMT
+      - Tue, 27 Jun 2023 20:19:14 GMT
       expires:
       - '-1'
       pragma:
@@ -17117,14 +16638,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17134,7 +16655,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:32:45 GMT
+      - Tue, 27 Jun 2023 20:19:44 GMT
       expires:
       - '-1'
       pragma:
@@ -17167,14 +16688,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17184,7 +16705,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:33:15 GMT
+      - Tue, 27 Jun 2023 20:20:15 GMT
       expires:
       - '-1'
       pragma:
@@ -17217,14 +16738,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17234,7 +16755,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:33:46 GMT
+      - Tue, 27 Jun 2023 20:20:46 GMT
       expires:
       - '-1'
       pragma:
@@ -17267,14 +16788,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17284,7 +16805,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:34:17 GMT
+      - Tue, 27 Jun 2023 20:21:17 GMT
       expires:
       - '-1'
       pragma:
@@ -17317,14 +16838,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17334,7 +16855,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:34:48 GMT
+      - Tue, 27 Jun 2023 20:21:47 GMT
       expires:
       - '-1'
       pragma:
@@ -17367,14 +16888,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17384,7 +16905,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:35:18 GMT
+      - Tue, 27 Jun 2023 20:22:17 GMT
       expires:
       - '-1'
       pragma:
@@ -17417,14 +16938,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17434,7 +16955,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:35:48 GMT
+      - Tue, 27 Jun 2023 20:22:48 GMT
       expires:
       - '-1'
       pragma:
@@ -17467,14 +16988,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17484,7 +17005,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:36:19 GMT
+      - Tue, 27 Jun 2023 20:23:18 GMT
       expires:
       - '-1'
       pragma:
@@ -17517,14 +17038,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -17534,7 +17055,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:36:49 GMT
+      - Tue, 27 Jun 2023 20:23:49 GMT
       expires:
       - '-1'
       pragma:
@@ -17567,14 +17088,14 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"c5860005-9f4a-4185-b0f8-5ab31bb1ceb3\",\r\n  \"startTime\":
-        \"2023-05-15T15:19:36.4331646Z\",\r\n  \"endTime\": \"2023-05-15T15:36:59.9648568Z\",\r\n
+      string: "{\r\n  \"name\": \"a2910001-81e6-4078-8d94-ec0f720fd980\",\r\n  \"startTime\":
+        \"2023-06-27T20:06:33.8017251Z\",\r\n  \"endTime\": \"2023-06-27T20:23:57.9438427Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -17584,7 +17105,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:19 GMT
+      - Tue, 27 Jun 2023 20:24:19 GMT
       expires:
       - '-1'
       pragma:
@@ -17617,27 +17138,27 @@ interactions:
       ParameterSetName:
       - -g -c --thumbprint
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/c5860005-9f4a-4185-b0f8-5ab31bb1ceb3?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/a2910001-81e6-4078-8d94-ec0f720fd980?api-version=2021-05-01
   response:
     body:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:19:36.2912729+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T20:06:33.6541754+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -17647,11 +17168,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1563'
+      - '1523'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:19 GMT
+      - Tue, 27 Jun 2023 20:24:19 GMT
       expires:
       - '-1'
       pragma:
@@ -17684,8 +17205,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -17693,18 +17214,18 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:19:36.2912729+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T20:06:33.6541754+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterState\": \"Ready\",\r\n    \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave0\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n    \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -17714,11 +17235,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1563'
+      - '1523'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:21 GMT
+      - Tue, 27 Jun 2023 20:24:21 GMT
       expires:
       - '-1'
       pragma:
@@ -17753,8 +17274,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -17762,17 +17283,17 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000003\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-05-15T13:05:15.0413341+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-05-15T15:19:36.2912729+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-27T17:49:03.0048646+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-27T20:06:33.6541754+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Basic\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"59270b5d-26ea-4ae1-906b-3a765d4571fa\",\r\n
-        \   \"clusterCodeVersion\": \"9.1.1653.9590\",\r\n    \"clusterUpgradeMode\":
+        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"3242f997-71ca-4e18-b2c2-b32e7fee39e4\",\r\n
+        \   \"clusterCodeVersion\": \"9.1.1833.9590\",\r\n    \"clusterUpgradeMode\":
         \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\": false,\r\n    \"clusterUpgradeCadence\":
         \"Wave0\",\r\n    \"adminUserName\": \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000003\",\r\n
         \   \"fqdn\": \"sfrp-cli-000003.eastasia.cloudapp.azure.com\",\r\n    \"ipv4Address\":
-        \"20.205.114.186\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"0CF74487F9064F79656CA23250BF02AAA05CF3F7\"\r\n
+        \"20.24.97.107\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"ABFFE157C4C968FB8C74380FD1DBEAC675AFA68F\"\r\n
         \   ],\r\n    \"clientConnectionPort\": 19000,\r\n    \"httpGatewayConnectionPort\":
         19080,\r\n    \"allowRdpAccess\": false,\r\n    \"clients\": [\r\n      {\r\n
         \       \"isAdmin\": true,\r\n        \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n
@@ -17780,19 +17301,19 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1532'
+      - '1492'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:23 GMT
+      - Tue, 27 Jun 2023 20:24:25 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -17820,24 +17341,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:23 GMT
+      - Tue, 27 Jun 2023 20:24:25 GMT
       expires:
       - '-1'
       pragma:
@@ -17870,24 +17391,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:37:53 GMT
+      - Tue, 27 Jun 2023 20:24:55 GMT
       expires:
       - '-1'
       pragma:
@@ -17920,24 +17441,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:38:23 GMT
+      - Tue, 27 Jun 2023 20:25:25 GMT
       expires:
       - '-1'
       pragma:
@@ -17970,24 +17491,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:38:54 GMT
+      - Tue, 27 Jun 2023 20:25:56 GMT
       expires:
       - '-1'
       pragma:
@@ -18020,24 +17541,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:39:24 GMT
+      - Tue, 27 Jun 2023 20:26:26 GMT
       expires:
       - '-1'
       pragma:
@@ -18070,24 +17591,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:39:55 GMT
+      - Tue, 27 Jun 2023 20:26:57 GMT
       expires:
       - '-1'
       pragma:
@@ -18120,24 +17641,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:40:25 GMT
+      - Tue, 27 Jun 2023 20:27:27 GMT
       expires:
       - '-1'
       pragma:
@@ -18170,24 +17691,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:40:55 GMT
+      - Tue, 27 Jun 2023 20:27:58 GMT
       expires:
       - '-1'
       pragma:
@@ -18220,24 +17741,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '190'
+      - '191'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:41:25 GMT
+      - Tue, 27 Jun 2023 20:28:27 GMT
       expires:
       - '-1'
       pragma:
@@ -18270,24 +17791,24 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"97420005-509b-424a-be98-512fb5a27815\",\r\n  \"startTime\":
-        \"2023-05-15T15:37:23.637072Z\",\r\n  \"endTime\": \"2023-05-15T15:41:41.6098119Z\",\r\n
+      string: "{\r\n  \"name\": \"358a0001-80e9-4fe2-8b17-3fb98b75ba91\",\r\n  \"startTime\":
+        \"2023-06-27T20:24:25.4006816Z\",\r\n  \"endTime\": \"2023-06-27T20:28:42.8233381Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '202'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:41:56 GMT
+      - Tue, 27 Jun 2023 20:28:58 GMT
       expires:
       - '-1'
       pragma:
@@ -18320,10 +17841,10 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/97420005-509b-424a-be98-512fb5a27815?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/358a0001-80e9-4fe2-8b17-3fb98b75ba91?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -18331,7 +17852,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Mon, 15 May 2023 15:41:56 GMT
+      - Tue, 27 Jun 2023 20:29:00 GMT
       expires:
       - '-1'
       pragma:
@@ -18360,8 +17881,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.48.1 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.11
-        (Linux-5.15.0-1036-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000003?api-version=2021-05-01
   response:
@@ -18377,7 +17898,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Mon, 15 May 2023 15:41:56 GMT
+      - Tue, 27 Jun 2023 20:28:59 GMT
       expires:
       - '-1'
       pragma:

--- a/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_node_type_operation.yaml
+++ b/src/azure-cli/azure/cli/command_modules/servicefabric/tests/latest/recordings/test_node_type_operation.yaml
@@ -14,106 +14,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
+      - Mon, 26 Jun 2023 23:50:31 GMT
       expires:
       - '-1'
       pragma:
@@ -142,22 +57,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
+      - Mon, 26 Jun 2023 23:50:31 GMT
       expires:
       - '-1'
       pragma:
@@ -186,22 +100,23 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
+      connection:
+      - close
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -230,64 +145,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -316,148 +188,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:07 GMT
+      - Mon, 26 Jun 2023 23:50:32 GMT
       expires:
       - '-1'
       pragma:
@@ -486,64 +231,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-cluster create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
-        --upgrade-cadence
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
-  response:
-    body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '310'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 22:49:08 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -572,22 +274,21 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:08 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
       expires:
       - '-1'
       pragma:
@@ -616,22 +317,322 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.10.9 (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31)
-        VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
   response:
     body:
-      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","date":"2023-02-07T22:49:05Z"},"properties":{"provisioningState":"Succeeded"}}'
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '310'
+      - '369'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:08 GMT
+      - Mon, 26 Jun 2023 23:50:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:33 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:36 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:35 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-azure-mgmt-resource/22.0.0 Python/3.9.13 (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001?api-version=2022-09-01
+  response:
+    body:
+      string: '{"id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001","name":"clitest.rg000001","type":"Microsoft.Resources/resourceGroups","location":"westus","tags":{"product":"azurecli","cause":"automation","test":"test_node_type_operation","date":"2023-06-26T23:50:29Z","module":"servicefabric"},"properties":{"provisioningState":"Succeeded"}}'
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '369'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:50:36 GMT
       expires:
       - '-1'
       pragma:
@@ -669,8 +670,8 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -678,12 +679,12 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T22:49:10.6260623+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T22:49:10.6260623+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.679692+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.679692+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Standard\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"6fe96140-b9f1-4a92-84ef-0f96cb024f6d\",\r\n
+        {\r\n    \"provisioningState\": \"Creating\",\r\n    \"clusterId\": \"435d686a-7209-4ba4-a986-af61a3237024\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave1\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n    \"clusterCertificateThumbprints\":
@@ -694,15 +695,15 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1337'
+      - '1297'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:12 GMT
+      - Mon, 26 Jun 2023 23:50:41 GMT
       expires:
       - '-1'
       pragma:
@@ -737,14 +738,14 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -754,7 +755,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:49:42 GMT
+      - Mon, 26 Jun 2023 23:50:42 GMT
       expires:
       - '-1'
       pragma:
@@ -788,14 +789,65 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 30.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:51:12 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -805,7 +857,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:50:13 GMT
+      - Mon, 26 Jun 2023 23:51:43 GMT
       expires:
       - '-1'
       pragma:
@@ -839,14 +891,14 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -856,7 +908,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:50:43 GMT
+      - Mon, 26 Jun 2023 23:52:13 GMT
       expires:
       - '-1'
       pragma:
@@ -890,14 +942,14 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -907,7 +959,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:51:12 GMT
+      - Mon, 26 Jun 2023 23:52:43 GMT
       expires:
       - '-1'
       pragma:
@@ -941,14 +993,14 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -958,7 +1010,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:51:44 GMT
+      - Mon, 26 Jun 2023 23:53:13 GMT
       expires:
       - '-1'
       pragma:
@@ -992,14 +1044,14 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 52.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1009,7 +1061,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:52:13 GMT
+      - Mon, 26 Jun 2023 23:53:43 GMT
       expires:
       - '-1'
       pragma:
@@ -1043,14 +1095,65 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/b08d0004-9eda-49a0-8f11-5a0e55cc2720?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"b08d0004-9eda-49a0-8f11-5a0e55cc2720\",\r\n  \"startTime\":
-        \"2023-02-07T22:49:12.0134044Z\",\r\n  \"endTime\": \"2023-02-07T22:52:44.0027489Z\",\r\n
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 90.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Mon, 26 Jun 2023 23:54:14 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
+        --upgrade-cadence
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f3810001-6177-469b-a6c4-98d785ea1dad?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"f3810001-6177-469b-a6c4-98d785ea1dad\",\r\n  \"startTime\":
+        \"2023-06-26T23:50:42.1586708Z\",\r\n  \"endTime\": \"2023-06-26T23:54:14.9922497Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -1060,7 +1163,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:52:44 GMT
+      - Mon, 26 Jun 2023 23:54:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1094,8 +1197,8 @@ interactions:
       - -g -c -l --cert-thumbprint --cert-is-admin --admin-password --sku --upgrade-mode
         --upgrade-cadence
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -1103,17 +1206,17 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T22:49:10.6260623+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T22:49:10.6260623+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.679692+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.679692+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Standard\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"6fe96140-b9f1-4a92-84ef-0f96cb024f6d\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"clusterId\": \"435d686a-7209-4ba4-a986-af61a3237024\",\r\n
         \   \"clusterState\": \"WaitingForNodes\",\r\n    \"clusterUpgradeMode\":
         \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\": false,\r\n    \"clusterUpgradeCadence\":
         \"Wave1\",\r\n    \"adminUserName\": \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n
         \   \"fqdn\": \"sfrp-cli-000002.eastasia.cloudapp.azure.com\",\r\n    \"ipv4Address\":
-        \"104.208.96.40\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"E5135341AB0A5E71644D0A389FFEBCDAB73EFFD2\"\r\n
+        \"20.24.197.34\",\r\n    \"clusterCertificateThumbprints\": [\r\n      \"F69625C22E1C88C5B760761B4613D25C8F08D6CB\"\r\n
         \   ],\r\n    \"clientConnectionPort\": 19000,\r\n    \"httpGatewayConnectionPort\":
         19080,\r\n    \"allowRdpAccess\": false,\r\n    \"clients\": [\r\n      {\r\n
         \       \"isAdmin\": true,\r\n        \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n
@@ -1123,11 +1226,11 @@ interactions:
       cache-control:
       - no-cache
       content-length:
-      - '1531'
+      - '1490'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:52:45 GMT
+      - Mon, 26 Jun 2023 23:54:45 GMT
       expires:
       - '-1'
       pragma:
@@ -1149,7 +1252,7 @@ interactions:
 - request:
     body: '{"properties": {"isPrimary": true, "vmInstanceCount": 5, "dataDiskSizeGB":
       100, "dataDiskType": "Premium_LRS", "vmSize": "Standard_DS2", "vmImagePublisher":
-      "MicrosoftWindowsServer", "vmImageOffer": "WindowsServer", "vmImageSku": "2019-Datacenter",
+      "MicrosoftWindowsServer", "vmImageOffer": "WindowsServer", "vmImageSku": "2022-Datacenter",
       "vmImageVersion": "latest", "isStateless": false, "multiplePlacementGroups":
       false}}'
     headers:
@@ -1168,8 +1271,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -1179,7 +1282,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_DS2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"Premium_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -1187,7 +1290,7 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -1195,7 +1298,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:52:49 GMT
+      - Mon, 26 Jun 2023 23:54:49 GMT
       expires:
       - '-1'
       pragma:
@@ -1230,14 +1333,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1247,7 +1350,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:53:19 GMT
+      - Mon, 26 Jun 2023 23:54:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1280,14 +1383,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1297,7 +1400,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:53:49 GMT
+      - Mon, 26 Jun 2023 23:55:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1330,14 +1433,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1347,7 +1450,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:54:20 GMT
+      - Mon, 26 Jun 2023 23:55:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1380,14 +1483,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1397,7 +1500,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:54:50 GMT
+      - Mon, 26 Jun 2023 23:56:21 GMT
       expires:
       - '-1'
       pragma:
@@ -1430,14 +1533,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1447,7 +1550,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:55:21 GMT
+      - Mon, 26 Jun 2023 23:56:51 GMT
       expires:
       - '-1'
       pragma:
@@ -1480,14 +1583,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1497,7 +1600,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:55:51 GMT
+      - Mon, 26 Jun 2023 23:57:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1530,14 +1633,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1547,7 +1650,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:56:21 GMT
+      - Mon, 26 Jun 2023 23:57:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1580,14 +1683,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1597,7 +1700,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:56:52 GMT
+      - Mon, 26 Jun 2023 23:58:22 GMT
       expires:
       - '-1'
       pragma:
@@ -1630,14 +1733,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1647,7 +1750,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:57:22 GMT
+      - Mon, 26 Jun 2023 23:58:52 GMT
       expires:
       - '-1'
       pragma:
@@ -1680,14 +1783,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1697,7 +1800,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:57:52 GMT
+      - Mon, 26 Jun 2023 23:59:23 GMT
       expires:
       - '-1'
       pragma:
@@ -1730,14 +1833,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1747,7 +1850,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:58:22 GMT
+      - Mon, 26 Jun 2023 23:59:54 GMT
       expires:
       - '-1'
       pragma:
@@ -1780,14 +1883,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1797,7 +1900,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:58:52 GMT
+      - Tue, 27 Jun 2023 00:00:24 GMT
       expires:
       - '-1'
       pragma:
@@ -1830,14 +1933,464 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:00:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:01:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:01:55 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:02:25 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:02:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:03:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:03:56 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:04:26 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:04:58 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1847,7 +2400,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:59:24 GMT
+      - Tue, 27 Jun 2023 00:05:28 GMT
       expires:
       - '-1'
       pragma:
@@ -1880,14 +2433,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1897,7 +2450,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 22:59:54 GMT
+      - Tue, 27 Jun 2023 00:05:59 GMT
       expires:
       - '-1'
       pragma:
@@ -1930,14 +2483,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1947,7 +2500,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:00:25 GMT
+      - Tue, 27 Jun 2023 00:06:29 GMT
       expires:
       - '-1'
       pragma:
@@ -1980,14 +2533,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -1997,7 +2550,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:00:54 GMT
+      - Tue, 27 Jun 2023 00:06:59 GMT
       expires:
       - '-1'
       pragma:
@@ -2030,14 +2583,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2047,7 +2600,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:01:25 GMT
+      - Tue, 27 Jun 2023 00:07:30 GMT
       expires:
       - '-1'
       pragma:
@@ -2080,14 +2633,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2097,7 +2650,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:01:55 GMT
+      - Tue, 27 Jun 2023 00:08:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2130,14 +2683,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2147,7 +2700,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:02:26 GMT
+      - Tue, 27 Jun 2023 00:08:30 GMT
       expires:
       - '-1'
       pragma:
@@ -2180,14 +2733,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2197,7 +2750,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:02:56 GMT
+      - Tue, 27 Jun 2023 00:09:00 GMT
       expires:
       - '-1'
       pragma:
@@ -2230,14 +2783,214 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/347c0004-0b25-41d7-8155-3e101701faab?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"347c0004-0b25-41d7-8155-3e101701faab\",\r\n  \"startTime\":
-        \"2023-02-07T22:52:49.9268261Z\",\r\n  \"endTime\": \"2023-02-07T23:03:24.0199372Z\",\r\n
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:09:31 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:10:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:10:32 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:11:02 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --primary --disk-type --vm-size
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/305f0001-445f-4364-aee8-8f5985765253?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"305f0001-445f-4364-aee8-8f5985765253\",\r\n  \"startTime\":
+        \"2023-06-26T23:54:50.7617502Z\",\r\n  \"endTime\": \"2023-06-27T00:11:25.3104959Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -2247,7 +3000,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:03:26 GMT
+      - Tue, 27 Jun 2023 00:11:32 GMT
       expires:
       - '-1'
       pragma:
@@ -2280,8 +3033,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --primary --disk-type --vm-size
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/pnt?api-version=2021-05-01
   response:
@@ -2291,7 +3044,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"pnt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": true,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_DS2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"Premium_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2305,7 +3058,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:03:26 GMT
+      - Tue, 27 Jun 2023 00:11:33 GMT
       expires:
       - '-1'
       pragma:
@@ -2338,8 +3091,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes?api-version=2021-05-01
   response:
@@ -2350,7 +3103,7 @@ interactions:
         {},\r\n      \"systemData\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"isPrimary\": true,\r\n        \"vmImagePublisher\":
         \"MicrosoftWindowsServer\",\r\n        \"vmImageOffer\": \"WindowsServer\",\r\n
-        \       \"vmImageSku\": \"2019-Datacenter\",\r\n        \"vmImageVersion\":
+        \       \"vmImageSku\": \"2022-Datacenter\",\r\n        \"vmImageVersion\":
         \"latest\",\r\n        \"vmSize\": \"Standard_DS2\",\r\n        \"vmInstanceCount\":
         5,\r\n        \"dataDiskSizeGB\": 100,\r\n        \"dataDiskType\": \"Premium_LRS\",\r\n
         \       \"placementProperties\": {},\r\n        \"capacities\": {},\r\n        \"vmExtensions\":
@@ -2364,7 +3117,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:03:29 GMT
+      - Tue, 27 Jun 2023 00:11:37 GMT
       expires:
       - '-1'
       pragma:
@@ -2386,7 +3139,7 @@ interactions:
 - request:
     body: '{"properties": {"isPrimary": false, "vmInstanceCount": 6, "dataDiskSizeGB":
       100, "vmSize": "Standard_D2", "vmImagePublisher": "MicrosoftWindowsServer",
-      "vmImageOffer": "WindowsServer", "vmImageSku": "2019-Datacenter", "vmImageVersion":
+      "vmImageOffer": "WindowsServer", "vmImageSku": "2022-Datacenter", "vmImageVersion":
       "latest", "isStateless": true, "multiplePlacementGroups": true}}'
     headers:
       Accept:
@@ -2404,8 +3157,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: PUT
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt?api-version=2021-05-01
   response:
@@ -2415,7 +3168,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"snt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n
         \   \"isPrimary\": false,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 6,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -2423,7 +3176,7 @@ interactions:
         true\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -2431,7 +3184,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:03:36 GMT
+      - Tue, 27 Jun 2023 00:11:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2448,7 +3201,7 @@ interactions:
       x-content-type-options:
       - nosniff
       x-ms-ratelimit-remaining-subscription-writes:
-      - '1199'
+      - '1198'
     status:
       code: 200
       message: OK
@@ -2466,14 +3219,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2483,7 +3236,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:04:06 GMT
+      - Tue, 27 Jun 2023 00:11:39 GMT
       expires:
       - '-1'
       pragma:
@@ -2516,14 +3269,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2533,7 +3286,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:04:36 GMT
+      - Tue, 27 Jun 2023 00:12:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2566,14 +3319,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2583,7 +3336,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:05:07 GMT
+      - Tue, 27 Jun 2023 00:12:40 GMT
       expires:
       - '-1'
       pragma:
@@ -2616,14 +3369,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2633,7 +3386,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:05:37 GMT
+      - Tue, 27 Jun 2023 00:13:10 GMT
       expires:
       - '-1'
       pragma:
@@ -2666,14 +3419,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2683,7 +3436,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:06:07 GMT
+      - Tue, 27 Jun 2023 00:13:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2716,14 +3469,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2733,7 +3486,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:06:38 GMT
+      - Tue, 27 Jun 2023 00:14:11 GMT
       expires:
       - '-1'
       pragma:
@@ -2766,14 +3519,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2783,7 +3536,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:07:08 GMT
+      - Tue, 27 Jun 2023 00:14:41 GMT
       expires:
       - '-1'
       pragma:
@@ -2816,14 +3569,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2833,7 +3586,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:07:38 GMT
+      - Tue, 27 Jun 2023 00:15:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2866,14 +3619,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2883,7 +3636,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:08:09 GMT
+      - Tue, 27 Jun 2023 00:15:43 GMT
       expires:
       - '-1'
       pragma:
@@ -2916,14 +3669,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2933,7 +3686,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:08:40 GMT
+      - Tue, 27 Jun 2023 00:16:13 GMT
       expires:
       - '-1'
       pragma:
@@ -2966,14 +3719,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -2983,7 +3736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:09:10 GMT
+      - Tue, 27 Jun 2023 00:16:43 GMT
       expires:
       - '-1'
       pragma:
@@ -3016,14 +3769,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3033,7 +3786,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:09:41 GMT
+      - Tue, 27 Jun 2023 00:17:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3066,14 +3819,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3083,7 +3836,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:10:11 GMT
+      - Tue, 27 Jun 2023 00:17:44 GMT
       expires:
       - '-1'
       pragma:
@@ -3116,14 +3869,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3133,7 +3886,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:10:41 GMT
+      - Tue, 27 Jun 2023 00:18:14 GMT
       expires:
       - '-1'
       pragma:
@@ -3166,14 +3919,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3183,7 +3936,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:11:11 GMT
+      - Tue, 27 Jun 2023 00:18:45 GMT
       expires:
       - '-1'
       pragma:
@@ -3216,14 +3969,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3233,7 +3986,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:11:41 GMT
+      - Tue, 27 Jun 2023 00:19:16 GMT
       expires:
       - '-1'
       pragma:
@@ -3266,14 +4019,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3283,7 +4036,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:12:12 GMT
+      - Tue, 27 Jun 2023 00:19:46 GMT
       expires:
       - '-1'
       pragma:
@@ -3316,14 +4069,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3333,7 +4086,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:12:42 GMT
+      - Tue, 27 Jun 2023 00:20:17 GMT
       expires:
       - '-1'
       pragma:
@@ -3366,14 +4119,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3383,7 +4136,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:13:13 GMT
+      - Tue, 27 Jun 2023 00:20:47 GMT
       expires:
       - '-1'
       pragma:
@@ -3416,14 +4169,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3433,7 +4186,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:13:43 GMT
+      - Tue, 27 Jun 2023 00:21:17 GMT
       expires:
       - '-1'
       pragma:
@@ -3466,14 +4219,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3483,7 +4236,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:14:14 GMT
+      - Tue, 27 Jun 2023 00:21:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3516,14 +4269,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3533,7 +4286,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:14:44 GMT
+      - Tue, 27 Jun 2023 00:22:18 GMT
       expires:
       - '-1'
       pragma:
@@ -3566,14 +4319,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3583,7 +4336,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:15:14 GMT
+      - Tue, 27 Jun 2023 00:22:48 GMT
       expires:
       - '-1'
       pragma:
@@ -3616,14 +4369,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3633,7 +4386,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:15:45 GMT
+      - Tue, 27 Jun 2023 00:23:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3666,14 +4419,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3683,7 +4436,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:16:15 GMT
+      - Tue, 27 Jun 2023 00:23:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3716,14 +4469,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3733,7 +4486,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:16:45 GMT
+      - Tue, 27 Jun 2023 00:24:19 GMT
       expires:
       - '-1'
       pragma:
@@ -3766,14 +4519,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3783,7 +4536,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:17:16 GMT
+      - Tue, 27 Jun 2023 00:24:49 GMT
       expires:
       - '-1'
       pragma:
@@ -3816,14 +4569,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3833,7 +4586,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:17:46 GMT
+      - Tue, 27 Jun 2023 00:25:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3866,14 +4619,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3883,7 +4636,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:18:16 GMT
+      - Tue, 27 Jun 2023 00:25:51 GMT
       expires:
       - '-1'
       pragma:
@@ -3916,14 +4669,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3933,7 +4686,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:18:47 GMT
+      - Tue, 27 Jun 2023 00:26:21 GMT
       expires:
       - '-1'
       pragma:
@@ -3966,14 +4719,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -3983,7 +4736,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:19:17 GMT
+      - Tue, 27 Jun 2023 00:26:51 GMT
       expires:
       - '-1'
       pragma:
@@ -4016,14 +4769,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4033,7 +4786,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:19:48 GMT
+      - Tue, 27 Jun 2023 00:27:21 GMT
       expires:
       - '-1'
       pragma:
@@ -4066,14 +4819,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4083,7 +4836,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:20:18 GMT
+      - Tue, 27 Jun 2023 00:27:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4116,14 +4869,64 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 20.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:28:22 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type create
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 40.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4133,7 +4936,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:20:48 GMT
+      - Tue, 27 Jun 2023 00:28:52 GMT
       expires:
       - '-1'
       pragma:
@@ -4166,14 +4969,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4183,7 +4986,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:21:19 GMT
+      - Tue, 27 Jun 2023 00:29:23 GMT
       expires:
       - '-1'
       pragma:
@@ -4216,14 +5019,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4233,7 +5036,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:21:49 GMT
+      - Tue, 27 Jun 2023 00:29:53 GMT
       expires:
       - '-1'
       pragma:
@@ -4266,14 +5069,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4283,7 +5086,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:22:19 GMT
+      - Tue, 27 Jun 2023 00:30:24 GMT
       expires:
       - '-1'
       pragma:
@@ -4316,14 +5119,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -4333,7 +5136,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:22:49 GMT
+      - Tue, 27 Jun 2023 00:30:55 GMT
       expires:
       - '-1'
       pragma:
@@ -4366,424 +5169,24 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/78730001-1bed-4216-82a9-84cc13eba80c?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:23:20 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:23:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:24:21 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:24:51 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:25:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:25:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:26:23 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:26:53 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type create
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n --instance-count --is-stateless --multiple-placement-groups
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/17a20004-19e1-4e13-bc07-938dab2a50de?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"17a20004-19e1-4e13-bc07-938dab2a50de\",\r\n  \"startTime\":
-        \"2023-02-07T23:03:36.7233287Z\",\r\n  \"endTime\": \"2023-02-07T23:27:10.857755Z\",\r\n
+      string: "{\r\n  \"name\": \"78730001-1bed-4216-82a9-84cc13eba80c\",\r\n  \"startTime\":
+        \"2023-06-27T00:11:39.9996364Z\",\r\n  \"endTime\": \"2023-06-27T00:38:14.2120621Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '202'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:27:24 GMT
+      - Tue, 27 Jun 2023 00:44:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4816,8 +5219,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --instance-count --is-stateless --multiple-placement-groups
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt?api-version=2021-05-01
   response:
@@ -4827,7 +5230,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"snt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
         \   \"isPrimary\": false,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 6,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -4841,7 +5244,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:27:25 GMT
+      - Tue, 27 Jun 2023 00:44:44 GMT
       expires:
       - '-1'
       pragma:
@@ -4874,8 +5277,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes?api-version=2021-05-01
   response:
@@ -4886,7 +5289,7 @@ interactions:
         {},\r\n      \"systemData\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"isPrimary\": true,\r\n        \"vmImagePublisher\":
         \"MicrosoftWindowsServer\",\r\n        \"vmImageOffer\": \"WindowsServer\",\r\n
-        \       \"vmImageSku\": \"2019-Datacenter\",\r\n        \"vmImageVersion\":
+        \       \"vmImageSku\": \"2022-Datacenter\",\r\n        \"vmImageVersion\":
         \"latest\",\r\n        \"vmSize\": \"Standard_DS2\",\r\n        \"vmInstanceCount\":
         5,\r\n        \"dataDiskSizeGB\": 100,\r\n        \"dataDiskType\": \"Premium_LRS\",\r\n
         \       \"placementProperties\": {},\r\n        \"capacities\": {},\r\n        \"vmExtensions\":
@@ -4897,7 +5300,7 @@ interactions:
         {},\r\n      \"systemData\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"isPrimary\": false,\r\n        \"vmImagePublisher\":
         \"MicrosoftWindowsServer\",\r\n        \"vmImageOffer\": \"WindowsServer\",\r\n
-        \       \"vmImageSku\": \"2019-Datacenter\",\r\n        \"vmImageVersion\":
+        \       \"vmImageSku\": \"2022-Datacenter\",\r\n        \"vmImageVersion\":
         \"latest\",\r\n        \"vmSize\": \"Standard_D2\",\r\n        \"vmInstanceCount\":
         6,\r\n        \"dataDiskSizeGB\": 100,\r\n        \"dataDiskType\": \"StandardSSD_LRS\",\r\n
         \       \"placementProperties\": {},\r\n        \"capacities\": {},\r\n        \"vmExtensions\":
@@ -4911,7 +5314,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:27:27 GMT
+      - Tue, 27 Jun 2023 00:44:47 GMT
       expires:
       - '-1'
       pragma:
@@ -4948,8 +5351,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt/restart?api-version=2021-05-01
   response:
@@ -4957,7 +5360,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -4965,11 +5368,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:27:30 GMT
+      - Tue, 27 Jun 2023 00:44:51 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -4998,14 +5401,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5015,7 +5418,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:28:01 GMT
+      - Tue, 27 Jun 2023 00:44:51 GMT
       expires:
       - '-1'
       pragma:
@@ -5025,6 +5428,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5044,14 +5451,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5061,7 +5468,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:28:31 GMT
+      - Tue, 27 Jun 2023 00:45:21 GMT
       expires:
       - '-1'
       pragma:
@@ -5071,6 +5478,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5090,14 +5501,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5107,7 +5518,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:29:01 GMT
+      - Tue, 27 Jun 2023 00:45:51 GMT
       expires:
       - '-1'
       pragma:
@@ -5117,6 +5528,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5136,14 +5551,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5153,7 +5568,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:29:32 GMT
+      - Tue, 27 Jun 2023 00:46:22 GMT
       expires:
       - '-1'
       pragma:
@@ -5163,6 +5578,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5182,14 +5601,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5199,7 +5618,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:30:02 GMT
+      - Tue, 27 Jun 2023 00:46:52 GMT
       expires:
       - '-1'
       pragma:
@@ -5209,6 +5628,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5228,14 +5651,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5245,7 +5668,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:30:32 GMT
+      - Tue, 27 Jun 2023 00:47:22 GMT
       expires:
       - '-1'
       pragma:
@@ -5255,6 +5678,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5274,14 +5701,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5291,7 +5718,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:31:02 GMT
+      - Tue, 27 Jun 2023 00:47:52 GMT
       expires:
       - '-1'
       pragma:
@@ -5301,6 +5728,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5320,14 +5751,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5337,7 +5768,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:31:33 GMT
+      - Tue, 27 Jun 2023 00:48:24 GMT
       expires:
       - '-1'
       pragma:
@@ -5347,6 +5778,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5366,14 +5801,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5383,7 +5818,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:32:04 GMT
+      - Tue, 27 Jun 2023 00:48:54 GMT
       expires:
       - '-1'
       pragma:
@@ -5393,6 +5828,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5412,14 +5851,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5429,7 +5868,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:32:34 GMT
+      - Tue, 27 Jun 2023 00:49:26 GMT
       expires:
       - '-1'
       pragma:
@@ -5439,6 +5878,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5458,14 +5901,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5475,7 +5918,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:33:05 GMT
+      - Tue, 27 Jun 2023 00:49:56 GMT
       expires:
       - '-1'
       pragma:
@@ -5485,6 +5928,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5504,14 +5951,64 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d7190004-11c0-430a-a39a-b02c1cbf59cc\",\r\n  \"startTime\":
-        \"2023-02-07T23:27:31.1413165Z\",\r\n  \"endTime\": \"2023-02-07T23:33:33.5397284Z\",\r\n
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:50:27 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node restart
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"7c220001-9bc8-4565-973a-90b2a97faf09\",\r\n  \"startTime\":
+        \"2023-06-27T00:44:51.5124174Z\",\r\n  \"endTime\": \"2023-06-27T00:50:33.1266227Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -5521,7 +6018,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:33:35 GMT
+      - Tue, 27 Jun 2023 00:50:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5531,6 +6028,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -5550,10 +6051,10 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d7190004-11c0-430a-a39a-b02c1cbf59cc?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/7c220001-9bc8-4565-973a-90b2a97faf09?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -5561,7 +6062,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Tue, 07 Feb 2023 23:33:36 GMT
+      - Tue, 27 Jun 2023 00:50:57 GMT
       expires:
       - '-1'
       pragma:
@@ -5594,8 +6095,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt/deleteNode?api-version=2021-05-01
   response:
@@ -5603,7 +6104,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -5611,11 +6112,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:33:38 GMT
+      - Tue, 27 Jun 2023 00:51:00 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -5644,14 +6145,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"deea0004-1bd5-491b-9b98-e7a49337d2ca\",\r\n  \"startTime\":
-        \"2023-02-07T23:33:38.1804169Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5661,7 +6162,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:34:08 GMT
+      - Tue, 27 Jun 2023 00:51:00 GMT
       expires:
       - '-1'
       pragma:
@@ -5694,14 +6195,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"deea0004-1bd5-491b-9b98-e7a49337d2ca\",\r\n  \"startTime\":
-        \"2023-02-07T23:33:38.1804169Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5711,7 +6212,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:34:37 GMT
+      - Tue, 27 Jun 2023 00:51:30 GMT
       expires:
       - '-1'
       pragma:
@@ -5744,14 +6245,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"deea0004-1bd5-491b-9b98-e7a49337d2ca\",\r\n  \"startTime\":
-        \"2023-02-07T23:33:38.1804169Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5761,7 +6262,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:35:09 GMT
+      - Tue, 27 Jun 2023 00:52:01 GMT
       expires:
       - '-1'
       pragma:
@@ -5794,14 +6295,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"deea0004-1bd5-491b-9b98-e7a49337d2ca\",\r\n  \"startTime\":
-        \"2023-02-07T23:33:38.1804169Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -5811,7 +6312,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:35:39 GMT
+      - Tue, 27 Jun 2023 00:52:31 GMT
       expires:
       - '-1'
       pragma:
@@ -5844,24 +6345,74 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"deea0004-1bd5-491b-9b98-e7a49337d2ca\",\r\n  \"startTime\":
-        \"2023-02-07T23:33:38.1804169Z\",\r\n  \"endTime\": \"2023-02-07T23:35:40.2784055Z\",\r\n
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 00:53:01 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"f7030001-f784-4d8c-8a0c-2b2a68edbcc7\",\r\n  \"startTime\":
+        \"2023-06-27T00:51:00.7051335Z\",\r\n  \"endTime\": \"2023-06-27T00:53:02.579132Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '203'
+      - '202'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:36:09 GMT
+      - Tue, 27 Jun 2023 00:53:32 GMT
       expires:
       - '-1'
       pragma:
@@ -5894,10 +6445,10 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/deea0004-1bd5-491b-9b98-e7a49337d2ca?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/f7030001-f784-4d8c-8a0c-2b2a68edbcc7?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -5905,7 +6456,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Tue, 07 Feb 2023 23:36:09 GMT
+      - Tue, 27 Jun 2023 00:53:32 GMT
       expires:
       - '-1'
       pragma:
@@ -5938,8 +6489,8 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: POST
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt/reimage?api-version=2021-05-01
   response:
@@ -5947,7 +6498,7 @@ interactions:
       string: '{}'
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -5955,11 +6506,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:36:16 GMT
+      - Tue, 27 Jun 2023 00:53:34 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -5988,14 +6539,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6005,7 +6556,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:36:47 GMT
+      - Tue, 27 Jun 2023 00:53:35 GMT
       expires:
       - '-1'
       pragma:
@@ -6015,6 +6566,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6034,14 +6589,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6051,7 +6606,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:37:18 GMT
+      - Tue, 27 Jun 2023 00:54:05 GMT
       expires:
       - '-1'
       pragma:
@@ -6061,6 +6616,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6080,14 +6639,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6097,7 +6656,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:37:48 GMT
+      - Tue, 27 Jun 2023 00:54:36 GMT
       expires:
       - '-1'
       pragma:
@@ -6107,6 +6666,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6126,14 +6689,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6143,7 +6706,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:38:18 GMT
+      - Tue, 27 Jun 2023 00:55:43 GMT
       expires:
       - '-1'
       pragma:
@@ -6153,6 +6716,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6172,14 +6739,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6189,7 +6756,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:38:48 GMT
+      - Tue, 27 Jun 2023 00:56:14 GMT
       expires:
       - '-1'
       pragma:
@@ -6199,6 +6766,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6218,14 +6789,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6235,7 +6806,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:39:18 GMT
+      - Tue, 27 Jun 2023 00:56:44 GMT
       expires:
       - '-1'
       pragma:
@@ -6245,6 +6816,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6264,14 +6839,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6281,7 +6856,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:39:49 GMT
+      - Tue, 27 Jun 2023 00:57:15 GMT
       expires:
       - '-1'
       pragma:
@@ -6291,6 +6866,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6310,14 +6889,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6327,7 +6906,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:40:19 GMT
+      - Tue, 27 Jun 2023 00:57:45 GMT
       expires:
       - '-1'
       pragma:
@@ -6337,6 +6916,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6356,14 +6939,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6373,7 +6956,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:40:50 GMT
+      - Tue, 27 Jun 2023 00:58:15 GMT
       expires:
       - '-1'
       pragma:
@@ -6383,6 +6966,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6402,14 +6989,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6419,7 +7006,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:41:20 GMT
+      - Tue, 27 Jun 2023 00:58:45 GMT
       expires:
       - '-1'
       pragma:
@@ -6429,6 +7016,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6448,14 +7039,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6465,7 +7056,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:41:51 GMT
+      - Tue, 27 Jun 2023 00:59:16 GMT
       expires:
       - '-1'
       pragma:
@@ -6475,6 +7066,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6494,14 +7089,14 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6511,7 +7106,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:42:21 GMT
+      - Tue, 27 Jun 2023 00:59:46 GMT
       expires:
       - '-1'
       pragma:
@@ -6521,6 +7116,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6540,14 +7139,364 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"a5600004-d725-49e0-9209-5b7b8b5835ce\",\r\n  \"startTime\":
-        \"2023-02-07T23:36:16.6391888Z\",\r\n  \"endTime\": \"2023-02-07T23:42:49.7120849Z\",\r\n
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:00:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:00:46 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:01:16 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:01:48 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:02:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:02:49 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '190'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:03:19 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-node-type node reimage
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c -n --node-name
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"6a160001-24b1-4ab4-a3bf-a23176293d33\",\r\n  \"startTime\":
+        \"2023-06-27T00:53:35.6912188Z\",\r\n  \"endTime\": \"2023-06-27T01:03:40.0701785Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -6557,7 +7506,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:42:52 GMT
+      - Tue, 27 Jun 2023 01:03:49 GMT
       expires:
       - '-1'
       pragma:
@@ -6567,6 +7516,10 @@ interactions:
       - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
       x-content-type-options:
       - nosniff
     status:
@@ -6586,10 +7539,10 @@ interactions:
       ParameterSetName:
       - -g -c -n --node-name
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/a5600004-d725-49e0-9209-5b7b8b5835ce?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/6a160001-24b1-4ab4-a3bf-a23176293d33?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -6597,7 +7550,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Tue, 07 Feb 2023 23:42:52 GMT
+      - Tue, 27 Jun 2023 01:03:50 GMT
       expires:
       - '-1'
       pragma:
@@ -6628,8 +7581,8 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt?api-version=2021-05-01
   response:
@@ -6639,7 +7592,7 @@ interactions:
         \"eastasia\",\r\n  \"name\": \"snt\",\r\n  \"tags\": {},\r\n  \"systemData\":
         {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Deleting\",\r\n
         \   \"isPrimary\": false,\r\n    \"vmImagePublisher\": \"MicrosoftWindowsServer\",\r\n
-        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2019-Datacenter\",\r\n
+        \   \"vmImageOffer\": \"WindowsServer\",\r\n    \"vmImageSku\": \"2022-Datacenter\",\r\n
         \   \"vmImageVersion\": \"latest\",\r\n    \"vmSize\": \"Standard_D2\",\r\n
         \   \"vmInstanceCount\": 5,\r\n    \"dataDiskSizeGB\": 100,\r\n    \"dataDiskType\":
         \"StandardSSD_LRS\",\r\n    \"placementProperties\": {},\r\n    \"capacities\":
@@ -6647,7 +7600,7 @@ interactions:
         true\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
@@ -6655,11 +7608,11 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:42:55 GMT
+      - Tue, 27 Jun 2023 01:03:53 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -6688,14 +7641,14 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6705,7 +7658,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:43:25 GMT
+      - Tue, 27 Jun 2023 01:03:53 GMT
       expires:
       - '-1'
       pragma:
@@ -6738,14 +7691,14 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6755,7 +7708,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:43:56 GMT
+      - Tue, 27 Jun 2023 01:04:24 GMT
       expires:
       - '-1'
       pragma:
@@ -6788,14 +7741,14 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6805,7 +7758,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:44:26 GMT
+      - Tue, 27 Jun 2023 01:04:54 GMT
       expires:
       - '-1'
       pragma:
@@ -6838,14 +7791,14 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -6855,7 +7808,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:44:56 GMT
+      - Tue, 27 Jun 2023 01:05:24 GMT
       expires:
       - '-1'
       pragma:
@@ -6888,24 +7841,24 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '191'
+      - '190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:45:27 GMT
+      - Tue, 27 Jun 2023 01:05:54 GMT
       expires:
       - '-1'
       pragma:
@@ -6938,24 +7891,24 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 0.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '191'
+      - '190'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Tue, 07 Feb 2023 23:45:57 GMT
+      - Tue, 27 Jun 2023 01:06:25 GMT
       expires:
       - '-1'
       pragma:
@@ -6988,1674 +7941,24 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:46:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:46:57 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:47:27 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:47:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:48:29 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:48:59 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:49:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:50:00 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:50:30 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:51:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:51:31 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:52:01 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:52:32 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:53:03 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:53:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:54:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:54:33 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:55:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:55:34 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:56:05 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:56:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:57:04 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:57:35 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:58:06 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:58:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:59:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Tue, 07 Feb 2023 23:59:37 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:00:07 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:00:38 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:01:08 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:01:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:02:09 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 80.0,\r\n  \"status\": \"Created\"\r\n}"
-    headers:
-      cache-control:
-      - no-cache
-      content-length:
-      - '191'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 08 Feb 2023 00:02:39 GMT
-      expires:
-      - '-1'
-      pragma:
-      - no-cache
-      server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains
-      transfer-encoding:
-      - chunked
-      vary:
-      - Accept-Encoding
-      x-content-type-options:
-      - nosniff
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      CommandName:
-      - sf managed-node-type delete
-      Connection:
-      - keep-alive
-      ParameterSetName:
-      - -g -c -n
-      User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
-    method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
-  response:
-    body:
-      string: "{\r\n  \"name\": \"82c20004-1590-4f1f-b83e-e72b4ee710d5\",\r\n  \"startTime\":
-        \"2023-02-07T23:42:55.9786811Z\",\r\n  \"endTime\": \"2023-02-08T00:02:40.812342Z\",\r\n
+      string: "{\r\n  \"name\": \"3f9a0001-e945-499b-a89f-1450840e4bc4\",\r\n  \"startTime\":
+        \"2023-06-27T01:03:54.1017196Z\",\r\n  \"endTime\": \"2023-06-27T01:24:08.6060937Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '202'
+      - '203'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:03:11 GMT
+      - Tue, 27 Jun 2023 01:24:17 GMT
       expires:
       - '-1'
       pragma:
@@ -8688,10 +7991,10 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/82c20004-1590-4f1f-b83e-e72b4ee710d5?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/3f9a0001-e945-499b-a89f-1450840e4bc4?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -8699,7 +8002,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 08 Feb 2023 00:03:11 GMT
+      - Tue, 27 Jun 2023 01:24:17 GMT
       expires:
       - '-1'
       pragma:
@@ -8728,14 +8031,14 @@ interactions:
       ParameterSetName:
       - -g -c -n
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes/snt?api-version=2021-05-01
   response:
     body:
       string: '{"error":{"code":"NotFound","message":"GetEntityFromTable: the NodeTypeData
-        6fe96140-b9f1-4a92-84ef-0f96cb024f6d_snt could not be found."}}'
+        435d686a-7209-4ba4-a986-af61a3237024_snt could not be found."}}'
     headers:
       cache-control:
       - no-cache
@@ -8744,7 +8047,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:03:13 GMT
+      - Tue, 27 Jun 2023 01:24:20 GMT
       expires:
       - '-1'
       pragma:
@@ -8773,8 +8076,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002/nodeTypes?api-version=2021-05-01
   response:
@@ -8785,7 +8088,7 @@ interactions:
         {},\r\n      \"systemData\": {},\r\n      \"properties\": {\r\n        \"provisioningState\":
         \"Succeeded\",\r\n        \"isPrimary\": true,\r\n        \"vmImagePublisher\":
         \"MicrosoftWindowsServer\",\r\n        \"vmImageOffer\": \"WindowsServer\",\r\n
-        \       \"vmImageSku\": \"2019-Datacenter\",\r\n        \"vmImageVersion\":
+        \       \"vmImageSku\": \"2022-Datacenter\",\r\n        \"vmImageVersion\":
         \"latest\",\r\n        \"vmSize\": \"Standard_DS2\",\r\n        \"vmInstanceCount\":
         5,\r\n        \"dataDiskSizeGB\": 100,\r\n        \"dataDiskType\": \"Premium_LRS\",\r\n
         \       \"placementProperties\": {},\r\n        \"capacities\": {},\r\n        \"vmExtensions\":
@@ -8799,7 +8102,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:03:15 GMT
+      - Tue, 27 Jun 2023 01:24:24 GMT
       expires:
       - '-1'
       pragma:
@@ -8834,8 +8137,8 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: DELETE
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
@@ -8843,17 +8146,17 @@ interactions:
       string: "{\r\n  \"id\": \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002\",\r\n
         \ \"type\": \"Microsoft.ServiceFabric/managedclusters\",\r\n  \"location\":
         \"eastasia\",\r\n  \"name\": \"sfrp-cli-000002\",\r\n  \"tags\": {},\r\n  \"systemData\":
-        {\r\n    \"createdBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"createdByType\": \"User\",\r\n    \"createdAt\": \"2023-02-07T22:49:10.6260623+00:00\",\r\n
-        \   \"lastModifiedBy\": \"azureclilivetest@azuresdkteam.onmicrosoft.com\",\r\n
-        \   \"lastModifiedByType\": \"User\",\r\n    \"lastModifiedAt\": \"2023-02-07T22:49:10.6260623+00:00\"\r\n
+        {\r\n    \"createdBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"createdByType\":
+        \"User\",\r\n    \"createdAt\": \"2023-06-26T23:50:39.679692+00:00\",\r\n
+        \   \"lastModifiedBy\": \"mwesigwaguma@microsoft.com\",\r\n    \"lastModifiedByType\":
+        \"User\",\r\n    \"lastModifiedAt\": \"2023-06-26T23:50:39.679692+00:00\"\r\n
         \ },\r\n  \"sku\": {\r\n    \"name\": \"Standard\"\r\n  },\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"6fe96140-b9f1-4a92-84ef-0f96cb024f6d\",\r\n
+        {\r\n    \"provisioningState\": \"Deleting\",\r\n    \"clusterId\": \"435d686a-7209-4ba4-a986-af61a3237024\",\r\n
         \   \"clusterUpgradeMode\": \"Automatic\",\r\n    \"isPrivateClusterCodeVersion\":
         false,\r\n    \"clusterUpgradeCadence\": \"Wave1\",\r\n    \"adminUserName\":
         \"vmadmin\",\r\n    \"dnsName\": \"sfrp-cli-000002\",\r\n    \"fqdn\": \"sfrp-cli-000002.eastasia.cloudapp.azure.com\",\r\n
-        \   \"ipv4Address\": \"104.208.96.40\",\r\n    \"clusterCertificateThumbprints\":
-        [\r\n      \"E5135341AB0A5E71644D0A389FFEBCDAB73EFFD2\"\r\n    ],\r\n    \"clientConnectionPort\":
+        \   \"ipv4Address\": \"20.24.197.34\",\r\n    \"clusterCertificateThumbprints\":
+        [\r\n      \"F69625C22E1C88C5B760761B4613D25C8F08D6CB\"\r\n    ],\r\n    \"clientConnectionPort\":
         19000,\r\n    \"httpGatewayConnectionPort\": 19080,\r\n    \"allowRdpAccess\":
         false,\r\n    \"clients\": [\r\n      {\r\n        \"isAdmin\": true,\r\n
         \       \"thumbprint\": \"123BDACDCDFB2C7B250192C6078E47D1E1DB119B\"\r\n      }\r\n
@@ -8861,19 +8164,19 @@ interactions:
         false\r\n  }\r\n}"
     headers:
       azure-asyncoperation:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
       cache-control:
       - no-cache
       content-length:
-      - '1490'
+      - '1449'
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:03:18 GMT
+      - Tue, 27 Jun 2023 01:24:28 GMT
       expires:
       - '-1'
       location:
-      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+      - https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
       pragma:
       - no-cache
       server:
@@ -8901,15 +8204,15 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
-        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 50.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
       - no-cache
@@ -8918,7 +8221,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:03:48 GMT
+      - Tue, 27 Jun 2023 01:24:28 GMT
       expires:
       - '-1'
       pragma:
@@ -8951,14 +8254,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -8968,7 +8271,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:04:19 GMT
+      - Tue, 27 Jun 2023 01:24:58 GMT
       expires:
       - '-1'
       pragma:
@@ -9001,14 +8304,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9018,7 +8321,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:04:49 GMT
+      - Tue, 27 Jun 2023 01:25:28 GMT
       expires:
       - '-1'
       pragma:
@@ -9051,14 +8354,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9068,7 +8371,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:05:19 GMT
+      - Tue, 27 Jun 2023 01:25:59 GMT
       expires:
       - '-1'
       pragma:
@@ -9101,14 +8404,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9118,7 +8421,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:05:49 GMT
+      - Tue, 27 Jun 2023 01:26:29 GMT
       expires:
       - '-1'
       pragma:
@@ -9151,14 +8454,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9168,7 +8471,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:06:20 GMT
+      - Tue, 27 Jun 2023 01:27:00 GMT
       expires:
       - '-1'
       pragma:
@@ -9201,14 +8504,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9218,7 +8521,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:06:49 GMT
+      - Tue, 27 Jun 2023 01:27:30 GMT
       expires:
       - '-1'
       pragma:
@@ -9251,14 +8554,14 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
         \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
     headers:
       cache-control:
@@ -9268,7 +8571,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:07:20 GMT
+      - Tue, 27 Jun 2023 01:28:00 GMT
       expires:
       - '-1'
       pragma:
@@ -9301,14 +8604,64 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
-      string: "{\r\n  \"name\": \"d49c0004-0dad-4584-ba31-27c444c7a1c1\",\r\n  \"startTime\":
-        \"2023-02-08T00:03:18.6793439Z\",\r\n  \"endTime\": \"2023-02-08T00:07:36.921292Z\",\r\n
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"0001-01-01T00:00:00\",\r\n
+        \ \"percentComplete\": 70.0,\r\n  \"status\": \"Created\"\r\n}"
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '191'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 27 Jun 2023 01:28:30 GMT
+      expires:
+      - '-1'
+      pragma:
+      - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      CommandName:
+      - sf managed-cluster delete
+      Connection:
+      - keep-alive
+      ParameterSetName:
+      - -g -c
+      User-Agent:
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
+    method: GET
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperations/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
+  response:
+    body:
+      string: "{\r\n  \"name\": \"93900001-1201-4cac-89a7-a52fb0526f12\",\r\n  \"startTime\":
+        \"2023-06-27T01:24:28.2314815Z\",\r\n  \"endTime\": \"2023-06-27T01:28:45.868147Z\",\r\n
         \ \"percentComplete\": 100.0,\r\n  \"status\": \"Succeeded\"\r\n}"
     headers:
       cache-control:
@@ -9318,7 +8671,7 @@ interactions:
       content-type:
       - application/json; charset=utf-8
       date:
-      - Wed, 08 Feb 2023 00:07:50 GMT
+      - Tue, 27 Jun 2023 01:29:01 GMT
       expires:
       - '-1'
       pragma:
@@ -9351,10 +8704,10 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
-    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/d49c0004-0dad-4584-ba31-27c444c7a1c1?api-version=2021-05-01
+    uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.ServiceFabric/locations/eastasia/managedclusteroperationresults/93900001-1201-4cac-89a7-a52fb0526f12?api-version=2021-05-01
   response:
     body:
       string: ''
@@ -9362,7 +8715,7 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Wed, 08 Feb 2023 00:07:50 GMT
+      - Tue, 27 Jun 2023 01:29:02 GMT
       expires:
       - '-1'
       pragma:
@@ -9391,34 +8744,31 @@ interactions:
       ParameterSetName:
       - -g -c
       User-Agent:
-      - AZURECLI/2.45.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.10.9
-        (Linux-5.15.0-1031-azure-x86_64-with-glibc2.31) VSTS_7b238909-6802-4b65-b90d-184bca47f458_build_220_0
+      - AZURECLI/2.49.0 azsdk-python-mgmt-servicefabricmanagedclusters/1.0.0 Python/3.9.13
+        (Windows-10-10.0.22621-SP0)
     method: GET
     uri: https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/clitest.rg000001/providers/Microsoft.ServiceFabric/managedClusters/sfrp-cli-000002?api-version=2021-05-01
   response:
     body:
-      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.ServiceFabric/managedclusters/sfrp-cli-000002''
-        under resource group ''clitest.rg000001'' was not found. For more details
-        please go to https://aka.ms/ARMResourceNotFoundFix"}}'
+      string: ''
     headers:
       cache-control:
       - no-cache
       content-length:
-      - '243'
-      content-type:
-      - application/json; charset=utf-8
+      - '0'
       date:
-      - Wed, 08 Feb 2023 00:07:51 GMT
+      - Tue, 27 Jun 2023 01:29:05 GMT
       expires:
       - '-1'
       pragma:
       - no-cache
+      server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-content-type-options:
       - nosniff
-      x-ms-failure-cause:
-      - gateway
     status:
       code: 404
       message: Not Found


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
Updating vmSkus to use 2022-Datacenter so that tests are tls compliant for ServiceFabric module

**Testing Guide**
see src\azure-cli\azure\cli\command_modules\help.py for examples and descriptions

**History Notes**
[Service Fabric] `az sf managed-node-type create`: creates nodetype with 2022-Datacenter vmSku as default

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
