### PR TITLE
{all services} TOC | product name changes

### DIFF
--- a/src/azure-cli/service_name.json
+++ b/src/azure-cli/service_name.json
@@ -6,7 +6,7 @@
   },
   {
     "Command": "az acr",
-    "AzureServiceName": "Azure Container Registries",
+    "AzureServiceName": "Azure Container Registry",
     "URL": "https://docs.microsoft.com/azure/container-registry/"
   },
   {
@@ -146,7 +146,7 @@
   },
   {
     "Command": "az cosmosdb",
-    "AzureServiceName": "Azure Cosmos DB",
+    "AzureServiceName": "Database for Cosmos DB",
     "URL": "https://docs.microsoft.com/azure/cosmos-db/"
   },
   {
@@ -356,7 +356,7 @@
   },
   {
     "Command": "az network",
-    "AzureServiceName": "Azure Network",
+    "AzureServiceName": "Azure Networking",
     "URL": "https://azure.microsoft.com/en-us/product-categories/networking/"
   },
   {


### PR DESCRIPTION
In aligning with the azure-cli-extensions _service_name.json_ file...

- "Registries" has been changed to "Registry" (singluar)
- "Azure Cosmos DB" has been changed to "Database for Cosmos DB"
- "Network" has been changed to "Networking"

