### PR TITLE
{CI} Put the cloud module at the end of the serial execution to avoid affecting other tests.

### DIFF
--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -568,6 +568,8 @@ class AutomaticScheduling(object):
                 serial_tests.append(k)
             else:
                 parallel_tests.append(k)
+        # Put the cloud module at the end of the serial execution
+        # Since it will cause the test_get_docker_credentials test to fail
         if 'cloud' in serial_tests:
             serial_tests.remove('cloud')
             serial_tests.append('cloud')

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -568,18 +568,21 @@ class AutomaticScheduling(object):
                 serial_tests.append(k)
             else:
                 parallel_tests.append(k)
+        if 'cloud' in serial_tests:
+            serial_tests.remove('cloud')
+            serial_tests.append('cloud')
         pipeline_result = build_pipeline_result() if enable_pipeline_result else None
-        if serial_tests:
-            azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.serial.xml")
-            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + serial_tests + \
-                  ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
-            serial_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
-            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if enable_pipeline_result else None
         if parallel_tests:
             azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.parallel.xml")
             cmd = ['azdev', 'test', '--no-exitfirst', '--verbose'] + parallel_tests + \
                   ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
             parallel_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
+            pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if enable_pipeline_result else None
+        if serial_tests:
+            azdev_test_result_fp = os.path.join(azdev_test_result_dir, f"test_results_{python_version}_{profile}_{instance_idx}.serial.xml")
+            cmd = ['azdev', 'test', '--no-exitfirst', '--verbose', '--series'] + serial_tests + \
+                  ['--profile', f'{profile}', '--xml-path', azdev_test_result_fp, '--pytest-args', '-o junit_family=xunit1 --durations=10 --tb=no']
+            serial_error_flag = process_test(cmd, azdev_test_result_fp, live_rerun=fix_failure_tests)
             pipeline_result = get_pipeline_result(azdev_test_result_fp, pipeline_result) if enable_pipeline_result else None
         save_pipeline_result(pipeline_result) if enable_pipeline_result else None
         return serial_error_flag or parallel_error_flag

--- a/scripts/ci/automation_full_test.py
+++ b/scripts/ci/automation_full_test.py
@@ -570,6 +570,7 @@ class AutomaticScheduling(object):
                 parallel_tests.append(k)
         # Put the cloud module at the end of the serial execution
         # Since it will cause the test_get_docker_credentials test to fail
+        # TODO: Find the root cause of the failure and modify the test code.
         if 'cloud' in serial_tests:
             serial_tests.remove('cloud')
             serial_tests.append('cloud')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Now the test is to dynamically allocate the modules that need to be tested for each instance.
PR #26785  adds a module graphservices. Due to the adjustment of dynamic allocation, on instance 7, we will test the cloud and acr modules in turn. There is a test test_get_docker_credentials in acr that will fail, and the error is as follows:
```
E ValueError: OIDC Discovery failed on https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration. HTTP status: 400, Error: {"error":"invalid_tenant","error_description":"AADSTS900021: Requested tenant identifier '00000000-0000-0000-0000-000000000000' is not valid. Tenant identifiers may not be an empty GUID.\r\nTrace ID: 4f691ff2-1fd0-4261-ab70-e1bf37b54600\r\nCorrelation ID: 5ee5b4ef-52f7-48d6-8e24-351d067c7bac\r\nTimestamp: 2023-07-05 08:16:30Z","error_codes":[900021],"timestamp":"2023-07-05 08:16:30Z","trace_id":"4f691ff2-1fd0-4261-ab70-e1bf37b54600","correlation_id":"5ee5b4ef-52f7-48d6-8e24-351d067c7bac"}

During handling of the above exception, another exception occurred:
E ValueError: Unable to get authority configuration for https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000. Authority would typically be in a format of https://login.microsoftonline.com/your_tenant Also please double check your tenant name or GUID is correct.
```
The reason is that after the cloud test is completed, some changes have been made and are not restored in [tearDown](https://github.com/Azure/azure-cli/blob/589da503e0855d0da192cab49ece457863876b92/src/azure-cli/azure/cli/command_modules/cloud/tests/latest/test_cloud.py#L16). Since the specific reason is not yet determined, the workaround is to put the cloud module at the end for testing to eliminate the impact.

Test screenshot:
![image](https://github.com/Azure/azure-cli/assets/18628534/d8c5d5dc-8fcd-49c0-837c-2225d8c38100)

TODO:
Find the root cause of the failure and modify the relevant test code.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
