### PR TITLE
[AKS] `az aks enable-addons`: Fix the default value of option `--enable-msi-auth-for-monitoring` being overwritten to `False` when specified

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_params.py
@@ -389,6 +389,7 @@ def load_arguments(self, _):
 
     with self.argument_context('aks enable-addons', resource_type=ResourceType.MGMT_CONTAINERSERVICE, operation_group='managed_clusters') as c:
         c.argument('addons', options_list=['--addons', '-a'])
+        c.argument('workspace_resource_id')
         c.argument('subnet_name', options_list=[
                    '--subnet-name', '-s'], help='Name of an existing subnet to use with the virtual-node add-on.')
         c.argument('appgw_name', arg_group='Application Gateway')
@@ -399,6 +400,9 @@ def load_arguments(self, _):
         c.argument('enable_sgxquotehelper', action='store_true')
         c.argument('enable_secret_rotation', action='store_true')
         c.argument('rotation_poll_interval')
+        c.argument('enable_msi_auth_for_monitoring', arg_type=get_three_state_flag(), is_preview=True)
+        c.argument('enable_syslog', arg_type=get_three_state_flag(), is_preview=True)
+        c.argument('data_collection_settings', is_preview=True)
 
     with self.argument_context('aks get-credentials', resource_type=ResourceType.MGMT_CONTAINERSERVICE, operation_group='managed_clusters') as c:
         c.argument('admin', options_list=['--admin', '-a'], default=False)

--- a/src/azure-cli/azure/cli/command_modules/acs/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/custom.py
@@ -872,10 +872,10 @@ def aks_enable_addons(cmd, client, resource_group_name, name, addons,
                       enable_sgxquotehelper=False,
                       enable_secret_rotation=False,
                       rotation_poll_interval=None,
-                      no_wait=False,
                       enable_msi_auth_for_monitoring=True,
                       enable_syslog=False,
-                      data_collection_settings=None,):
+                      data_collection_settings=None,
+                      no_wait=False,):
     instance = client.get(resource_group_name, name)
     msi_auth = False
     if instance.service_principal_profile.client_id == "msi":

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_aks_commands.py
@@ -3437,14 +3437,13 @@ class AzureKubernetesServiceScenarioTest(ScenarioTest):
         self.cmd('aks show -g {resource_group} -n {name}', checks=[
             self.check('addonProfiles.omsagent.enabled', False),
             self.check('addonProfiles.omsagent.config', None)
-
         ])
 
         # enable monitoring add-on
         self.cmd('aks enable-addons -a monitoring -g {resource_group} -n {name}', checks=[
             self.check('addonProfiles.omsagent.enabled', True),
-            self.exists(
-                'addonProfiles.omsagent.config.logAnalyticsWorkspaceResourceID'),
+            self.exists('addonProfiles.omsagent.config.logAnalyticsWorkspaceResourceID'),
+            self.check('addonProfiles.omsagent.config.useAADAuth', "true"),
             StringContainCheckIgnoreCase('Microsoft.OperationalInsights'),
             StringContainCheckIgnoreCase('DefaultResourceGroup'),
             StringContainCheckIgnoreCase('DefaultWorkspace')


### PR DESCRIPTION
**Related command**
`az aks enable-addons`

**Description**<!--Mandatory-->
{AKS} `az aks enable-addons`: Fix the default value of option `--enable-msi-auth-for-monitoring` being overwritten to `False` when specified. Fix issue #26839.

As the option is not declared in `_params.py`, and the default value of the parameter is True, the following config is implicitly generated for this option by argparse 
> {'options_list': ['--enable-msi-auth-for-monitoring'], 'required': False, 'default': True, 'help': None, 'action': '**store_false**', 'dest': 'enable_msi_auth_for_monitoring'}

So, if use specifies the option explicitly, the value would be overwritten to False.

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
