### PR TITLE
[Core] Drop client telemetry cache strategy

### DIFF
--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -44,7 +44,7 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'argcomplete~=3.1.1',
-    'azure-cli-telemetry==1.0.8.*',
+    'azure-cli-telemetry==1.1.0.*',
     'azure-mgmt-core>=1.2.0,<2',
     'cryptography',
     # On Linux, the distribution (Ubuntu, Debian, etc) and version are logged in telemetry

--- a/src/azure-cli-telemetry/HISTORY.rst
+++ b/src/azure-cli-telemetry/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+1.1.0
++++++
+* Drop telemetry cache strategy. Records will be uploaded immediately
+
 1.0.8
 +++++
 * Keep storing telemetry to CLI AppInsights in local cache but send telemetry to other AppInsights immediately

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -10,7 +10,7 @@ import portalocker
 
 from azure.cli.telemetry.util import save_payload
 
-__version__ = "1.0.8"
+__version__ = "1.1.0"
 
 DEFAULT_INSTRUMENTATION_KEY = 'c4395b75-49cc-422c-bc95-c7d51aef5d46'
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -54,8 +54,8 @@ def save(config_dir, payload):
     logger = get_logger('main')
     try:
         # Split payload to cli events and extra events by instrumentation key
-        # cli events should be stored in local cache and sent together
         # extra events can be sent immediately
+        # cli events will be handled in separate process
         import json
         events = json.loads(payload)
 
@@ -75,7 +75,7 @@ def save(config_dir, payload):
         logger.info("Split cli events and extra events failure: %s", str(ex))
         cli_payload = payload
 
-    if save_payload(config_dir, cli_payload) and should_upload(config_dir):
+    if save_payload(config_dir, cli_payload):
         logger.info('Begin creating telemetry upload process.')
         _start(config_dir)
         logger.info('Finish creating telemetry upload process.')
@@ -94,10 +94,6 @@ def main():
 
         logger = get_logger('main')
         logger.info('Attempt start. Configuration directory [%s].', sys.argv[1])
-
-        if not should_upload(config_dir):
-            logger.info('Exit early. The note file indicates it is not a suitable time to upload telemetry.')
-            sys.exit(0)
 
         try:
             with TelemetryNote(config_dir) as telemetry_note:

--- a/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/__init__.py
@@ -47,7 +47,6 @@ def _start(config_dir):
 
 
 def save(config_dir, payload):
-    from azure.cli.telemetry.util import should_upload
     from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient
     from azure.cli.telemetry.components.telemetry_logging import get_logger
 
@@ -82,7 +81,6 @@ def save(config_dir, payload):
 
 
 def main():
-    from azure.cli.telemetry.util import should_upload
     from azure.cli.telemetry.components.telemetry_note import TelemetryNote
     from azure.cli.telemetry.components.records_collection import RecordsCollection
     from azure.cli.telemetry.components.telemetry_client import CliTelemetryClient

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -36,11 +36,8 @@ class RecordsCollection:
         if not os.path.isdir(folder):
             return
 
-        # Collect all cache.x files. If it has been a long time since last sent, also collect cache file itself.
-        push_interval = datetime.timedelta(hours=self._get_push_interval_config())
-        include_cache = datetime.datetime.now() - self._last_sent > push_interval
-        candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder)
-                      if include_cache or fn != 'cache']
+        # Collect all cache/cache.x files
+        candidates = [(fn, os.stat(os.path.join(folder, fn))) for fn in os.listdir(folder)]
 
         # sort the cache files base on their last modification time.
         candidates = [(fn, file_stat) for fn, file_stat in candidates if stat.S_ISREG(file_stat.st_mode)]
@@ -71,12 +68,6 @@ class RecordsCollection:
                       ignore_errors=True,
                       onerror=lambda _, p, tr: self._logger.error('Fail to remove file %s', p))
         self._logger.info('Remove directory %s', tmp)
-
-    def _get_push_interval_config(self):
-        config = CLIConfig(config_dir=self._config_dir)
-        threshold = config.getint('telemetry', 'push_interval_in_hours', fallback=1)
-        # the threshold for push telemetry can't be less than 1 hour, default value is 1 hour
-        return threshold if threshold >= 1 else 1
 
     def _read_file(self, path):
         """ Read content of a telemetry cache file and parse them into records. """

--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/records_collection.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import stat
 import tempfile
-from knack.config import CLIConfig
 
 
 class RecordsCollection:

--- a/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/tests/test_records_collection.py
@@ -46,8 +46,8 @@ class TestRecordsCollection(unittest.TestCase):
         collection = RecordsCollection(last_send, self.work_dir)
         collection.snapshot_and_read()
 
-        # the threshold for pushing 'cache' file is 1 hour, so 'cache' file should not be moved
-        self.assert_cache_files_count(1)
+        # cache strategy has been dropped, so no `cache` file
+        self.assert_cache_files_count(0)
         # no new records since last_send
         self.assertEqual(0, len([r for r in collection]))
 

--- a/src/azure-cli-telemetry/azure/cli/telemetry/util.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/util.py
@@ -4,41 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import stat
 import logging
 import logging.handlers
-from datetime import datetime
-
-from azure.cli.telemetry.const import TELEMETRY_NOTE_NAME, MANDATORY_WAIT_PERIOD
-
-
-def should_upload(config_dir):
-    """Returns True if it is the right moment to add telemetry.
-    Before the client request a telemetry add process, it can invoke this method to test if it is the right moment.
-    The conditions are:
-        1. The telemetry.txt file doesn't exist; OR
-        2. The telemetry.txt file is a regular file AND there have been enough time passed since last add.
-    """
-    logger = logging.getLogger('telemetry.check')
-
-    telemetry_note_path = os.path.join(config_dir, TELEMETRY_NOTE_NAME)
-    if not os.path.exists(telemetry_note_path):
-        logger.info('Positive: The %s does not exist.', telemetry_note_path)
-        return True
-
-    file_stat = os.stat(telemetry_note_path)
-    if not stat.S_ISREG(file_stat.st_mode):
-        logger.warning('Negative: The %s is not a regular file.', telemetry_note_path)
-        return False
-
-    modify_time = datetime.fromtimestamp(file_stat.st_mtime)
-    if datetime.now() - modify_time < MANDATORY_WAIT_PERIOD:
-        logger.warning('Negative: The %s was modified at %s, which in less than %f s',
-                       telemetry_note_path, modify_time, MANDATORY_WAIT_PERIOD.total_seconds())
-        return False
-
-    logger.info('Returns Positive.')
-    return True
 
 
 def save_payload(config_dir, payload):

--- a/src/azure-cli-telemetry/setup.py
+++ b/src/azure-cli-telemetry/setup.py
@@ -8,7 +8,7 @@
 from codecs import open
 from setuptools import setup
 
-VERSION = "1.0.8"
+VERSION = "1.1.0"
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.0.0
 azure-cli-core==2.50.0
-azure-cli-telemetry==1.0.8
+azure-cli-telemetry==1.1.0
 azure-cli==2.50.0
 azure-common==1.1.22
 azure-core==1.26.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.0.0
 azure-cli-core==2.50.0
-azure-cli-telemetry==1.0.8
+azure-cli-telemetry==1.1.0
 azure-cli==2.50.0
 azure-common==1.1.22
 azure-core==1.26.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -5,7 +5,7 @@ asn1crypto==0.24.0
 azure-appconfiguration==1.1.1
 azure-batch==14.0.0
 azure-cli-core==2.50.0
-azure-cli-telemetry==1.0.8
+azure-cli-telemetry==1.1.0
 azure-cli==2.50.0
 azure-common==1.1.22
 azure-core==1.26.0


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We have reduce client telemetry push interval from 24h to 6h in #26065, from 6h to 1h in #26509

Now it's time to fully drop client telemetry cache strategy. All telemetry records will be uploaded immediately.

**Testing Guide**
<!--Example commands with explanations.-->
Run any cli command and check if there's `$HOME_DIR/.azure/telemetry/cache` file anymore

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
