### PR TITLE
[ARM] Hotfix: `az stack`: Fix bug regarding none value for required parameter

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/resource/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/resource/custom.py
@@ -1057,7 +1057,7 @@ def _get_deployment_management_client(cli_ctx, aux_subscriptions=None, aux_tenan
 
 def _prepare_stacks_deny_settings(rcf, deny_settings_mode):
     deny_settings_mode = None if deny_settings_mode.lower() == "none" else deny_settings_mode
-    deny_settings_enum = None
+    deny_settings_enum = "None"
     if deny_settings_mode:
         if deny_settings_mode.lower().replace(' ', '') == "denydelete":
             deny_settings_enum = rcf.deployment_stacks.models.DenySettingsMode.deny_delete
@@ -2541,7 +2541,6 @@ def create_deployment_stack_at_management_group(cmd, management_group_id, name, 
 
     excluded_principals_array = _prepare_stacks_excluded_principals(deny_settings_excluded_principals)
     excluded_actions_array = _prepare_stacks_excluded_actions(deny_settings_excluded_actions)
-    excluded_principals_array = []
 
     tags = tags or {}
 


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
This PR fixed two major bugs that have minor fixes. The required deny-settings-mode parameter does not except None and the deny-settings-excluded-principals parameters was accidentally being reset"

**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
az stack sub create
az stack group create
az stack mg create

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
2 minor changes: 

1. Deny-Settings-Mode parameter now allows the value "None"
![e9dd18f1-6413-4843-a3ea-df50810efe60](https://github.com/Azure/azure-cli/assets/23566730/a79eede9-12f9-4e1c-8bda-c06053188651)
This error was occurring because **None** was not being passed in as a string

2. Deny-Settings-Excluded-Principals parameter was being reset to [], causing the value to be empty in the request 

**Testing Guide**
<!--Example commands with explanations.-->
az stack sub create -n cli20_2 -f <template-path> **--deny-settings-mode None** -l westus2

az stack mg create -n newStack --deployment-subscription <subscriptionId> -m <Mg Name> --location westus2 --template-file <template-path>  --deny-settings-mode  None  --deny-settings-excluded-principals "principal1 principal2" 

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
