### PR TITLE
[Core] `aaz`: Support blank input for compound argument types

### DIFF
--- a/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
+++ b/src/azure-cli-core/azure/cli/core/aaz/_arg_action.py
@@ -173,7 +173,7 @@ class AAZCompoundTypeArgAction(AAZArgAction):  # pylint: disable=abstract-method
     def setup_operations(cls, dest_ops, values, prefix_keys=None):
         if prefix_keys is None:
             prefix_keys = []
-        if values is None:
+        if values is None or values == []:
             if cls._schema._blank == AAZUndefined:
                 raise AAZInvalidValueError("argument cannot be blank")
             assert not isinstance(cls._schema._blank, AAZPromptInput), "Prompt input is not supported in " \
@@ -402,7 +402,7 @@ class AAZListArgAction(AAZCompoundTypeArgAction):
     def setup_operations(cls, dest_ops, values, prefix_keys=None):
         if prefix_keys is None:
             prefix_keys = []
-        if values is None:
+        if values is None or values == []:
             if cls._schema._blank == AAZUndefined:
                 raise AAZInvalidValueError("argument cannot be blank")
             assert not isinstance(cls._schema._blank, AAZPromptInput), "Prompt input is not supported in List args."


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

The blank value is not parsed correctly for compound argument types, because for thouse arguments, the argparser will put empty list in setup_operations call. This PR fixed such issue.

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
