### PR TITLE
[Keyvault] `az keyvault restore start`: Add `--key-name` to support selective key restore

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/_params.py
@@ -654,6 +654,8 @@ def load_arguments(self, _):
     with self.argument_context('keyvault restore start') as c:
         c.argument('folder_to_restore', options_list=['--backup-folder'],
                    help='Name of the blob container which contains the backup')
+        c.argument('key_name', options_list=['--key-name', '--key'],
+                   help='Name of a single key in the backup. When set, only this key will be restored')
 
     with self.argument_context('keyvault restore start', arg_group='Storage Id') as c:
         c.extra('storage_resource_uri', required=False,

--- a/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
+++ b/src/azure-cli/azure/cli/command_modules/keyvault/custom.py
@@ -2157,13 +2157,13 @@ def full_backup(cmd, client, token, storage_resource_uri=None, storage_account_n
 
 
 def full_restore(cmd, client, token, folder_to_restore, storage_resource_uri=None, storage_account_name=None,
-                 blob_container_name=None, hsm_name=None):  # pylint: disable=unused-argument
+                 blob_container_name=None, key_name=None, hsm_name=None):  # pylint: disable=unused-argument
     storage_account_parameters_check(storage_resource_uri, storage_account_name, blob_container_name)
     if not storage_resource_uri:
         storage_resource_uri = construct_storage_uri(
             cmd.cli_ctx.cloud.suffixes.storage_endpoint, storage_account_name, blob_container_name)
     folder_url = '{}/{}'.format(storage_resource_uri, folder_to_restore)
-    return client.begin_restore(folder_url, token)
+    return client.begin_restore(folder_url, token, key_name=key_name)
 # endregion
 
 


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault restore start`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az keyvault restore start` used to restore the whole HSM. This PR adds an optional parameter `--key-name`, when key name specified, only this key will be restored

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
