### PR TITLE
[Storage] `az storage file upload-batch`: Allow uploading files in parallel to improve performance

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/file.py
@@ -163,6 +163,9 @@ def storage_file_upload(client, local_file_path, content_settings=None,
 
 def _execute_in_parallel(max_workers, fn, args_list):
     from concurrent.futures import ThreadPoolExecutor, as_completed
+    if len(args_list) == 0:
+        return []
+    max_workers = min(max_workers, len(args_list))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(fn, *args) for args in args_list]
         return list(f.result() for f in as_completed(futures))

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -307,14 +307,14 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
         self.storage_cmd('storage file upload-batch -s "{}" -d {} --max-connections 3', storage_account_info,
                          test_dir, src_share)
         self.storage_cmd('storage file download-batch -s {} -d "{}"', storage_account_info, src_share, local_folder)
-        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+        self.assertEqual(41, sum(len(f) for _, _, f in os.walk(local_folder)))
         multi_thread_time = time.time() - start_time
         start_time = time.time()
         src_share = self.create_share(storage_account_info)
         self.storage_cmd('storage file upload-batch -s "{}" -d {} --max-connections 1', storage_account_info,
                          test_dir, src_share)
         self.storage_cmd('storage file download-batch -s {} -d "{}"', storage_account_info, src_share, local_folder)
-        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+        self.assertEqual(41, sum(len(f) for _, _, f in os.walk(local_folder)))
         single_thread_time = time.time() - start_time
         self.assertGreater(single_thread_time, multi_thread_time)
 

--- a/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/tests/latest/test_storage_batch_operations.py
@@ -299,6 +299,25 @@ class StorageBatchOperationScenarios(StorageScenarioMixin, LiveScenarioTest):
                                JMESPathCheck('properties.contentSettings.contentType', 'multipart/form-data;'),
                                JMESPathCheck('metadata', {'key': 'val'}))
 
+        # parallel upload with max-connections
+        import time
+        start_time = time.time()
+        src_share = self.create_share(storage_account_info)
+        local_folder = self.create_temp_dir()
+        self.storage_cmd('storage file upload-batch -s "{}" -d {} --max-connections 3', storage_account_info,
+                         test_dir, src_share)
+        self.storage_cmd('storage file download-batch -s {} -d "{}"', storage_account_info, src_share, local_folder)
+        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+        multi_thread_time = time.time() - start_time
+        start_time = time.time()
+        src_share = self.create_share(storage_account_info)
+        self.storage_cmd('storage file upload-batch -s "{}" -d {} --max-connections 1', storage_account_info,
+                         test_dir, src_share)
+        self.storage_cmd('storage file download-batch -s {} -d "{}"', storage_account_info, src_share, local_folder)
+        self.assertEqual(41, sum(len(f) for r, d, f in os.walk(local_folder)))
+        single_thread_time = time.time() - start_time
+        self.assertGreater(single_thread_time, multi_thread_time)
+
     @ResourceGroupPreparer()
     @StorageAccountPreparer(parameter_name='src_account')
     @StorageAccountPreparer(parameter_name='dst_account')


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az storage file upload-batch`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
- Why this PR?
  - Resolved a pending TODO for improving performance.
- What is changed?
  - Uploading files in batch in parallel. 
- What is the effect?
  - Faster `az storage file upload-batch` command execution depending on `--max-connections` argument. 

**Testing Guide**
<!--Example commands with explanations.-->
- Default: 1 thread worker for uploading one file at a time.
  - `az storage file upload-batch -s "source" -d "destination" --account-name "storage_account_name" --account-key "storage_account_access_key"`
- Parallel: `--max-connections 4` argument -> 4 thread worker -> each worker uploading one file at a time .
  - `az storage file upload-batch -s "source" -d "destination" --account-name "storage_account_name" --account-key "storage_account_access_key" --max-connections 4`

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
