### PR TITLE
{Packaging} Change default Debian repo to bookworm

### DIFF
--- a/scripts/release/debian/deb_install.sh
+++ b/scripts/release/debian/deb_install.sh
@@ -62,7 +62,7 @@ setup() {
             if [[ $DIST =~ "Ubuntu" ]]; then
                 CLI_REPO="jammy"
             elif [[ $DIST =~ "Debian" ]]; then
-                CLI_REPO="bullseye"
+                CLI_REPO="bookworm"
             elif [[ $DIST =~ "LinuxMint" ]]; then
                 CLI_REPO=$(cat /etc/os-release | grep -Po 'UBUNTU_CODENAME=\K.*') || true
                 if [[ -z $CLI_REPO ]]; then


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
CLI supports Debian bookworm from 2.50.0, use bookworm as default repo.

Related PR:
- https://github.com/Azure/azure-cli/pull/26690

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
