### PR TITLE
[Storage] `az storage container-rm update`: `--default-encryption-scope` and `--deny-encryption-scope-override` should not be specified during update

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/storage/_params.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/_params.py
@@ -1703,6 +1703,17 @@ def load_arguments(self, _):  # pylint: disable=too-many-locals, too-many-statem
             c.ignore('enable_nfs_v3_root_squash')
             c.ignore('enable_nfs_v3_all_squash')
 
+    with self.argument_context('storage container-rm update', resource_type=ResourceType.MGMT_STORAGE) as c:
+        c.argument('default_encryption_scope', options_list=['--default-encryption-scope', '-d'],
+                   arg_group='Encryption Policy', min_api='2019-06-01',
+                   help='Default the container to use specified encryption scope for all writes.',
+                   deprecate_info=c.deprecate(hide=True, target='--default-encryption-scope', expiration="2.54"))
+        c.argument('deny_encryption_scope_override',
+                   options_list=['--deny-encryption-scope-override', '--deny-override'],
+                   arg_type=get_three_state_flag(), arg_group='Encryption Policy', min_api='2019-06-01',
+                   help='Block override of encryption scope from the container default.',
+                   deprecate_info=c.deprecate(hide=True, target='--deny-encryption-scope-override', expiration="2.54"))
+
     with self.argument_context('storage container-rm list', resource_type=ResourceType.MGMT_STORAGE) as c:
         c.argument('account_name', storage_account_type, id_part=None)
         c.argument('include_deleted', action='store_true',

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -91,13 +91,21 @@ def update_container_rm(cmd, instance, metadata=None, public_access=None,
                         default_encryption_scope=None, deny_encryption_scope_override=None,
                         enable_nfs_v3_root_squash=None, enable_nfs_v3_all_squash=None):
     BlobContainer = cmd.get_models('BlobContainer', resource_type=ResourceType.MGMT_STORAGE)
+
+    # # TODO will remove warning as well as the parameters in November 2023
+    if default_encryption_scope is not None:
+        logger.warning('--default-encryption-scope cannot be updated after container is created. '
+                       'When it is provided, it will be ignored by the server. '
+                       'This parameter will be removed for the update command in November 2023.')
+    if deny_encryption_scope_override is not None:
+        logger.warning('--deny-encryption-scope-override cannot be updated after container is created. '
+                       'When it is provided, it will be ignored by the server. '
+                       'This parameter will be removed for the update command in November 2023.')
     blob_container = BlobContainer(
         metadata=metadata if metadata is not None else instance.metadata,
         public_access=public_access if public_access is not None else instance.public_access,
-        default_encryption_scope=default_encryption_scope
-        if default_encryption_scope is not None else instance.default_encryption_scope,
-        deny_encryption_scope_override=deny_encryption_scope_override
-        if deny_encryption_scope_override is not None else instance.deny_encryption_scope_override,
+        default_encryption_scope=instance.default_encryption_scope,
+        deny_encryption_scope_override=instance.deny_encryption_scope_override,
         enable_nfs_v3_all_squash=enable_nfs_v3_all_squash
         if enable_nfs_v3_all_squash is not None else instance.enable_nfs_v3_all_squash,
         enable_nfs_v3_root_squash=enable_nfs_v3_root_squash

--- a/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
+++ b/src/azure-cli/azure/cli/command_modules/storage/operations/blob.py
@@ -104,8 +104,10 @@ def update_container_rm(cmd, instance, metadata=None, public_access=None,
     blob_container = BlobContainer(
         metadata=metadata if metadata is not None else instance.metadata,
         public_access=public_access if public_access is not None else instance.public_access,
-        default_encryption_scope=instance.default_encryption_scope,
-        deny_encryption_scope_override=instance.deny_encryption_scope_override,
+        default_encryption_scope=default_encryption_scope
+        if default_encryption_scope is not None else instance.default_encryption_scope,
+        deny_encryption_scope_override=deny_encryption_scope_override
+        if deny_encryption_scope_override is not None else instance.deny_encryption_scope_override,
         enable_nfs_v3_all_squash=enable_nfs_v3_all_squash
         if enable_nfs_v3_all_squash is not None else instance.enable_nfs_v3_all_squash,
         enable_nfs_v3_root_squash=enable_nfs_v3_root_squash


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
`az storage container-rm update`: `--default-encryption-scope` and `--deny-encryption-scope-override` should not be specified during update, when specified, server would also ignore. 


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Storage] `az storage container-rm update`: `--default-encryption-scope` and `--deny-encryption-scope-override` should not be specified during update

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
