### PR TITLE
{Packaging} Bump antlr4-python3-runtime to 4.13.0

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.9.3
+antlr4-python3-runtime==4.13.0
 applicationinsights==0.11.9
 argcomplete==3.1.1
 asn1crypto==0.24.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.9.3
+antlr4-python3-runtime==4.13.0
 applicationinsights==0.11.9
 argcomplete==3.1.1
 asn1crypto==0.24.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -1,4 +1,4 @@
-antlr4-python3-runtime==4.9.3
+antlr4-python3-runtime==4.13.0
 applicationinsights==0.11.9
 argcomplete==3.1.1
 asn1crypto==0.24.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -49,7 +49,7 @@ CLASSIFIERS = [
 ]
 
 DEPENDENCIES = [
-    "antlr4-python3-runtime~=4.9.3",
+    "antlr4-python3-runtime~=4.13.0",
     'azure-appconfiguration~=1.1.1',
     'azure-batch~=14.0.0',
     'azure-cli-core=={}'.format(VERSION),


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Close #26969
Pip print this during installation.
> DEPRECATION: antlr4-python3-runtime is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559

This issue is fixed from 4.11, which provides whl.

Since a lot of change is made in [antlr 4.10](https://github.com/antlr/antlr4/releases) and monitor is only used in monitor, @kairu-ms for review.


**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
