### PR TITLE
{Core} Add `msal_telemetry` to client telemetry

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/util.py
+++ b/src/azure-cli-core/azure/cli/core/auth/util.py
@@ -129,6 +129,12 @@ def check_result(result, **kwargs):
     if not result:
         raise AuthenticationError("Can't find token from MSAL cache.",
                                   recommendation="To re-authenticate, please run:\naz login")
+
+    # msal_telemetry should be sent no matter if the MSAL response is a success or an error
+    if 'msal_telemetry' in result:
+        from azure.cli.core.telemetry import set_msal_telemetry
+        set_msal_telemetry(result['msal_telemetry'])
+
     if 'error' in result:
         aad_error_handler(result, **kwargs)
 

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -71,6 +71,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         self.poll_start_time = None
         self.poll_end_time = None
         self.allow_broker = None
+        self.msal_telemetry = None
 
     def add_event(self, name, properties):
         for key in self.instrumentation_key:
@@ -217,6 +218,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'RegionInput', self.region_input)
         set_custom_properties(result, 'RegionIdentified', self.region_identified)
         set_custom_properties(result, 'AllowBroker', str(self.allow_broker))
+        set_custom_properties(result, 'MsalTelemetry', str(self.msal_telemetry))
 
         return result
 
@@ -457,6 +459,11 @@ def set_region_identified(region_input, region_identified):
 def set_broker_info(allow_broker):
     # whether customer has configured `allow_broker` to enable WAM(Web Account Manager) login for authentication
     _session.allow_broker = allow_broker
+
+
+@decorators.suppress_all_exceptions()
+def set_msal_telemetry(msal_telemetry):
+    _session.msal_telemetry = msal_telemetry
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -463,7 +463,8 @@ def set_broker_info(allow_broker):
 
 @decorators.suppress_all_exceptions()
 def set_msal_telemetry(msal_telemetry):
-    _session.msal_telemetry = msal_telemetry
+    if not _session.msal_telemetry:
+        _session.msal_telemetry = msal_telemetry
 
 
 @decorators.suppress_all_exceptions()

--- a/src/azure-cli-core/azure/cli/core/telemetry.py
+++ b/src/azure-cli-core/azure/cli/core/telemetry.py
@@ -218,7 +218,7 @@ class TelemetrySession:  # pylint: disable=too-many-instance-attributes
         set_custom_properties(result, 'RegionInput', self.region_input)
         set_custom_properties(result, 'RegionIdentified', self.region_identified)
         set_custom_properties(result, 'AllowBroker', str(self.allow_broker))
-        set_custom_properties(result, 'MsalTelemetry', str(self.msal_telemetry))
+        set_custom_properties(result, 'MsalTelemetry', self.msal_telemetry)
 
         return result
 

--- a/src/azure-cli-core/setup.py
+++ b/src/azure-cli-core/setup.py
@@ -52,7 +52,7 @@ DEPENDENCIES = [
     'jmespath',
     'knack~=0.10.1',
     'msal-extensions~=1.0.0',
-    'msal[broker]==1.22.0',
+    'msal[broker]==1.24.0b1',
     'msrestazure~=0.6.4',
     'packaging>=20.9',
     'paramiko>=2.0.8,<4.0.0',

--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -110,7 +110,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.22.0
+msal[broker]==1.24.0b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -111,7 +111,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.22.0
+msal[broker]==1.24.0b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -110,7 +110,7 @@ jsondiff==2.0.0
 knack==0.10.1
 MarkupSafe==2.0.1
 msal-extensions==1.0.0
-msal[broker]==1.22.0
+msal[broker]==1.24.0b1
 msrest==0.7.1
 msrestazure==0.6.4
 oauthlib==3.2.2


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
Incorporate https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/575 and add `msal_telemetry` from MSAL's response to Azure CLI's client telemetry. (Similar to how `core.allow_broker` configuration is added to client telemetry: https://github.com/Azure/azure-cli/pull/24304)

**Testing Guide**
```
az config set core.allow_broker=true
az login
```

Then 

- Continue the login to trigger the success path, or
- Close the window to trigger the error path
