### PR TITLE
{Core} Directly call `acquire_token_for_client` to acquire access token for service principal

### DIFF
--- a/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
+++ b/src/azure-cli-core/azure/cli/core/auth/msal_authentication.py
@@ -135,8 +135,6 @@ class ServicePrincipalCredential(ConfidentialClientApplication):
         logger.debug("ServicePrincipalCredential.get_token: scopes=%r, kwargs=%r", scopes, kwargs)
 
         scopes = list(scopes)
-        result = self.acquire_token_silent(scopes, None, **kwargs)
-        if not result:
-            result = self.acquire_token_for_client(scopes, **kwargs)
+        result = self.acquire_token_for_client(scopes, **kwargs)
         check_result(result)
         return build_sdk_access_token(result)


### PR DESCRIPTION
**Related command**
`az login`

**Description**<!--Mandatory-->
MSAL 1.23.0 (https://github.com/AzureAD/microsoft-authentication-library-for-python/pull/581) changed the behavior of `acquire_token_for_client` so that it will **automatically look up access tokens from cache**, so there is no need to call `acquire_token_silent` and check the result manually then call `acquire_token_for_client`.

The MSAL example also reflects the same:

https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/95df6086ec186e395186e097f8c9103c4ee74d83/sample/confidential_client_secret_sample.py#L53-L55

```py
# Since MSAL 1.23, acquire_token_for_client(...) will automatically look up
# a token from cache, and fall back to acquire a fresh token when needed.
result = app.acquire_token_for_client(scopes=config["scope"])
```
