### PR TITLE
{Telemetry} Add telemetry log for local debugging

### DIFF
--- a/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
+++ b/src/azure-cli-telemetry/azure/cli/telemetry/components/telemetry_client.py
@@ -39,6 +39,7 @@ class CliTelemetryClient:
             if not client:
                 continue
 
+            self._logger.info('Add %d record(s) to client %s for uploading: %s', len(records), instrumentation_key, records)
             for record in records:
                 name = record.get('name')
                 if not name:


### PR DESCRIPTION
**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
We have dropped telemetry local cache strategy in https://github.com/Azure/azure-cli/pull/26854. So there won't be `cache` file under `$HOMEDIR/.azure/telemetry` folder anymore. This brings some trouble for CLI developers when they add/modify some telemetry properties.

So this PR adds telemetry log with full property values which was used to be stored in `cache` file. Developers can now check `$HOMEDIR/.azure/logs/telemetry.log` for local debugging

**Testing Guide**
<!--Example commands with explanations.-->
Run any CLI command then check `$HOMEDIR/.azure/logs/telemetry.log`, there should be log like this:
```
2023-07-26 17:31:21,127 : INFO : telemetry.client : Add 1 record(s) to client c4395b75-49cc-422c-bc95-xxxxxxxxxxxx for uploading: [{'name': 'azurecli/command', 'properties': {'Reserved.DataModel.EntityType': 'UserTask', 'Reserved.DataModel.Action.Type': 'Atomic', 'Reserved.DataModel.Action.Result': 'Success', 'Reserved.ChannelUsed': 'AI', 'Reserved.EventId': '0d614f42-5628-4036-87ce-bad4a9c55f74', 'Reserved.SequenceNumber': 1, 'Reserved.SessionId': '63dec10d2df75bcb47db2cfcc3a5795d01f32d6633b6635c9dddeb19cb7d6a8b', 'Reserved.TimeSinceSessionStart': 0, 'Reserved.DataModel.Source': 'DataModelAPI', 'Reserved.DataModel.EntitySchemaVersion': 4, 'Reserved.DataModel.Severity': 0, 'Reserved.DataModel.ProductName': 'azurecli', 'Reserved.DataModel.FeatureName': 'command', 'Reserved.DataModel.EntityName': 'keyvault-show', 'Reserved.DataModel.CorrelationId': 'ca6afc7b-4386-43d7-bbf1-1eca4f61ee9f', 'Context.Default.VS.Core.ExeName': 'azurecli', 'Context.Default.VS.Core.ExeVersion': '2.50.0@none', ...... 'Context.Default.AzureCLI.ShowSurveyMessage': 'False', 'Context.Default.AzureCLI.AllowBroker': 'False'}}]
2023-07-26 17:31:21,127 : INFO : telemetry.client : Accumulated 1 events. Flush the clients.
```



---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
