### PR TITLE
{AKS} `az aks create/update`: Update logic to sanitize cluster name for DC* objects

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
@@ -17,7 +17,7 @@ def sanitize_name(name, objtype, length):
     length = length - 1
     if objtype == DC_TYPE.DCE:
         name = name.replace("_", "")
-    name = ''.join(char for char in name if char.isalnum() or char == '-')
+        name = ''.join(char for char in name if char.isalnum() or char == '-')
     lastIndexAlphaNumeric = len(name) - 1
     while ((name[lastIndexAlphaNumeric].isalnum() is False) and lastIndexAlphaNumeric > -1):
         lastIndexAlphaNumeric = lastIndexAlphaNumeric - 1

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
@@ -13,10 +13,11 @@ from azure.cli.command_modules.acs.azuremonitormetrics.deaults import get_defaul
 # All DC* object names should end only in alpha numeric (after `length` trim)
 # DCE remove underscore from cluster name
 def sanitize_name(name, objtype, length):
+    name = name[0:length]
     length = length - 1
     if objtype == DC_TYPE.DCE:
         name = name.replace("_", "")
-    name = name[0:length]
+    name = ''.join(char for char in name if char.isalnum() or char == '-')
     lastIndexAlphaNumeric = len(name) - 1
     while ((name[lastIndexAlphaNumeric].isalnum() is False) and lastIndexAlphaNumeric > -1):
         lastIndexAlphaNumeric = lastIndexAlphaNumeric - 1

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
@@ -14,16 +14,14 @@ from azure.cli.command_modules.acs.azuremonitormetrics.deaults import get_defaul
 # DCE remove underscore from cluster name
 def sanitize_name(name, objtype, length):
     name = name[0:length]
-    length = length - 1
     if objtype == DC_TYPE.DCE:
-        name = name.replace("_", "")
         name = ''.join(char for char in name if char.isalnum() or char == '-')
     lastIndexAlphaNumeric = len(name) - 1
     while ((name[lastIndexAlphaNumeric].isalnum() is False) and lastIndexAlphaNumeric > -1):
         lastIndexAlphaNumeric = lastIndexAlphaNumeric - 1
     if lastIndexAlphaNumeric < 0:
         return ""
-    return name[0:lastIndexAlphaNumeric + 1]
+    return name[0:lastIndexAlphaNumeric+1]
 
 
 def get_default_dce_name(cmd, mac_region, cluster_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/defaults.py
@@ -21,7 +21,7 @@ def sanitize_name(name, objtype, length):
         lastIndexAlphaNumeric = lastIndexAlphaNumeric - 1
     if lastIndexAlphaNumeric < 0:
         return ""
-    return name[0:lastIndexAlphaNumeric+1]
+    return name[0:lastIndexAlphaNumeric + 1]
 
 
 def get_default_dce_name(cmd, mac_region, cluster_name):

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/tests/test_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/tests/test_defaults.py
@@ -1,3 +1,7 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
 import unittest
 
 from azure.cli.command_modules.acs.azuremonitormetrics.constants import DC_TYPE

--- a/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/tests/test_defaults.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/azuremonitormetrics/dc/tests/test_defaults.py
@@ -1,0 +1,28 @@
+import unittest
+
+from azure.cli.command_modules.acs.azuremonitormetrics.constants import DC_TYPE
+from azure.cli.command_modules.acs.azuremonitormetrics.dc.defaults import sanitize_name
+
+
+class TestSanitizeName(unittest.TestCase):
+
+    def test_sanitize_dcr(self):
+        result = sanitize_name("test_name_123$%", DC_TYPE.DCR, 64)
+        self.assertEqual(result, "test_name_123")
+
+    def test_sanitize_dce(self):
+        result = sanitize_name("test_name_123_#", DC_TYPE.DCE, 44)
+        self.assertEqual(result, "testname123")
+    
+    def test_sanitize_dcra(self):
+        result = sanitize_name("test_name_123$$", DC_TYPE.DCRA, 64)
+        self.assertEqual(result, "test_name_123")
+
+    def test_sanitize_long_name(self):
+        long_name = "a" * 100
+        result = sanitize_name(long_name, DC_TYPE.DCE, 44)
+        self.assertEqual(result, "a" * 44)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

```az aks update -n kaveeshcli22 -g kaveeshcli --enable-azuremonitormetrics --enable-windows-recording-rules```

```az aks create -n kaveeshcli22 -g kaveeshcli --location westeurope --enable-azuremonitormetrics --enable-windows-recording-rules --azure-monitor-workspace-resource-id "{full_id}" --grafana-resource-id "{full_id}"```

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

The DC* objects can only container alphanumeric characters and '-' so updating the code to reflect it.

DC* refers to [DCRA](https://learn.microsoft.com/en-us/rest/api/monitor/data-collection-rule-associations), [DCR ](https://learn.microsoft.com/en-us/rest/api/monitor/data-collection-rules) and [DCE](https://learn.microsoft.com/en-us/rest/api/monitor/data-collection-endpoints) i.e. Data Collection Rule Association, Data Collection Rules and Data Collection Endpoints that are being created as part of the managed prometheus addon onboarding.

**Testing Guide**
<!--Example commands with explanations.-->

This is a bug fix and can be tested by onboarding to the azure monitor for metrics addon using the above mentioned commands.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
