### PR TITLE
{Packaging} Test x86 and x64 MSI installation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,14 +228,14 @@ jobs:
       TargetPath: 'build_scripts/windows/out/'
       ArtifactName: msi-$(Platform)
 
-- job: TestWindowsMSI
-  displayName: Test Windows MSI
+- job: TestMsiInstallation
+  displayName: Test MSI Installation
   strategy:
     matrix:
       x86:
         Platform: x86
-#      x64:
-#        Platform: x64
+      x64:
+        Platform: x64
 
   dependsOn: BuildWindowsMSI
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual', 'Schedule'))
@@ -257,47 +257,7 @@ jobs:
   - task: PowerShell@2
     displayName: Install and Load CLI
     inputs:
-      targetType: inline
-      script: |
-        if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-          # Start another Powershell process as Admin and execute this script again
-          $arguments = "& '" +$myinvocation.mycommand.definition + "'"
-          Start-Process powershell -Verb runAs -ArgumentList $arguments
-          # Stop if the PowerShell is not run as Admin
-          Break
-        }
-        # The following are executed by elevated PowerShell
-        az --version
-        
-        $InstallArgs = @(
-          "/i"
-          "`"$env:SYSTEM_ARTIFACTSDIRECTORY\msi\Microsoft Azure CLI.msi`""
-          "/q"
-          "/norestart"
-          "/l*v"
-          ".\install_logs.txt"
-        )
-        $pre_installed_version=az version --query '\"azure-cli\"' -o tsv
-        $to_be_installed_version=Get-Content $(System.ArtifactsDirectory)/metadata/version
-        if ($pre_installed_version -eq $to_be_installed_version){
-          # See https://docs.microsoft.com/windows/win32/msi/reinstallmode about options of REINSTALLMODE
-          $reinstall_option="REINSTALL=ALL REINSTALLMODE=emus"
-          $InstallArgs += $reinstall_option
-        }
-        Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow
-        $install_time=Measure-Command {Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow} | select -expand TotalSeconds
-        $installed_version=az version --query '\"azure-cli\"' -o tsv
-        if ($installed_version -ne $to_be_installed_version){
-          echo "The MSI failed to install."
-          Exit 1
-        }
-        echo 'Install time(seconds):' $install_time
-        az --version
-        # Test bundled pip with extension installation
-        az extension add -n rdbms-connect
-        az self-test
-        
-        Get-Content .\install_logs.txt
+      filePath: build_scripts\windows\scripts\test_msi_installation.ps1
 
 - job: BuildDockerImage
   displayName: Build Docker Image
@@ -1137,7 +1097,7 @@ jobs:
     - VerifyWindowsRequirements
     - VerifyVersions
     - BuildWindowsMSI
-    - TestWindowsMSI
+    - TestMsiInstallation
     - BuildDockerImage
     - TestDockerImage
     - BuildPythonWheel

--- a/build_scripts/windows/scripts/test_msi_installation.ps1
+++ b/build_scripts/windows/scripts/test_msi_installation.ps1
@@ -1,0 +1,76 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+Set-PSDebug -Trace 1
+
+if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    # Start another Powershell process as Admin and execute this script again
+    $arguments = "& '" + $myinvocation.mycommand.definition + "'"
+    Start-Process powershell -Verb runAs -ArgumentList $arguments
+    # Stop if the PowerShell is not run as Admin
+    Break
+}
+# The following are executed by elevated PowerShell
+
+# Deal with the pre-installed Azure CLI on the ADO agent
+az --version
+
+# Uninstall the pre-installed Azure CLI. We use wildcard, since product name can be:
+# - Microsoft Azure CLI          --deprecated
+# - Microsoft Azure CLI (32-bit)
+# - Microsoft Azure CLI (64-bit)
+$cli_package = Get-Package -Provider Programs -IncludeWindowsInstaller -Name "Microsoft Azure CLI*"
+$cli_package | Format-List
+Uninstall-Package -Name $cli_package.Name
+
+# Make sure it is uninstalled
+Get-Package -Provider Programs -IncludeWindowsInstaller
+
+
+# Install artifact MSI
+$InstallArgs = @(
+    "/i"
+    "`"$env:SYSTEM_ARTIFACTSDIRECTORY\msi\Microsoft Azure CLI.msi`""
+    "/q"
+    "/norestart"
+    "/l*v"
+    ".\install_logs.txt"
+)
+Write-Output "Calling: msiexec.exe $InstallArgs"
+$install_time = Measure-Command {Start-Process "msiexec.exe" -ArgumentList $InstallArgs -Wait -NoNewWindow}
+
+# Show installation log. Since the log is too big, we only print it when needed.
+# Get-Content .\install_logs.txt
+
+# Show installation time
+Write-Output "Installation time (seconds): $($install_time.TotalSeconds)"
+
+# Show package information
+Get-Package -Provider Programs -IncludeWindowsInstaller -Name "Microsoft Azure CLI*" | Format-List
+
+# We can't restart the current shell in CI to refresh PATH, so use absolute path.
+# If we can find a way to refresh PATH in the same shell session, we can directly call az.
+if ($env:PLATFORM -eq 'x64')  {
+    $az_full_path = "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.cmd"
+} else {
+    $az_full_path = "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az.cmd"
+}
+
+& $az_full_path --version
+
+$installed_version=& $az_full_path version --query '\"azure-cli\"' -o tsv
+Write-Output "Installed version: $installed_version"
+
+$artifact_version=Get-Content $env:SYSTEM_ARTIFACTSDIRECTORY\metadata\version
+Write-Output "Artifact version: $artifact_version"
+
+if ($installed_version -ne $artifact_version){
+    Write-Output "The installed version doesn't match the artifact version."
+    Exit 1
+}
+
+# Test bundled pip with extension installation
+& $az_full_path extension add -n account
+& $az_full_path self-test


### PR DESCRIPTION
As explained in https://github.com/Azure/azure-cli/pull/17317#discussion_r1277480110, CI job **TestWindowsMSI** never works as expected. The test for x64 MSI is disabled by https://github.com/Azure/azure-cli/pull/27018.

However, that issue doesn't happen if the artifact MSI has higher version, as in that case, the script doesn't append `"REINSTALL=ALL REINSTALLMODE=emus"` and x64 MSI uninstalls x86 MSI (https://github.com/Azure/azure-cli/pull/26640#issuecomment-1645337341).

In order to mimic a clean installation, this PR changes the logic to **uninstall the pre-installed Azure CLI first, then install the artifact MSI**.

