### PR TITLE
{AKS} Retain value in network profile of mc object only when decorator is in update mode

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/_loadbalancer.py
@@ -129,10 +129,13 @@ def _get_load_balancer_outbound_ips(load_balancer_outbound_ips, models):
         ResourceReference = models.ResourceReference
     else:
         ResourceReference = models.get("ResourceReference")
-    if load_balancer_outbound_ips:
-        load_balancer_outbound_ip_resources = \
-            [ResourceReference(id=x.strip())
-             for x in load_balancer_outbound_ips.split(',')]
+    if load_balancer_outbound_ips is not None:
+        if isinstance(load_balancer_outbound_ips, str):
+            load_balancer_outbound_ip_resources = \
+                [ResourceReference(id=x.strip())
+                    for x in load_balancer_outbound_ips.split(',')]
+        else:
+            load_balancer_outbound_ip_resources = load_balancer_outbound_ips
     return load_balancer_outbound_ip_resources
 
 

--- a/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/managed_cluster_decorator.py
@@ -1763,7 +1763,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             "load_balancer_managed_outbound_ip_count"
         )
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if load_balancer_managed_outbound_ip_count is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1788,7 +1788,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         """
         count_ipv6 = self.raw_param.get('load_balancer_managed_outbound_ipv6_count')
 
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if count_ipv6 is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1799,23 +1799,6 @@ class AKSManagedClusterContext(BaseAKSContext):
                 count_ipv6 = (
                     self.mc.network_profile.load_balancer_profile.managed_outbound_i_ps.count_ipv6
                 )
-        elif self.decorator_mode == DecoratorMode.UPDATE:
-            if (
-                not self.get_load_balancer_outbound_ips() and
-                not self.get_load_balancer_outbound_ip_prefixes() and
-                count_ipv6 is None
-            ):
-                if (
-                    self.mc and
-                    self.mc.network_profile and
-                    self.mc.network_profile.load_balancer_profile and
-                    self.mc.network_profile.load_balancer_profile.managed_outbound_i_ps and
-                    self.mc.network_profile.load_balancer_profile.managed_outbound_i_ps.count_ipv6 is not None
-                ):
-                    count_ipv6 = (
-                        self.mc.network_profile.load_balancer_profile.managed_outbound_i_ps.count_ipv6
-                    )
-
         return count_ipv6
 
     def get_load_balancer_outbound_ips(self) -> Union[str, List[ResourceReference], None]:
@@ -1830,7 +1813,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             "load_balancer_outbound_ips"
         )
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if load_balancer_outbound_ips is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1856,7 +1839,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             "load_balancer_outbound_ip_prefixes"
         )
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if load_balancer_outbound_ip_prefixes is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1884,7 +1867,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             "load_balancer_outbound_ports"
         )
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if load_balancer_outbound_ports is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1911,7 +1894,7 @@ class AKSManagedClusterContext(BaseAKSContext):
             "load_balancer_idle_timeout"
         )
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if load_balancer_idle_timeout is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1936,7 +1919,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # read the original value passed by the command
         nat_gateway_managed_outbound_ip_count = self.raw_param.get("nat_gateway_managed_outbound_ip_count")
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if nat_gateway_managed_outbound_ip_count is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and
@@ -1962,7 +1945,7 @@ class AKSManagedClusterContext(BaseAKSContext):
         # read the original value passed by the command
         nat_gateway_idle_timeout = self.raw_param.get("nat_gateway_idle_timeout")
         # In create mode, try to read the property value corresponding to the parameter from the `mc` object.
-        if self.decorator_mode == DecoratorMode.CREATE:
+        if nat_gateway_idle_timeout is None and self.decorator_mode == DecoratorMode.UPDATE:
             if (
                 self.mc and
                 self.mc.network_profile and

--- a/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
+++ b/src/azure-cli/azure/cli/command_modules/acs/tests/latest/test_managed_cluster_decorator.py
@@ -1233,10 +1233,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_sku(), CONST_LOAD_BALANCER_SKU_STANDARD)
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_sku="test_mc_load_balancer_SKU")
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_load_balancer_sku(), "test_mc_load_balancer_sku")
 
         # custom value
         ctx_2 = AKSManagedClusterContext(
@@ -1301,15 +1297,17 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_managed_outbound_ip_count(), None)
-        load_balancer_profile = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
-            managed_outbound_i_ps=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileManagedOutboundIPs(
-                count=10
-            )
+        ctx_1_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_managed_outbound_ip_count": 10,
+                }
+            ),
+            self.models,
+            DecoratorMode.CREATE,
         )
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile)
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_load_balancer_managed_outbound_ip_count(), 10)
+        self.assertEqual(ctx_1_notnull.get_load_balancer_managed_outbound_ip_count(), 10)
 
         # custom value
         ctx_2 = AKSManagedClusterContext(
@@ -1330,8 +1328,27 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
         ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_load_balancer_managed_outbound_ip_count(), None)
-
+        self.assertEqual(ctx_2.get_load_balancer_managed_outbound_ip_count(), 10)
+        ctx_2_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_managed_outbound_ip_count": None,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        load_balancer_profile_2 = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
+            managed_outbound_i_ps=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileManagedOutboundIPs(
+                count=10
+            )
+        )
+        network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
+        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
+        ctx_2_notnull.attach_mc(mc)
+        self.assertEqual(ctx_2_notnull.get_load_balancer_managed_outbound_ip_count(), 10)
+        
     def test_get_load_balancer_outbound_ips(self):
         # default
         ctx_1 = AKSManagedClusterContext(
@@ -1345,19 +1362,6 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_outbound_ips(), None)
-        load_balancer_profile = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
-            outbound_i_ps=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileOutboundIPs(
-                public_i_ps=[self.models.load_balancer_models.ResourceReference(id="test_public_ip")]
-            )
-        )
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile)
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
-        self.assertEqual(
-            ctx_1.get_load_balancer_outbound_ips(),
-            [self.models.load_balancer_models.ResourceReference(id="test_public_ip")],
-        )
-
         # custom value
         ctx_2 = AKSManagedClusterContext(
             self.cmd,
@@ -1377,7 +1381,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
         ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_load_balancer_outbound_ips(), None)
+        self.assertEqual(ctx_2.get_load_balancer_outbound_ips(), [self.models.load_balancer_models.ResourceReference(id="test_public_ip")])
 
     def test_get_load_balancer_outbound_ip_prefixes(self):
         # default
@@ -1392,19 +1396,17 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_outbound_ip_prefixes(), None)
-        load_balancer_profile = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
-            outbound_ip_prefixes=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileOutboundIPPrefixes(
-                public_ip_prefixes=[self.models.load_balancer_models.ResourceReference(id="test_public_ip_prefix")]
-            )
+        ctx_1_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_outbound_ip_prefixes": "fakeids",
+                }
+            ),
+            self.models,
+            DecoratorMode.CREATE,
         )
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile)
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
-        self.assertEqual(
-            ctx_1.get_load_balancer_outbound_ip_prefixes(),
-            [self.models.load_balancer_models.ResourceReference(id="test_public_ip_prefix")],
-        )
-
+        self.assertEqual(ctx_1_notnull.get_load_balancer_outbound_ip_prefixes(), "fakeids")
         # custom value
         ctx_2 = AKSManagedClusterContext(
             self.cmd,
@@ -1425,7 +1427,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
         ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_load_balancer_outbound_ip_prefixes(), None)
+        self.assertEqual(ctx_2.get_load_balancer_outbound_ip_prefixes(), [self.models.load_balancer_models.ResourceReference(id="test_public_ip_prefix")])
 
     def test_get_load_balancer_outbound_ports(self):
         # default
@@ -1440,12 +1442,16 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_outbound_ports(), None)
-        load_balancer_profile = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
-            allocated_outbound_ports=10
+        ctx_1 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_outbound_ports": 10,
+                }
+            ),
+            self.models,
+            DecoratorMode.CREATE,
         )
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile)
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
         self.assertEqual(ctx_1.get_load_balancer_outbound_ports(), 10)
 
         # custom value
@@ -1466,7 +1472,7 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
         ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_load_balancer_outbound_ports(), None)
+        self.assertEqual(ctx_2.get_load_balancer_outbound_ports(), 10)
 
     def test_get_load_balancer_idle_timeout(self):
         # default
@@ -1481,14 +1487,19 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_load_balancer_idle_timeout(), None)
-        load_balancer_profile = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
-            idle_timeout_in_minutes=10
-        )
-        network_profile = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile)
-        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile)
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_load_balancer_idle_timeout(), 10)
 
+        ctx_1_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_idle_timeout": 10,
+                }
+            ),
+            self.models,
+            DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1_notnull.get_load_balancer_idle_timeout(), 10)
+        
         # custom value
         ctx_2 = AKSManagedClusterContext(
             self.cmd,
@@ -1507,7 +1518,27 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
         network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
         mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
         ctx_2.attach_mc(mc)
-        self.assertEqual(ctx_2.get_load_balancer_idle_timeout(), None)
+        self.assertEqual(ctx_2.get_load_balancer_idle_timeout(), 10)
+        
+                # custom value
+        ctx_2_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict(
+                {
+                    "load_balancer_idle_timeout": 20,
+                }
+            ),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        self.assertEqual(ctx_2_notnull.get_load_balancer_idle_timeout(), 20)
+        load_balancer_profile_2 = self.models.load_balancer_models.ManagedClusterLoadBalancerProfile(
+            idle_timeout_in_minutes=10
+        )
+        network_profile_2 = self.models.ContainerServiceNetworkProfile(load_balancer_profile=load_balancer_profile_2)
+        mc = self.models.ManagedCluster(location="test_location", network_profile=network_profile_2)
+        ctx_2_notnull.attach_mc(mc)
+        self.assertEqual(ctx_2_notnull.get_load_balancer_idle_timeout(), 20)
 
     def test_get_nat_gateway_managed_outbound_ip_count(self):
         # default
@@ -1518,6 +1549,22 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_nat_gateway_managed_outbound_ip_count(), None)
+        
+                # default
+        ctx_1_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"nat_gateway_managed_outbound_ip_count": 2}),
+            self.models,
+            DecoratorMode.CREATE,
+        )
+        self.assertEqual(ctx_1_notnull.get_nat_gateway_managed_outbound_ip_count(), 2)
+        
+        ctx_2 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"nat_gateway_managed_outbound_ip_count": None}),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
         nat_gateway_profile = self.models.nat_gateway_models.ManagedClusterNATGatewayProfile(
             managed_outbound_ip_profile=self.models.nat_gateway_models.ManagedClusterManagedOutboundIPProfile(count=10)
         )
@@ -1526,9 +1573,26 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             location="test_location",
             network_profile=network_profile,
         )
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_nat_gateway_managed_outbound_ip_count(), 10)
-
+        ctx_2.attach_mc(mc)
+        self.assertEqual(ctx_2.get_nat_gateway_managed_outbound_ip_count(), 10)
+        
+        ctx_2_notnull = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"nat_gateway_managed_outbound_ip_count": 15}),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
+        nat_gateway_profile = self.models.nat_gateway_models.ManagedClusterNATGatewayProfile(
+            managed_outbound_ip_profile=self.models.nat_gateway_models.ManagedClusterManagedOutboundIPProfile(count=10)
+        )
+        network_profile = self.models.ContainerServiceNetworkProfile(nat_gateway_profile=nat_gateway_profile)
+        mc = self.models.ManagedCluster(
+            location="test_location",
+            network_profile=network_profile,
+        )
+        ctx_2_notnull.attach_mc(mc)
+        self.assertEqual(ctx_2_notnull.get_nat_gateway_managed_outbound_ip_count(), 15)
+        
     def test_get_nat_gateway_idle_timeout(self):
         # default
         ctx_1 = AKSManagedClusterContext(
@@ -1538,6 +1602,12 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             DecoratorMode.CREATE,
         )
         self.assertEqual(ctx_1.get_nat_gateway_idle_timeout(), None)
+        ctx_2 = AKSManagedClusterContext(
+            self.cmd,
+            AKSManagedClusterParamDict({"nat_gateway_idle_timeout": None}),
+            self.models,
+            DecoratorMode.UPDATE,
+        )
         nat_gateway_profile = self.models.nat_gateway_models.ManagedClusterNATGatewayProfile(
             idle_timeout_in_minutes=20,
         )
@@ -1546,8 +1616,8 @@ class AKSManagedClusterContextTestCase(unittest.TestCase):
             location="test_location",
             network_profile=network_profile,
         )
-        ctx_1.attach_mc(mc)
-        self.assertEqual(ctx_1.get_nat_gateway_idle_timeout(), 20)
+        ctx_2.attach_mc(mc)
+        self.assertEqual(ctx_2.get_nat_gateway_idle_timeout(), 20)
 
     def test_get_outbound_type(self):
         # default
@@ -8072,7 +8142,12 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             managed_outbound_i_ps=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileManagedOutboundIPs(
                 count=10
             ),
-            outbound_i_ps=None,
+            outbound_i_ps=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileOutboundIPs(
+                public_i_ps=[
+                    self.models.load_balancer_models.ResourceReference(id="test_ip_1"),
+                    self.models.load_balancer_models.ResourceReference(id="test_ip_2"),
+                ]
+            ),
             outbound_ip_prefixes=self.models.load_balancer_models.ManagedClusterLoadBalancerProfileOutboundIPPrefixes(
                 public_ip_prefixes=[
                     self.models.load_balancer_models.ResourceReference(id="test_ip_prefix_1"),
@@ -8089,6 +8164,8 @@ class AKSManagedClusterUpdateDecoratorTestCase(unittest.TestCase):
             location="test_location",
             network_profile=ground_truth_network_profile_3,
         )
+        print(dec_mc_3.network_profile.load_balancer_profile)
+        print(ground_truth_mc_3.network_profile.load_balancer_profile)
         self.assertEqual(dec_mc_3, ground_truth_mc_3)
 
     def test_update_nat_gateway_profile(self):


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[AKS] `az aks update`: Retain value in network profile in mc object only when decorator is in update mode

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
