### PR TITLE
{packaging} Bump semver to 3.0.x

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -129,7 +129,7 @@ python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.31.0
 scp==0.13.2
-semver==2.13.0
+semver==3.0.1
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -130,7 +130,7 @@ python-dateutil==2.8.0
 requests-oauthlib==1.2.0
 requests[socks]==2.31.0
 scp==0.13.2
-semver==2.13.0
+semver==3.0.1
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -130,7 +130,7 @@ pywin32==305
 requests-oauthlib==1.2.0
 requests[socks]==2.31.0
 scp==0.13.2
-semver==2.13.0
+semver==3.0.1
 six==1.16.0
 sshtunnel==0.1.5
 tabulate==0.8.9

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -145,7 +145,7 @@ DEPENDENCIES = [
     'PyGithub~=1.38',
     'PyNaCl~=1.5.0',
     'scp~=0.13.2',
-    'semver==2.13.0',
+    'semver~=3.0.0',
     'six>=1.10.0',  # six is still used by countless extensions
     'sshtunnel~=0.1.4',
     'urllib3',


### PR DESCRIPTION
**Related command**
N/A

**Description**<!--Mandatory-->
Many Linux distributions, including Fedora, have updated to semver 3.0.x. It would be helpful if azure-cli could use this newer version.

**Testing Guide**
No testing changes needed.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [x] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [x] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).

👋 **This PR replaces the closed PR #26523.**