### PR TITLE
{Keyvault} Bump `azure-mgmt-keyvault` to `10.2.3` to fix API version mistmatch issue

### DIFF
--- a/src/azure-cli/requirements.py3.Darwin.txt
+++ b/src/azure-cli/requirements.py3.Darwin.txt
@@ -53,7 +53,7 @@ azure-mgmt-imagebuilder==1.2.0
 azure-mgmt-iotcentral==10.0.0b1
 azure-mgmt-iothub==2.3.0
 azure-mgmt-iothubprovisioningservices==1.1.0
-azure-mgmt-keyvault==10.2.2
+azure-mgmt-keyvault==10.2.3
 azure-mgmt-kusto==0.3.0
 azure-mgmt-loganalytics==13.0.0b4
 azure-mgmt-managementgroups==1.0.0

--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -53,7 +53,7 @@ azure-mgmt-imagebuilder==1.2.0
 azure-mgmt-iotcentral==10.0.0b1
 azure-mgmt-iothub==2.3.0
 azure-mgmt-iothubprovisioningservices==1.1.0
-azure-mgmt-keyvault==10.2.2
+azure-mgmt-keyvault==10.2.3
 azure-mgmt-kusto==0.3.0
 azure-mgmt-loganalytics==13.0.0b4
 azure-mgmt-managementgroups==1.0.0

--- a/src/azure-cli/requirements.py3.windows.txt
+++ b/src/azure-cli/requirements.py3.windows.txt
@@ -53,7 +53,7 @@ azure-mgmt-imagebuilder==1.2.0
 azure-mgmt-iotcentral==10.0.0b1
 azure-mgmt-iothub==2.3.0
 azure-mgmt-iothubprovisioningservices==1.1.0
-azure-mgmt-keyvault==10.2.2
+azure-mgmt-keyvault==10.2.3
 azure-mgmt-kusto==0.3.0
 azure-mgmt-loganalytics==13.0.0b4
 azure-mgmt-managementgroups==1.0.0

--- a/src/azure-cli/setup.py
+++ b/src/azure-cli/setup.py
@@ -95,7 +95,7 @@ DEPENDENCIES = [
     'azure-mgmt-iotcentral~=10.0.0b1',
     'azure-mgmt-iothub==2.3.0',
     'azure-mgmt-iothubprovisioningservices==1.1.0',
-    'azure-mgmt-keyvault==10.2.2',
+    'azure-mgmt-keyvault==10.2.3',
     'azure-mgmt-kusto~=0.3.0',
     'azure-mgmt-loganalytics==13.0.0b4',
     'azure-mgmt-managedservices~=1.0',


### PR DESCRIPTION
**Related command**
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->
`az keyvault show`

**Description**<!--Mandatory-->
<!--Why this PR? What is changed? What is the effect? etc. A high-quality description can accelerate the review process.-->
Fix #26950 #27109 #27147 

`az keyvault show` calls `vaults_operation.list()` to query for the matched vault if customer only provide `--vault-name` without `--resource-group-name`.

But SDK has API version mismatch issue for `vaults_operation.list()` and it was fixed in https://github.com/Azure/azure-sdk-for-python/pull/31272

This PR aims to bump related SDK `azure-mgmt-keyvault==10.2.3` to pick up the fix from CLI side

**Testing Guide**
<!--Example commands with explanations.-->

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: `az command a`: Make some customer-facing breaking change
[Component Name 2] `az command b`: Add some customer-facing feature

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
